### PR TITLE
refactor(#762 D9): tighten OrderType — drop typeName + dead constants, add UNKNOWN

### DIFF
--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParsedFieldsFactory.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParsedFieldsFactory.kt
@@ -1,7 +1,6 @@
 package cloud.trotter.dashbuddy.core.pipeline.rules
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.ParsedTime
-import cloud.trotter.dashbuddy.domain.model.offer.OfferBadge
 import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
 import cloud.trotter.dashbuddy.domain.model.order.OrderBadge
 import cloud.trotter.dashbuddy.domain.model.order.OrderType
@@ -249,8 +248,17 @@ object ParsedFieldsFactory {
             }
             ParsedOrder(
                 orderIndex = idx,
-                orderType = o.str("orderType")?.let {
-                    try { OrderType.valueOf(it) } catch (_: Exception) { null }
+                // Distinguish two cases: an ABSENT orderType is the neutral bare-delivery default
+                // (PICKUP, silent); a PRESENT-but-unrecognized string is a real gap between the
+                // rule-source vocabulary and [OrderType] → UNKNOWN + a WARN. The string is
+                // rule-source vocabulary, not PII, so it's safe to log verbatim.
+                orderType = o.str("orderType")?.let { raw ->
+                    try {
+                        OrderType.valueOf(raw)
+                    } catch (_: IllegalArgumentException) {
+                        Timber.tag("Rules").w("ParsedFieldsFactory: unrecognized orderType '$raw' -> UNKNOWN")
+                        OrderType.UNKNOWN
+                    }
                 } ?: OrderType.PICKUP,
                 storeName = o.str("storeName") ?: "",
                 itemCount = o.int("itemCount") ?: 1,

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParsedFieldsFactoryTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParsedFieldsFactoryTest.kt
@@ -1,0 +1,50 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import cloud.trotter.dashbuddy.domain.model.order.OrderType
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for [ParsedFieldsFactory] order-type resolution (#762 D9).
+ *
+ * The order type is rule-source vocabulary resolved via [OrderType.valueOf]. Three cases matter:
+ * a KNOWN string resolves to its constant; an ABSENT field takes the neutral [OrderType.PICKUP]
+ * default (a bare delivery); a PRESENT-but-unrecognized string degrades to [OrderType.UNKNOWN]
+ * (a logged gap between the ruleset and the enum) without crashing.
+ */
+class ParsedFieldsFactoryTest {
+
+    private fun offerWithOrderType(orderType: String?): OrderType {
+        val order = buildMap<String, Any?> {
+            if (orderType != null) put("orderType", orderType)
+            put("storeName", "Test Store")
+        }
+        val fields = mapOf<String, Any?>("orders" to listOf(order))
+        val result = ParsedFieldsFactory.create("offer", fields)
+        val offerFields = result as ParsedFields.OfferFields
+        return offerFields.parsedOffer.orders.single().orderType
+    }
+
+    @Test
+    fun `known PICKUP resolves to PICKUP`() {
+        assertEquals(OrderType.PICKUP, offerWithOrderType("PICKUP"))
+    }
+
+    @Test
+    fun `known SHOP_FOR_ITEMS resolves to SHOP_FOR_ITEMS`() {
+        assertEquals(OrderType.SHOP_FOR_ITEMS, offerWithOrderType("SHOP_FOR_ITEMS"))
+    }
+
+    @Test
+    fun `absent orderType takes the neutral PICKUP default`() {
+        assertEquals(OrderType.PICKUP, offerWithOrderType(null))
+    }
+
+    @Test
+    fun `present-but-unrecognized orderType degrades to UNKNOWN without crashing`() {
+        // A retired constant name is exactly the historical gap this guards against.
+        assertEquals(OrderType.UNKNOWN, offerWithOrderType("RESTAURANT_PICKUP"))
+        assertEquals(OrderType.UNKNOWN, offerWithOrderType("totally-bogus"))
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/order/OrderType.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/order/OrderType.kt
@@ -1,47 +1,29 @@
 package cloud.trotter.dashbuddy.domain.model.order
 
 /**
- * Represents the various types of orders that can be offered by DoorDash.
- * Each type has a display name that matches the text on the offer screen
- * and a flag indicating if it's a shopping-type order.
+ * The kind of order within an offer, as far as it affects downstream logic.
  *
- * Recognition is data, not code (CLAUDE.md): the JSON rule engine emits the order type as parse
- * output, which `ParsedFieldsFactory` maps to a constant via the intrinsic [valueOf]. The old
- * Kotlin text-matching helpers (`fromTypeName`/`orderTypeCount`/`allTypeNames`) were superseded by
- * the rules and removed.
+ * Recognition is data, not code (CLAUDE.md): a platform's JSON ruleset emits the order type as a
+ * parse-output string, which [ParsedOrder] carries as this enum. `ParsedFieldsFactory` resolves the
+ * string via the intrinsic [valueOf]. The only behavioural distinction the state/economics layers
+ * draw is [isShoppingOrder] (a shop leg costs shopping time); everything else is a display concern
+ * owned by the UI. The old Kotlin text-matching helpers
+ * (`fromTypeName`/`orderTypeCount`/`allTypeNames`/`typeName`) were superseded by the rules and
+ * removed — a new platform adds vocabulary through its ruleset + corpus, not here.
  */
 enum class OrderType(
-    val typeName: String,
-    val isShoppingOrder: Boolean
+    val isShoppingOrder: Boolean,
 ) {
-    /**
-     *  Standard order pickup from an establishment where items are pre-prepared.
-     *  This can include non-restaurant retail if not explicitly 'Retail pickup'.
-     */
-    PICKUP(
-        typeName = "Pickup",
-        isShoppingOrder = false
-    ),
+    /** A standard pickup of pre-prepared items from a store — the neutral default for a bare order. */
+    PICKUP(isShoppingOrder = false),
 
-    /** Specific order pickup from a restaurant, explicitly labeled as such. */
-    RESTAURANT_PICKUP(
-        typeName = "Restaurant Pickup",
-        isShoppingOrder = false
-    ),
-
-    /** Order requires the Dasher to shop for the items at the store. */
-    SHOP_FOR_ITEMS(
-        typeName = "Shop for items",
-        isShoppingOrder = true
-    ),
+    /** The order requires the Dasher to shop for the items at the store. */
+    SHOP_FOR_ITEMS(isShoppingOrder = true),
 
     /**
-     *  Order pickup from a retail store, typically pre-packaged
-     *  or ready for collection, explicitly labeled as such.
+     * A parse produced an order-type string no [OrderType] constant maps to — a gap between the
+     * ruleset vocabulary and this enum. Non-shopping so it degrades to the safe default in
+     * economics; the mismatch is logged at the parse site (`ParsedFieldsFactory`).
      */
-    RETAIL_PICKUP(
-        typeName = "Retail pickup",
-        isShoppingOrder = false
-    );
-    // Add more types here if new, distinct strings appear on offer screens in the future.
+    UNKNOWN(isShoppingOrder = false),
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/order/OrderTypeTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/order/OrderTypeTest.kt
@@ -1,14 +1,16 @@
 package cloud.trotter.dashbuddy.domain.model.order
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
  * Recognition is data, not code (CLAUDE.md): the text-matching helpers
- * (`fromTypeName`/`orderTypeCount`/`allTypeNames`) were superseded by the JSON rule engine and
- * deleted, so their tests are gone too. `ParsedFieldsFactory` now resolves the order type from
- * parse output via the intrinsic [OrderType.valueOf]. What remains is the [OrderType.isShoppingOrder]
- * flag and the [OrderType.typeName] label.
+ * (`fromTypeName`/`orderTypeCount`/`allTypeNames`/`typeName`) were superseded by the JSON rule
+ * engine and deleted, so their tests are gone too. `ParsedFieldsFactory` now resolves the order
+ * type from parse output via the intrinsic [OrderType.valueOf]; an unrecognized string maps to
+ * [OrderType.UNKNOWN]. What remains is the [OrderType.isShoppingOrder] flag.
  */
 class OrderTypeTest {
 
@@ -18,22 +20,17 @@ class OrderTypeTest {
 
     @Test
     fun `isShoppingOrder - SHOP_FOR_ITEMS is a shopping order`() {
-        assert(OrderType.SHOP_FOR_ITEMS.isShoppingOrder)
+        assertTrue(OrderType.SHOP_FOR_ITEMS.isShoppingOrder)
     }
 
     @Test
     fun `isShoppingOrder - PICKUP is not a shopping order`() {
-        assert(!OrderType.PICKUP.isShoppingOrder)
+        assertFalse(OrderType.PICKUP.isShoppingOrder)
     }
 
     @Test
-    fun `isShoppingOrder - RESTAURANT_PICKUP is not a shopping order`() {
-        assert(!OrderType.RESTAURANT_PICKUP.isShoppingOrder)
-    }
-
-    @Test
-    fun `isShoppingOrder - RETAIL_PICKUP is not a shopping order`() {
-        assert(!OrderType.RETAIL_PICKUP.isShoppingOrder)
+    fun `isShoppingOrder - UNKNOWN degrades to non-shopping`() {
+        assertFalse(OrderType.UNKNOWN.isShoppingOrder)
     }
 
     // -------------------------------------------------------------------------
@@ -48,9 +45,10 @@ class OrderTypeTest {
     }
 
     @Test
-    fun `every type exposes a non-blank typeName`() {
-        OrderType.entries.forEach { type ->
-            assert(type.typeName.isNotBlank()) { "typeName for $type should be non-blank" }
-        }
+    fun `the enum shape is exactly PICKUP, SHOP_FOR_ITEMS, UNKNOWN`() {
+        assertEquals(
+            listOf(OrderType.PICKUP, OrderType.SHOP_FOR_ITEMS, OrderType.UNKNOWN),
+            OrderType.entries.toList(),
+        )
     }
 }


### PR DESCRIPTION
## Summary

#762 item **D9** — the last stringly-typed platform vocabulary on the order model. `OrderType` drops the hand-maintained `typeName` display strings and the two dead DoorDash-flavoured constants (`RESTAURANT_PICKUP`, `RETAIL_PICKUP` — no ruleset ever emitted either; the only live producers are the doordash/uber parse rules, which emit `PICKUP`/`SHOP_FOR_ITEMS`), and gains `UNKNOWN` so a vocabulary gap is *visible* instead of silently coerced.

- **`OrderType`** (`:domain`): `{ PICKUP, SHOP_FOR_ITEMS, UNKNOWN }`, each carrying only the one flag downstream logic actually reads (`isShoppingOrder`). `typeName` deleted — display is a UI concern, and the old strings were a second hand-maintained copy of ruleset vocabulary (SSOT violation, the D9 finding).
- **`ParsedFieldsFactory`** (`:core:pipeline`): the two failure cases are now distinguished. An **absent** `orderType` stays the neutral bare-delivery default (`PICKUP`, silent — the overwhelmingly common shape). A **present-but-unrecognized** string is a real rules↔enum vocabulary gap → `UNKNOWN` + a `Timber.tag("Rules").w` naming the raw value (rule-source vocabulary, not PII). Previously both collapsed to the same silent `PICKUP`, hiding exactly the drift class D9 is about.
- Dead `OfferBadge` import removed; new `ParsedFieldsFactoryTest` covers absent/valid/unrecognized routing; `OrderTypeTest` updated.

## Persistence safety (why deleting enum constants is safe)

The deleted constants' *names* could in principle live in persisted data (`app_events` payloads, state snapshots), and `valueOf`-style decode of a deleted name throws. Two independent grounds make this a non-issue — the second alone is sufficient:

1. **The names never reached disk.** `RESTAURANT_PICKUP`/`RETAIL_PICKUP` were reachable only from a parse rule emitting those strings, and no shipped ruleset ever did. Additionally, the supported on-disk history horizon begins at the v6→v8 destructive-wipe era (2026-06-11) — everything before the current rules-engine vocabulary is already gone from every supported device (n=1, the dev's).
2. **Even a hypothetical stale name cannot crash anything.** Both decode edges are caught: `AppEventRepo.toDomain()` (event-log reads, incl. the projector refold path) and `SnapshotStore.restoreLatest()` (crash recovery) wrap decode and degrade per-row/fail-to-replay respectively. A projector-refold crash from a deleted enum constant is unreachable.

(Ground 2 is the correction the adversarial review required: the original argument stopped at ground 1, which is true but insufficient on its own — it proves absence by construction, not tolerance by design.)

## Design-goal review

- **SSOT (5):** the core of the change — `typeName` was a hand-maintained second copy of ruleset display vocabulary; deleted. The ruleset is the sole vocabulary owner; the enum carries only behaviour (`isShoppingOrder`).
- **Platform-agnostic core (8):** removes DoorDash-flavoured constants from `:domain`; new platform vocabulary arrives via ruleset + corpus, not enum edits (KDoc states this). No new platform literals in logic.
- **Semantic logging (7):** the new WARN is a defended-invariant fire (vocabulary drift), infrequent by construction; the logged raw value is rule-source vocabulary (build-coupled in-tree), not third-party UI text or PII, and the site is tagged (`Rules`), per the #764 ratchet.
- **Kotlin practices (4):** narrows the catch from `Exception` to `IllegalArgumentException` (the only failure `valueOf` throws for a bad name).
- **UDF/purity (1):** parse-time mapping only; no reducer or effect changes.

## Adversarial review

Fable-tier adversarial pass ran on the branch pre-PR (branch head `a7da572f`; this PR adds only the clean master merge): **APPROVE**. The review's required correction (the two-ground persistence argument above) is incorporated; its three non-blocking advisories are recorded on #762 ([comment](https://github.com/sjtrotter/DashBuddy/issues/762#issuecomment-4975773403)): load-time orderType vocabulary validation belongs with the #419/#640 OTA hardening; an optional `^[A-Z_]{1,32}$` format guard on the WARN's raw value; and the pre-existing Uber shop-offer gap (uber.json5 emits literal `PICKUP` unconditionally — #556 class, capture-first, not introduced here).

Part of #762 (D9). No field-validation checklist item — the change is enum/parse plumbing fully covered by unit tests; the observable behaviours (shop detection, badges) are unchanged for all fielded vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
