### PR TITLE
docs(#762/#773): post-merge context updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,7 +344,14 @@ resolution reads that from the committed rows so a payout-less `DASH_STOP` re-ru
 a downgrade. A driver `newStoreName` correction sets a sticky `storeKeyPinned` (H1, never re-keyed). Per-store
 reads group on the resolved key, unresolved rows fall back to `normalizedChain(storeName)` (F9); the #315
 Patterns tab (store report card + dwell percentiles) is the consumer. `PROJECTOR_VERSION` 4→5 refolds all
-history and (F8) the version-bump wipe now also clears `stores`/`pickup_records`. `NetProfit`
+history and (F8) the version-bump wipe now also clears `stores`/`pickup_records`. **#773 (address
+running-key fallback, `PROJECTOR_VERSION` 6→7):** a chain-bare receipt (H-E-B renders no parenthetical
+code) now falls back to an address-derived key — `StoreKeys.addressRunningKey` takes the leading
+pure-ASCII street-number token (1–6 digits, fail-null on ranges/suffixes/non-numeric), `@`-prefixed
+(`@12125`) so provenance is self-describing; the resolution ladder is receipt key > address(`@`) key >
+chain-only with tier-aware monotonic upgrades (an address key never downgrades a receipt key), and
+`normalizeRunningKey` strips a leading `@` from receipt-path keys so a payout parenthetical can't
+masquerade as address-tier. `NetProfit`
 (`:domain`) is the one shared cost-math SSOT for both the offer estimate and the frozen realized net.
 `AnalyticsRepository` (`:core:data`, **DAO-only — no economy dependency**, so historical net is structurally
 immutable) serves period economics (`SUM(netProfit)` frozen + `unattributedPay`; all-pay gross =
@@ -527,8 +534,12 @@ Every new feature or refactor holds to these — they are forefront design input
    offer slots, lifecycle-edge anchors, learned rate models — is either ruleset data validated at
    load or state keyed by `Platform`, never a global tuned to whichever platform we field-test
    most. New rule↔state vocabulary goes through the enumerated, load-validated contract
-   (`StateMachineContract` + `REQUIRED_FIELDS_BY_SHAPE`), not a magic string consumed by a Kotlin
-   `when`. The acceptance test: adding a platform means shipping a ruleset + corpus with **zero**
+   (`StateMachineContract` — `REQUIRED_FIELDS_BY_SHAPE`, plus #762's `EFFECT_INTENTS`
+   (effect-bearing notification intent → its required parse fields) and `REQUIRED_FIELDS_BY_FLOW`
+   (deliberately empty today — every `task:*` flow has a legitimate parse-less rule), both enforced
+   at compile by `RuleCompiler` as *declaration* checks, fail-loud per file; unknown intents stay
+   informational by construction, so an OTA ruleset can't smuggle an effect), not a magic string
+   consumed by a Kotlin `when`. The acceptance test: adding a platform means shipping a ruleset + corpus with **zero**
    `:core:state` / `:core:pipeline` / `:domain` edits. DoorDash-heavy field testing *masks*
    violations (a global slot never collides while only one platform runs), so this is enforced at
    PR-review time — see *Every PR gets a design-goal review* under Git Workflow, and the drift

--- a/docs/design/stores-read-model.md
+++ b/docs/design/stores-read-model.md
@@ -303,6 +303,16 @@ The `storeKey` must be a pure, stable function of the resolved surfaces or refol
 - **Extraction precedence stays deterministic:** when a payout form carries both a parenthetical
   code and a ` - Area` suffix, the parenthetical wins (today's `StoreChainProjector` behavior) —
   keep and test it.
+- **Address tier (#773, shipped PR #781):** a chain-bare receipt (H-E-B renders no parenthetical
+  code — four San Antonio H-E-Bs conflated to one `heb|` row, field-quantified 07-13) falls back
+  to an **address-derived running key**: `StoreKeys.addressRunningKey` takes the leading
+  pure-ASCII street-number token of the address line (1–6 digits; fail-null on ranges, suffixes,
+  hyphenated numbers, non-numeric first lines — fail-toward-conflation, never fabrication),
+  prefixed `@` (`@12125`) so the key's provenance is self-describing. The resolution ladder is
+  **receipt key > address(`@`) key > chain-only**, tier-aware in `isMonotonicDowngrade` (a later
+  receipt key upgrades an address key; an address key never downgrades a receipt key), and
+  `normalizeRunningKey` strips a leading `@` on the receipt path so a payout parenthetical can
+  never masquerade as address-tier. `PROJECTOR_VERSION` 6→7 refolds all history onto the ladder.
 - **Accepted residual (no alias table, D2):** a store whose payout form flips between
   `(02426)`-style and ` - Area`-style across sessions forks into two entities. Named, not fixed —
   a phase-2 alias table (or the OTA lookup) is the home for cross-form unification.

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,30 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — per-location store cards: the four H-E-Bs split apart on the Patterns tab (#773 / PR #781).**
+  Chain-bare receipts (H-E-B shows no store code) now fall back to an address-derived running key
+  (`@<street number>`), so same-chain locations resolve to distinct `storeKey`s instead of one
+  conflated chain row. The projector refolds all history onto the new keys (v7) on first launch of
+  the new build.
+  **How to tell it's working (desk-side, after any dash touching ≥2 locations of one chain — or
+  immediately from the refolded history):** the Patterns tab shows separate store cards per H-E-B
+  location, each with a street-line chip (e.g. "12125 Alamo Ranch Pkwy"); dwell percentiles and
+  visit counts split per location instead of pooling. Watch for: a location whose card shows NO
+  street chip (address failed the strict street-number parse → chain-only fallback, expected for
+  mall/named-plaza addresses — capture the address shape if it looks parseable), and any store that
+  *forks* into two cards across dashes (a receipt-code appearing later should upgrade, not split).
+  - Confirmed: 0/2
+
+- **🆕 NEW — "Shopping off" declines shop offers at the verdict edge (#762 D12 / PR #778).**
+  With `allowShopping` off, a shop-type offer now gets a structural `SHOP_DECLINED` verdict (label
+  "Shopping off") from the evaluator itself — full economics still computed and shown, score 0,
+  decline recommendation — instead of relying on downstream handling.
+  **How to tell it's working (needs the strategy toggle off; watch any shop offer):** the offer
+  card/bubble shows the "Shopping off" quality label with the decline recommendation while the pay/
+  mileage numbers still render; non-shop offers are completely unaffected. Flip the toggle back on
+  and a shop offer scores normally again (the gate reads live strategy prefs).
+  - Confirmed: 0/2
+
 - **🆕 NEW — idle bubble: gas + vehicle are now two separate full-width cards (#728 / PR #767).**
   The cramped one-row `JustInTimeActions` (the layout the dev called "a nightmare to try to operate")
   is now a stacked pair of full-width cards on the idle dashboard card: one for the #722 mode-adaptive


### PR DESCRIPTION
[skip ci]

Docs-only follow-up to the merged #762/#773 chain (PRs #778/#779/#780/#781/#782):

- **CLAUDE.md**: Principle 8 now names the #780 compile-time contract (`EFFECT_INTENTS` + `REQUIRED_FIELDS_BY_FLOW` alongside `REQUIRED_FIELDS_BY_SHAPE`); the §5 analytics section gains the #773 address-running-key + `PROJECTOR_VERSION` 6→7 sentence.
- **docs/design/stores-read-model.md**: F7 key-determinism section gains the shipped `@`-address tier (ladder receipt > address(@) > chain-only, tier-aware monotonicity, `@`-masquerade guard).
- **docs/field-testing/README.md**: two new checklist items at Confirmed: 0/2 — #773 per-location store cards (the four H-E-Bs splitting on the Patterns tab) and #778 "Shopping off" shop-decline verdict.

No code. Design-goal review: docs-only — the CLAUDE.md/design-doc edits are the mandated same-PR context-update discipline applied post-merge (batched since the code PRs merged in a chain); no principle touched by a behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)