### PR TITLE
perf(#435): recognition hot-path pack — rule partition, allText cache, check-before-map, lazy capture

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipelineSensitiveOrderingTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipelineSensitiveOrderingTest.kt
@@ -50,7 +50,7 @@ import org.robolectric.annotation.Config
 @Config(sdk = [35])
 class NotificationPipelineSensitiveOrderingTest {
 
-    private val captureBus: CaptureBus = mock()
+    private val captureBus: CaptureBus = mock { on { isEnabled } doReturn true }
     private val platformPrefs: PlatformPreferences = mock {
         on { enabledPlatforms } doReturn MutableStateFlow(setOf<Platform>(Platform.DoorDash))
         on { enabledPackages } doReturn MutableStateFlow(setOf("com.doordash.driverapp"))

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/NoOpCaptureBus.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/NoOpCaptureBus.kt
@@ -17,6 +17,13 @@ class NoOpCaptureBus @Inject constructor() : CaptureBus {
         Timber.i("Capture persistence disabled (release build) — no envelopes will be written")
     }
 
+    /**
+     * Release builds never persist (#435 item 5): reporting `false` lets [CaptureWriter]
+     * skip the full envelope-build pipeline whose only output would be discarded by
+     * [offer]. Structural, not a call-site guard — the sink itself declares it is off.
+     */
+    override val isEnabled: Boolean = false
+
     override fun offer(
         captureId: String,
         source: String,

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
@@ -39,6 +39,12 @@ class CaptureWriter @Inject constructor(
         obs: Observation.Screen,
         event: PipelineEvent.Screen,
     ): Observation.Screen {
+        // #435 item 5: a disabled bus (release NoOpCaptureBus) discards every offer,
+        // so skip the full tree→DTO→JSON→reparse→pretty-print envelope build here —
+        // it would only be thrown away. The returned obs is unchanged (captureId stays
+        // null, exactly as when the bus deduped/skipped), so downstream is identical.
+        // Structural skip: the bus DECLARES it is off; not a per-call-site guess.
+        if (!captureBus.isEnabled) return obs
         // Fail-closed backstop (#432): the sensitive gate upstream only sees
         // screens a RULE recognized as sensitive. An UNRECOGNIZED sensitive
         // screen classifies UNKNOWN and would be captured verbatim for triage
@@ -129,6 +135,8 @@ class CaptureWriter @Inject constructor(
         event: PipelineEvent.Click,
         screenTarget: String?,
     ): Observation.Click {
+        // #435 item 5: skip the envelope build for a disabled bus (see captureScreen).
+        if (!captureBus.isEnabled) return obs
         // Same fail-closed backstop as captureScreen (#432), added with #597:
         // an UNKNOWN click envelope carries the raw tapped node, and a tap on
         // an unruled sensitive surface must not persist its text. (Rule-matched
@@ -180,6 +188,8 @@ class CaptureWriter @Inject constructor(
         obs: Observation.Notification,
         raw: RawNotificationData,
     ): Observation.Notification {
+        // #435 item 5: skip the envelope build for a disabled bus (see captureScreen).
+        if (!captureBus.isEnabled) return obs
         // Same fail-closed backstop as captureScreen (#432) for UNKNOWN
         // notification bodies. Scans the flat text fields AND actionLabels
         // (#666 item 2c — a push action button label is serialized into the

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/content_changed/ContentChangedPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/content_changed/ContentChangedPipeline.kt
@@ -37,10 +37,21 @@ class ContentChangedPipeline @Inject constructor(
             // Reset for the next debounce window; the accumulated bitmask itself is
             // logged above (#439 — TreeSnapshot no longer carries it, never consumed).
             pendingChangeTypes.set(0)
+            // Check-before-map (#435 item 3): read the active window's package first and
+            // skip the full tree mapping for a non-target window (bubble overlay, launcher).
+            val activePkg = source.getActiveWindowPackage()
+            if (activePkg !in Platform.watchedPackages) {
+                Timber.v(
+                    "🚫 Skip active window (pre-map): non-target pkg=%s (event pkg=%s)",
+                    activePkg, event.packageName,
+                )
+                return@mapNotNull null
+            }
             val snapshot = source.getCurrentRootSnapshot() ?: return@mapNotNull null
             // Attribute to the window actually on screen, not the triggering event. Drop snapshots
             // of non-target windows (our own bubble overlay, launcher, etc.) so we never recognize
-            // our own UI as the platform — the #4 self-recognition feedback loop.
+            // our own UI as the platform — the #4 self-recognition feedback loop. Retained as a
+            // post-map re-check: the active root can swap between the package read and the map.
             if (snapshot.packageName !in Platform.watchedPackages) {
                 Timber.v(
                     "🚫 Skip active window: non-target pkg=%s (event pkg=%s)",

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/state_changed/StateChangedPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/state_changed/StateChangedPipeline.kt
@@ -20,9 +20,20 @@ class StateChangedPipeline @Inject constructor(
             Timber.d("⚡ STATE_CHANGED from %s  types=0x%02x", it.className, it.contentChangeTypes)
         }
         .mapNotNull { event ->
+            // Check-before-map (#435 item 3): read the active window's package first and
+            // skip the full tree mapping for a non-target window (bubble overlay, launcher).
+            val activePkg = source.getActiveWindowPackage()
+            if (activePkg !in Platform.watchedPackages) {
+                Timber.v(
+                    "🚫 Skip active window (pre-map): non-target pkg=%s (event pkg=%s)",
+                    activePkg, event.packageName,
+                )
+                return@mapNotNull null
+            }
             val snapshot = source.getCurrentRootSnapshot() ?: return@mapNotNull null
             // Attribute to the on-screen window, not the event; drop non-target windows (e.g. our
-            // own bubble overlay) so we don't recognize our own UI as the platform (#4).
+            // own bubble overlay) so we don't recognize our own UI as the platform (#4). Retained
+            // as a post-map re-check: the active root can swap between the package read and the map.
             if (snapshot.packageName !in Platform.watchedPackages) {
                 Timber.v(
                     "🚫 Skip active window: non-target pkg=%s (event pkg=%s)",

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilitySource.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilitySource.kt
@@ -80,6 +80,23 @@ class AccessibilitySource @Inject constructor() {
      */
     fun getService(): AccessibilityService? = serviceRef?.get()
 
+    /**
+     * The package owning the active window, read from the native root WITHOUT mapping
+     * the tree (#435 item 3). A full [getCurrentRootSnapshot] converts every node with
+     * one binder IPC apiece; the active-window pipelines drop non-target windows (our
+     * own bubble overlay, the launcher, …) by package, so reading just the package
+     * first lets them skip that whole mapping pass for a window they'll discard anyway.
+     * Cheap: `rootInActiveWindow` fetches only the root node, not the subtree.
+     *
+     * This mirrors [WindowsChangedPipeline], which already reads `nativeRoot.packageName`
+     * before converting. [getCurrentRootSnapshot] re-reads the active root and re-derives
+     * the package, so a rare root swap between the two calls is still caught by the
+     * caller's post-map package re-check — the #4 overlay-drop guarantee is unchanged.
+     *
+     * SAFE to call from background threads.
+     */
+    fun getActiveWindowPackage(): String? = getLiveNativeRoot()?.packageName?.toString()
+
     /** Active-window root snapshot: the converted [UiNode] tree + the **real package** owning it. */
     data class RootSnapshot(val tree: UiNode, val packageName: String?)
 

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/Ruleset.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/Ruleset.kt
@@ -63,6 +63,14 @@ class Ruleset<TInput>(rules: List<CompiledRule<TInput>>) {
      * `substringBefore('.', "")` makes a dotless id group under `""` (never a valid
      * `platformWire`), byte-identical to the old `startsWith` filter which likewise
      * never matched a dotless id.
+     *
+     * DELIBERATE divergence from `Platform.fromRuleId` (the registry's prefix
+     * resolver): `fromRuleId` uses `substringBefore('.')` with NO default, so a
+     * dotless id resolves the whole id as its wire — while this partition buckets
+     * a dotless id under `""`, preserving the old filter's exclusion semantics.
+     * Real rule ids are always `<wire>.<section>.<name>` (wires are non-empty and
+     * dot-free — see the `Platform` KDoc), so the divergence is unreachable in
+     * practice; documented at both sites so neither is "unified" blindly.
      */
     private val evalOrderByPlatform: Map<String, List<CompiledRule<TInput>>> =
         evalOrder.groupBy { it.id.substringBefore('.', "") }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/Ruleset.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/Ruleset.kt
@@ -47,6 +47,26 @@ class Ruleset<TInput>(rules: List<CompiledRule<TInput>>) {
     private val evalOrder: List<CompiledRule<TInput>> =
         sorted.filterNot { it.overrideable } + sorted.filter { it.overrideable }
 
+    /**
+     * [evalOrder] pre-partitioned by the rule-id platform namespace (#435 item 1).
+     *
+     * [matchFirst] used to allocate a fresh filtered list per event via a linear
+     * `id.startsWith("$platformWire.")` scan over every rule — on the recognition
+     * hot path, once per frame. The partition is a pure function of the immutable
+     * rule set, so it is computed ONCE here and looked up by key at match time.
+     *
+     * Platform-agnostic (principle 8): the key is the rule-id's own namespace
+     * prefix — the first dotted segment (`doordash` in `doordash.screen.offer`) —
+     * NOT a hardcoded platform literal. `groupBy` preserves [evalOrder]'s encounter
+     * order within each group, so each partition keeps the non-overrideable-first,
+     * priority-ordered sequence [matchFirst] relies on (#419). Using
+     * `substringBefore('.', "")` makes a dotless id group under `""` (never a valid
+     * `platformWire`), byte-identical to the old `startsWith` filter which likewise
+     * never matched a dotless id.
+     */
+    private val evalOrderByPlatform: Map<String, List<CompiledRule<TInput>>> =
+        evalOrder.groupBy { it.id.substringBefore('.', "") }
+
     /** Rule lookup by id (#598) — the capture-redaction seam fetches a
      *  recognized rule's compiled `redact` block without exposing the list. */
     private val byId: Map<String, CompiledRule<TInput>> = sorted.associateBy { it.id }
@@ -76,7 +96,8 @@ class Ruleset<TInput>(rules: List<CompiledRule<TInput>>) {
         screenTarget: String? = null,
     ): RuleMatchResult? {
         val rules = if (platformWire != null) {
-            evalOrder.filter { it.id.startsWith("$platformWire.") }
+            // Pre-partitioned at construction (#435 item 1) — no per-frame filter alloc.
+            evalOrderByPlatform[platformWire] ?: emptyList()
         } else {
             evalOrder
         }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
@@ -19,6 +19,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -30,7 +31,7 @@ import org.mockito.kotlin.whenever
  */
 class CaptureRedactionTest {
 
-    private val captureBus: CaptureBus = mock()
+    private val captureBus: CaptureBus = mock { on { isEnabled } doReturn true }
     private val stats = PipelineStats()
 
     /** A dropoff-shaped redact block: name node keeps its marker, address masked whole. */

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
@@ -15,6 +15,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -27,7 +28,7 @@ import org.mockito.kotlin.verify
  */
 class CaptureScrubTest {
 
-    private val captureBus: CaptureBus = mock()
+    private val captureBus: CaptureBus = mock { on { isEnabled } doReturn true }
     private val stats = PipelineStats()
     private val writer = CaptureWriter(captureBus, stats, NoRedaction)
 

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriterDisabledBusTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriterDisabledBusTest.kt
@@ -1,0 +1,112 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.core.pipeline.accessibility.TreeSnapshot
+import cloud.trotter.dashbuddy.core.pipeline.rules.NoRedaction
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+/**
+ * #435 item 5 — pins the structural capture skip for a DISABLED bus (the release
+ * `NoOpCaptureBus`, `isEnabled == false`): each `CaptureWriter` writer method must
+ * return the input observation untouched WITHOUT building an envelope or calling
+ * [CaptureBus.offer]. Without these pins the `if (!captureBus.isEnabled) return obs`
+ * branches are untested — the class of blindness that let #770 ship green.
+ *
+ * (The enabled-bus behavior — full build + offer + redaction — is pinned by
+ * `CaptureScrubTest` / `CaptureRedactionTest` / `NotificationRedactionTest`, whose
+ * mocks stub `isEnabled = true`.)
+ */
+class CaptureWriterDisabledBusTest {
+
+    private val disabledBus: CaptureBus = mock { on { isEnabled } doReturn false }
+    private val stats = PipelineStats()
+    private val writer = CaptureWriter(disabledBus, stats, NoRedaction)
+
+    private fun screenObs() = Observation.Screen(
+        timestamp = 1_000L,
+        captureId = null,
+        ruleId = "doordash.screen.test",
+        metadata = ReplayMetadata.EMPTY,
+        flow = null,
+        modeHint = null,
+        parsed = ParsedFields.None,
+        target = "idle_map",
+    )
+
+    @Test
+    fun `disabled bus - captureScreen never offers and returns the input observation`() {
+        val obs = screenObs()
+        val tree = UiNode(children = listOf(UiNode(text = "Some screen")))
+        val event = PipelineEvent.Screen(
+            timestamp = 1_000L,
+            tree = tree,
+            snapshot = TreeSnapshot(tree = tree, packageName = "com.doordash.driverapp"),
+            packageName = "com.doordash.driverapp",
+        )
+
+        val result = writer.captureScreen(obs, event)
+
+        verify(disabledBus, never()).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertSame("observation must pass through untouched (captureId stays null)", obs, result)
+    }
+
+    @Test
+    fun `disabled bus - captureClick never offers and returns the input observation`() {
+        val obs = Observation.Click(
+            timestamp = 1_000L,
+            captureId = null,
+            ruleId = "doordash.click.test",
+            metadata = ReplayMetadata.EMPTY,
+            flow = null,
+            modeHint = null,
+            parsed = ParsedFields.ClickFields(intent = "accept"),
+            target = "accept",
+        )
+        val event = PipelineEvent.Click(
+            timestamp = 1_000L,
+            node = UiNode(text = "Accept", isClickable = true),
+            packageName = "com.doordash.driverapp",
+        )
+
+        val result = writer.captureClick(obs, event, screenTarget = "offer_popup")
+
+        verify(disabledBus, never()).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertSame("observation must pass through untouched (captureId stays null)", obs, result)
+    }
+
+    @Test
+    fun `disabled bus - captureNotification never offers and returns the input observation`() {
+        val obs = Observation.Notification(
+            timestamp = 1_000L,
+            captureId = null,
+            ruleId = "doordash.notification.test",
+            metadata = ReplayMetadata.EMPTY,
+            flow = null,
+            modeHint = null,
+            parsed = ParsedFields.None,
+            target = "new_order",
+        )
+        val raw = RawNotificationData(
+            title = "New Delivery!", text = "New order: go to Chipotle",
+            tickerText = null, bigText = null,
+            packageName = "com.doordash.driverapp", postTime = 1_000L, isClearable = true,
+        )
+
+        val result = writer.captureNotification(obs, raw)
+
+        verify(disabledBus, never()).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertSame("observation must pass through untouched (captureId stays null)", obs, result)
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/ClickCaptureNoDedupTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/ClickCaptureNoDedupTest.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -28,7 +29,7 @@ import org.mockito.kotlin.whenever
  */
 class ClickCaptureNoDedupTest {
 
-    private val captureBus: CaptureBus = mock()
+    private val captureBus: CaptureBus = mock { on { isEnabled } doReturn true }
     private val writer = CaptureWriter(captureBus, PipelineStats(), NoRedaction)
 
     private fun clickObs(t: Long) = Observation.Click(

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/NotificationRedactionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/NotificationRedactionTest.kt
@@ -20,6 +20,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -31,7 +32,7 @@ import org.mockito.kotlin.whenever
  */
 class NotificationRedactionTest {
 
-    private val captureBus: CaptureBus = mock()
+    private val captureBus: CaptureBus = mock { on { isEnabled } doReturn true }
     private val stats = PipelineStats()
 
     private fun compileNotifRedact(json: String): CompiledNotifRedact =

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/PreMapPackageSkipTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/PreMapPackageSkipTest.kt
@@ -1,0 +1,145 @@
+package cloud.trotter.dashbuddy.core.pipeline.accessibility
+
+import android.view.accessibility.AccessibilityEvent
+import cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.window.content_changed.ContentChangedPipeline
+import cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.window.state_changed.StateChangedPipeline
+import cloud.trotter.dashbuddy.core.pipeline.accessibility.input.AccessibilitySource
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * #435 item 3 — pins the check-before-map skip in the two active-window
+ * pipelines: when [AccessibilitySource.getActiveWindowPackage] reports a
+ * NON-target package (our bubble overlay, the launcher), the pipeline must
+ * never call [AccessibilitySource.getCurrentRootSnapshot] — that call maps the
+ * entire tree (one binder IPC per node), which is the exact work the pre-map
+ * check exists to skip. Without these pins the skip branch is untested — a
+ * refactor that reorders the check after the map would ship green.
+ *
+ * A positive control per pipeline (target package → snapshot IS taken and a
+ * TreeSnapshot emitted) proves the harness actually flows.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class PreMapPackageSkipTest {
+
+    private val nonTargetPkg = "com.android.launcher3"
+    private val targetPkg = "com.doordash.driverapp" // Platform.watchedPackages member
+
+    private fun event(type: Int): AccessibilityEvent = mock {
+        on { eventType } doReturn type
+        on { contentChangeTypes } doReturn 0
+        on { className } doReturn "android.widget.FrameLayout"
+        on { packageName } doReturn nonTargetPkg
+    }
+
+    private fun sourceWith(
+        events: MutableSharedFlow<AccessibilityEvent>,
+        activePkg: String,
+        snapshot: AccessibilitySource.RootSnapshot?,
+    ): AccessibilitySource = mock {
+        on { this.events } doReturn events
+        on { getActiveWindowPackage() } doReturn activePkg
+        on { getCurrentRootSnapshot() } doReturn snapshot
+    }
+
+    private fun snapshotOf(pkg: String) =
+        AccessibilitySource.RootSnapshot(tree = UiNode(text = "root"), packageName = pkg)
+
+    /** Emit [event] into a collecting [pipelineOutput], return everything emitted. */
+    private fun collectWith(
+        events: MutableSharedFlow<AccessibilityEvent>,
+        pipelineOutput: Flow<TreeSnapshot>,
+        event: AccessibilityEvent,
+    ): List<TreeSnapshot> {
+        val emitted = mutableListOf<TreeSnapshot>()
+        runTest {
+            val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                pipelineOutput.collect { emitted += it }
+            }
+            advanceUntilIdle()
+            assertTrue("test harness: event must enter the shared flow", events.tryEmit(event))
+            advanceUntilIdle()
+            job.cancel()
+        }
+        return emitted
+    }
+
+    // ── ContentChangedPipeline ──────────────────────────────────────────
+
+    @Test
+    fun `content-changed - non-target active window is skipped BEFORE mapping`() {
+        val events = MutableSharedFlow<AccessibilityEvent>(extraBufferCapacity = 4)
+        val source = sourceWith(events, activePkg = nonTargetPkg, snapshot = snapshotOf(nonTargetPkg))
+
+        val emitted = collectWith(
+            events, ContentChangedPipeline(source).output(),
+            event(AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED),
+        )
+
+        verify(source, never()).getCurrentRootSnapshot()
+        assertTrue("non-target window must emit nothing", emitted.isEmpty())
+    }
+
+    @Test
+    fun `content-changed - target active window still maps and emits (control)`() {
+        val events = MutableSharedFlow<AccessibilityEvent>(extraBufferCapacity = 4)
+        val source = sourceWith(events, activePkg = targetPkg, snapshot = snapshotOf(targetPkg))
+
+        val emitted = collectWith(
+            events, ContentChangedPipeline(source).output(),
+            event(AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED),
+        )
+
+        verify(source, times(1)).getCurrentRootSnapshot()
+        assertEquals("target window must flow through", 1, emitted.size)
+        assertEquals(targetPkg, emitted.single().packageName)
+    }
+
+    // ── StateChangedPipeline ────────────────────────────────────────────
+
+    @Test
+    fun `state-changed - non-target active window is skipped BEFORE mapping`() {
+        val events = MutableSharedFlow<AccessibilityEvent>(extraBufferCapacity = 4)
+        val source = sourceWith(events, activePkg = nonTargetPkg, snapshot = snapshotOf(nonTargetPkg))
+
+        val emitted = collectWith(
+            events, StateChangedPipeline(source).output(),
+            event(AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED),
+        )
+
+        verify(source, never()).getCurrentRootSnapshot()
+        assertTrue("non-target window must emit nothing", emitted.isEmpty())
+    }
+
+    @Test
+    fun `state-changed - target active window still maps and emits (control)`() {
+        val events = MutableSharedFlow<AccessibilityEvent>(extraBufferCapacity = 4)
+        val source = sourceWith(events, activePkg = targetPkg, snapshot = snapshotOf(targetPkg))
+
+        val emitted = collectWith(
+            events, StateChangedPipeline(source).output(),
+            event(AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED),
+        )
+
+        verify(source, times(1)).getCurrentRootSnapshot()
+        assertEquals("target window must flow through", 1, emitted.size)
+        assertEquals(targetPkg, emitted.single().packageName)
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,18 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — Recognition hot-path pack: pre-map package skip must not drop real frames (#435 / PR #791).**
+  ContentChanged/StateChanged now read the active window's package FIRST and skip the full tree
+  mapping when it isn't a watched platform (bubble overlay, launcher). The skip must only ever fire
+  for windows we were going to drop anyway — recognition of the platform app must be unaffected.
+  **What to watch:** recognition frames still land normally with overlays around (our bubble over
+  the DoorDash map, the offer popup, the quick-decline confirm sheet) and there are NO missing /
+  late screens while the platform app is foreground — screen changes keep reflecting in the HUD at
+  the usual cadence. **Desk-side:** the VERBOSE `🚫 Skip active window (pre-map)` lines name ONLY
+  non-target packages (launcher, dashbuddy, systemui) — never a watched platform package — and
+  recognized-frame counts per session look normal vs prior dashes.
+  - Confirmed: 0/2
+
 - **🆕 NEW — Automation taps un-broken: active-window candidate scoping + window-root dedup (#788, fixes the 07-16 regression).**
   Both automation taps died on 07-16 with `No decisive match among 2 verified candidates` — the active
   window's root was enumerated TWICE (tying with itself) and a viewId twin in a lower window (the offer

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/CaptureBus.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/CaptureBus.kt
@@ -13,6 +13,16 @@ package cloud.trotter.dashbuddy.domain.capture
 interface CaptureBus {
 
     /**
+     * Whether this bus persists envelopes (#435 item 5). When `false` — the release
+     * [NoOpCaptureBus], which discards every offer — [CaptureWriter] skips the entire
+     * tree→DTO→JSON→reparse→pretty-print envelope build structurally, since there is
+     * nothing to build for a sink that throws the result away. Defaults `true`, so the
+     * debug [DiskCaptureBus] and every test fake keep exercising the full build path
+     * (envelope content / redaction are debug-tested and must stay byte-identical).
+     */
+    val isEnabled: Boolean get() = true
+
+    /**
      * Write a capture envelope to disk.
      *
      * @param captureId  UUID assigned to this capture by the pipeline.

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Platform.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Platform.kt
@@ -15,6 +15,11 @@ import java.util.Locale
  * chat gerund — "Dashing"/"Ubering"; `null` falls back to a generic verb at
  * the UI edge). No UI/Android types — this is pure copy + a phrase, derived
  * everywhere it's shown.
+ *
+ * [wire] values are assumed **non-empty and dot-free** — they are used as the
+ * platform namespace prefix of rule ids (`<wire>.<section>.<name>`), so a wire
+ * containing a `.` or an empty wire would break prefix-based resolution
+ * ([fromRuleId], `Ruleset.evalOrderByPlatform`).
  */
 enum class Platform(
     val wire: String,
@@ -34,7 +39,18 @@ enum class Platform(
         private val byWire = entries.associateBy { it.wire }
         private val byName = entries.associateBy { it.name.lowercase(Locale.ROOT) }
 
-        /** Resolve the platform prefix from a rule id, or [Unknown]. */
+        /**
+         * Resolve the platform prefix from a rule id, or [Unknown].
+         *
+         * Note a deliberate divergence from `Ruleset.evalOrderByPlatform`'s
+         * partition key (#435): `substringBefore('.')` with no default means a
+         * DOTLESS id resolves the whole id as its wire (so a literal `"doordash"`
+         * would resolve to [DoorDash]), whereas the Ruleset partition buckets a
+         * dotless id under `""` — matching the old `startsWith("$wire.")` filter,
+         * which never matched a dotless id. Real rule ids are always
+         * `<wire>.<section>.<name>`, so the divergence is unreachable in practice;
+         * it is documented so neither side is "fixed" to match the other blindly.
+         */
         fun fromRuleId(ruleId: String?): Platform {
             val prefix = ruleId?.substringBefore('.') ?: return Unknown
             return byWire[prefix] ?: Unknown


### PR DESCRIPTION
Closes #435 (partial — items 1/3/5 shipped, item 2 already done, item 4 deferred, item 6 done in #790).

Recognition hot-path optimization pack. Recognition results are **byte-inert**: `AllMatchersSuite` is green and `approved-parse-output.json` is unchanged (never regenerated).

## Per-item summary

### Item 1 — pre-partition rules per platform ✅
`Ruleset.matchFirst` allocated a fresh `evalOrder.filter { it.id.startsWith("$platformWire.") }` list **per event** on the recognition hot path (once per frame). The partition is a pure function of the immutable rule set, so it is now computed **once at construction** into `evalOrderByPlatform`, looked up by key at match time.

- Platform-agnostic (principle 8): the key is the rule-id's own namespace prefix — the first dotted segment (`doordash` in `doordash.screen.offer`) — **not** a hardcoded platform literal.
- `groupBy` preserves `evalOrder`'s encounter order, so each partition keeps the non-overrideable-first, priority-ordered sequence `matchFirst` relies on (#419).
- `substringBefore('.', "")` groups a dotless id under `""` (never a valid `platformWire`), making the map **byte-identical** to the old `startsWith` filter (which also never matched a dotless id).

### Item 2 — allText cache ✅ (already implemented)
`UiNode.allTextLowerJoined` (lazy val, lowercased once with `Locale.ROOT`) already exists (#293) and `PredicateCompiler`'s `allTextContains*` predicates already read it. No change needed — noted for completeness.

### Item 3 — package-check before mapping ✅
`getCurrentRootSnapshot()` converted the **entire** active-window tree (one binder IPC per node) *before* the caller checked the package — a full mapping pass wasted on every non-target active window (bubble overlay, launcher). Added `AccessibilitySource.getActiveWindowPackage()` (reads only the root node's package, no subtree map). `ContentChangedPipeline`/`StateChangedPipeline` now read the package first and skip the map for a non-target window. This mirrors `WindowsChangedPipeline`, which already reads `nativeRoot.packageName` before converting.

**Behavior preserved:** the #4 overlay-drop guarantee is intact — `snapshot.packageName` still comes from the mapped root, and the post-map watched-package **re-check is retained** (catches a rare active-root swap between the package read and the map). The `AccessibilityPipeline.output()` gate ordering (#432 rulesets-not-loaded, #399 sensitive/noise) is untouched — this change is upstream, in the snapshot producers, and only skips mapping when the package is determinable *without* mapping.

### Item 4 — coalesce STATE_CHANGED + CONTENT_CHANGED double-mapping ⛔ DEFERRED
Cannot be proven inert w.r.t. `FrameGate` admission semantics (#360 identity dedup + rolling UNKNOWN suppression) or the hot `shareIn` single-pass contract (#361): the two events feed distinct sub-flows (one debounced 150/300 ms, one immediate) merged upstream, and their reconciliation *is* FrameGate. Coalescing them would change which frame wins admission and when — a semantics change. Per the acceptance bar, a **partial-pack ship is preferred** over an unproven admission change. Left for a dedicated change with a `SessionReplay` admission-invariant test.

### Item 5 — skip envelope build under a no-op bus ✅
Release binds `NoOpCaptureBus`, which discards every `offer`, yet `CaptureWriter` still ran the full `tree→DTO→JSON→reparse→pretty-print` build and handed the result to the sink. Added `CaptureBus.isEnabled` (defaults `true`; `NoOpCaptureBus` overrides `false`) and a **structural** guard at the top of each `CaptureWriter` method — the sink *declares* it is off, not a per-call-site guess. The returned observation is unchanged (`captureId` stays null, exactly as when the bus dedups/skips), so downstream is identical.

- Debug `DiskCaptureBus` and every test fake keep the default `true`, so the full build path — and rule-declared redaction (#598/#623) — stays **byte-identical in debug**.
- The `prettyPrint`/double-serialization drop suggested in the issue is **NOT taken**: it would change the debug envelope bytes, violating the byte-identical-in-debug acceptance bar. Deferred with that justification.

### Item 6 — `getLiveWindowRoots` dedup ✅ already fixed by #790 (not touched).

## Timing evidence
Scratch JVM harness (not committed) over the generated screen ruleset (95 rules: 76 doordash + 19 uber) and the full 513-frame snapshot corpus; load once, GC between rounds, 15 rounds, per-round medians. Run on this branch vs the same corpus with `Ruleset.kt` reverted to the per-frame filter.

**Isolated selection step** (the exact operation item 1 changes), 513 frames/round:

| Path | µs/round (median) | µs/frame | allocation |
|---|---|---|---|
| OLD `filter { startsWith }` | 1046.3 | 2.040 | one ~76-elem `ArrayList`/frame |
| NEW `evalOrderByPlatform[wire]` | 8.0 | 0.016 | zero |
| **speedup** | **~130x** | | |

**Full `matchFirst` over the corpus** (end-to-end, dominated by per-rule predicate evaluation that item 1 does not touch): ~116 µs/frame; the earlier coarse before/after was within run-to-run noise (~40k vs ~42k µs/round). Honest read: item 1 removes a per-frame allocation + a 95-rule scan (measured 130x on the isolated step, ~2 µs/frame + GC pressure end-to-end); it is a hot-path allocation/GC win, not a large CPU win, because predicate evaluation dominates the full path.

## Security / privacy posture
Untrusted-input-adjacent (the accessibility tree; eventually CDN rules). **No gate, cap, or scrub is removed or weakened:**
- Item 3 only skips *mapping* for a window whose package is a non-target — the mapping was going to be dropped anyway. The #4 overlay-drop and both watched-package checks (pre-map + post-map) remain; the fail-closed pipeline gates (#432/#399) are untouched.
- Item 5 skips envelope building **only** when the bus is the release `NoOpCaptureBus` (which never persists). When any real bus is bound, every scrub/redaction site (#432 UNKNOWN `SensitiveTextMarkers` backstop, #598/#623 rule redaction, #624/#632/#666 `CustomerTextMarkers` backstop) runs exactly as before, byte-identical. The skip is the sink declaring it discards — it cannot leak because nothing is built or written.
- **Release-observability delta (adversarial-review finding, disclosed rather than hidden in the "pure perf" framing):** in **release builds** the item-5 structural skip returns before the `SensitiveTextMarkers`/`CustomerTextMarkers` backstop *scans* inside `CaptureWriter`, so their `Capture scrubbed:`/`Capture backstop:` WARN lines never fire and the `PipelineStats` scrub counters (`scrubbedUnknownCaptureCount`, redact-backstop counts) will read **0 in release**. This is a behavior change, not just a perf change. Privacy strictly *improves* — less third-party text is handled at all, and nothing was ever persisted in release (`NoOpCaptureBus` discarded every envelope post-scan) — but release logs/stats lose the "a rule forgot to redact" early-warning signal those WARNs provided. Debug builds (the only place captures exist) keep every scan, WARN, and counter unchanged.
- Item 1 changes only which rules are *iterated*, keyed on the rule-id namespace; the non-overrideable-first sensitive-block ordering (#419) is preserved byte-for-byte.
- No new logging; no PII surface added.

## Test doubles
Tests that `mock<CaptureBus>()` now stub `isEnabled = true` (Mockito returns `false` for an un-stubbed Boolean, which would disable the very capture path they assert). That is the enabled-bus precondition those tests already assume. Object-based fakes (`RecordingBus`) inherit the `true` default unchanged.

## Review follow-ups (applied in-PR, commit 2)
Adversarial review came back APPROVE with non-blocking findings, applied:
- **Test pins for the two new branches** (previously untested — the #770 class of blindness): `CaptureWriterDisabledBusTest` (per writer method: disabled bus → `never().offer(...)` + input observation passes through `assertSame`-identical) and `PreMapPackageSkipTest` (per active-window pipeline: non-target `getActiveWindowPackage()` → `getCurrentRootSnapshot()` never called, plus a positive control proving the harness flows).
- **KDoc cross-refs** for the deliberate namespace-parse divergence between `Ruleset.evalOrderByPlatform` (dotless id → `""` bucket, matching the old `startsWith` exclusion) and `Platform.fromRuleId` (dotless id resolves the whole id as its wire) — documented at both sites, plus a `Platform` note that wires are assumed non-empty and dot-free. KDoc only, no runtime change.
- **Field-test checklist item** for the item-3 pre-map skip (`docs/field-testing/README.md`, Confirmed: 0/2).
- The release-observability delta disclosure above.

### Design-goal review
- **1 (UDF):** reducers/steppers untouched; all changes are at the sensor/edge (snapshot producers, capture sink). No state written from new sites.
- **3 (single responsibility):** small, focused additions — one method on `AccessibilitySource`, one property on `CaptureBus`, one map on `Ruleset`. No file grew toward the ~900-line smell.
- **5 (SSOT):** `evalOrderByPlatform` derives from the owned `evalOrder` anchor (no second hand-maintained copy); item 2's cache already derives from `allText`. `isEnabled` is a single declared property, not a duplicated flag.
- **6 (security & privacy):** covered above — no gate/cap/scrub weakened; fail-closed properties intact; captures still debug-only. One disclosed behavior delta: release builds skip the CaptureWriter backstop *scans* (and their WARNs/stats) along with the envelope build — privacy strictly improves, observability of the "rule forgot to redact" signal in release logs is lost (debug unchanged).
- **7 (semantic logging):** the release delta above removes (release-only) WARN sites by construction rather than adding noise; the new pre-map skip line is VERBOSE (per-frame trace, firehose only), matching the existing post-map skip line's level.
- **8 (platform-agnostic core):** the partition keys on the rule-id namespace prefix generically (first dotted segment), never a `== Platform.DoorDash` or literal wire string; no new platform literals in `:core:pipeline` logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
