### PR TITLE
test(#700): drive two_pickup_stack fixture to job close — restore 2× DELIVERY_COMPLETED assertion

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/OdometerPredicateEquivalenceTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/OdometerPredicateEquivalenceTest.kt
@@ -173,7 +173,9 @@ class OdometerPredicateEquivalenceTest {
             listOf(
                 "receipt_skip_2026_06_29" to 2,
                 "receipt_skip_2026_06_29" to 3,
-                "two_pickup_stack_2026_07_05" to 9,
+                // #700 added frames 12 (dropoff_photo) + 13 (nav_arriving) before frame 11, so the
+                // mamamargies-drive divergence frame shifted from screen-step 9 to 11 (same shape).
+                "two_pickup_stack_2026_07_05" to 11,
             ),
             divergences.sortedWith(compareBy({ it.first }, { it.second })),
         )

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/TwoPickupStackReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/TwoPickupStackReplayTest.kt
@@ -1,12 +1,16 @@
 package cloud.trotter.dashbuddy.replay
 
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
 import cloud.trotter.dashbuddy.test.util.SessionReplay
 import cloud.trotter.dashbuddy.test.util.SnapshotSecurityScanner
 import cloud.trotter.dashbuddy.test.util.TestResourceLoader
@@ -37,16 +41,37 @@ import java.io.File
  *    bearing Mama Margies' hash carries "Mama Margies" — via the D6 customer-hash join.
  *
  * The drops resolve onto the accept-minted dropoff placeholders (F3's economics + placeholders are
- * what make that possible). RESIDUAL (documented, out of #526's scope): these `dropoff_pre_arrival`
- * frames parse NO customer ADDRESS, and the stacked-dropoff detector (#565) keys the two-drop split
- * on a changed address hash — so with THIS capture the two drops fold onto ONE active dropoff slot
- * rather than two distinct tasks, and the job never reaches a clean grace close (no DELIVERY_COMPLETED
- * here). Both drops are still correctly store-attributed AT THEIR ACTIVE STEP (asserted below); the
- * distinct-task split + completion is a separate address-parse concern, not #526.
+ * what make that possible). Both drops are correctly store-attributed AT THEIR ACTIVE STEP.
+ *
+ * **#700 — driving to job close (`drives the two-drop stack to a clean job close`).** The per-frame
+ * tests above use ONLY the captured `run()` sequence, which ends mid-dropoff. Reaching the two
+ * `DELIVERY_COMPLETED` completions the on-device machine emitted (db `app_events` seq 28/29) needs
+ * three device frames the capture layer **suppressed** and cannot be recovered from disk:
+ *  1. the sustained navigation AWAY from Bill Miller (drove db seq 24 `DELIVERY_CONFIRMED` + seq 25
+ *     `DELIVERY_NAV_STARTED` at 15:59:07) — no capture exists in the 8-minute drive gap (15:59:06 →
+ *     16:07:13), the frames were identity/content deduped;
+ *  2. Bill Miller's grace-committed retire (the `TASK_RETIRE` grace armed by (1));
+ *  3. Mama Margies' ARRIVAL (drove db seq 26 `DELIVERY_ARRIVED` at 16:07:34) — that frame fell to
+ *     `UNKNOWN` on-device ("Leave it at the door", no completion CTA the rules key on), never a
+ *     recognized envelope.
+ * The captured frames additionally parse **no `customerAddressHash`** anywhere, so the #565
+ * address-keyed stacked-dropoff split cannot fire either — which is exactly why #700 targets the
+ * `TASK_RETIRE` grace + customer-less placeholder-resolution path instead. So the close test
+ * ([drivesTheTwoDropStackToACleanJobClose]) reduces the real captured frames + real accept click
+ * PLUS a small, explicitly-labelled set of injections that stand in for those db-proven suppressed
+ * frames: two synthetic `idle` observations (the two drive-away legs that arm each drop's retire),
+ * one synthetic `dropoff_photo`-arrived observation carrying **frame 11's own real parsed Mama
+ * Margies fields** (the suppressed arrival), and two `GRACE_COMMIT` timers. This is a hand-authored
+ * correct-behaviour invariant (never `replay == db`): given the machine is driven the way the device
+ * really was, the current lineage code (#749 per-customer coverage close + the #596 close-out sweep)
+ * closes the job and mints exactly two distinct `DELIVERY_COMPLETED`, both offer-minted placeholders
+ * consumed, both (customer-hash, store) pairs intact — the assertion #700 restores.
  *
  * Fixture: `snapshots/sessions/two_pickup_stack_2026_07_05/` — real device envelopes, edge-redacted
  * (customers appear only as `[redacted:4ee5]` / `[redacted:d290]` markers; the SAME marker on a
- * customer's pickup AND dropoff is exactly what the sha256 join keys on). Verified PII-safe.
+ * customer's pickup AND dropoff is exactly what the sha256 join keys on — frames 12/13 add Bill
+ * Miller's "Complete delivery" screen and the Mama Margies `nav_arriving` overlay, both edge-redacted
+ * with the `roadNameView` street label additionally masked). Verified PII-safe.
  */
 class TwoPickupStackReplayTest {
 
@@ -60,6 +85,61 @@ class TwoPickupStackReplayTest {
     }
 
     private fun dd(step: SessionReplay.ReplayStep) = step.stateAfter.regions.platforms[Platform.DoorDash]
+
+    // ---------------------------------------------------------------------------------------------
+    // #700 — reconstruction of the db-proven suppressed device frames (see the class KDoc). Each
+    // injection stands in for a real on-device frame the capture layer deduped or dropped to UNKNOWN,
+    // so the CAPTURED-only `run()` sequence can be driven to the same job close the device reached.
+    // ---------------------------------------------------------------------------------------------
+
+    /** A drive leg away from the just-arrived drop — a real navigation screen the capture layer
+     *  deduped. Its non-task `idle` flow is what arms the drop's `TASK_RETIRE` grace. */
+    private fun driveAway(atMs: Long): SessionReplay.RawInput = SessionReplay.RawInput(
+        Observation.Screen(
+            timestamp = atMs, captureId = null, ruleId = "doordash.screen.idle_map",
+            metadata = ReplayMetadata.EMPTY, flow = Flow.Idle, modeHint = Mode.Online,
+            parsed = ParsedFields.IdleFields(), target = "idle_map",
+        ),
+        atMs = atMs,
+    )
+
+    /** Mama Margies' ARRIVAL — the frame that fell to UNKNOWN on-device (db seq 26). It carries
+     *  frame 11's OWN real parsed Mama Margies fields (store + customer hash), re-stamped as the
+     *  arrived sub-flow, so `arrivedAt` is set and the drop can count as delivered. */
+    private fun mamaMargiesArrival(atMs: Long, realFields: ParsedFields.TaskFields): SessionReplay.RawInput =
+        SessionReplay.RawInput(
+            Observation.Screen(
+                timestamp = atMs, captureId = null, ruleId = "doordash.screen.dropoff_photo",
+                metadata = ReplayMetadata.EMPTY, flow = Flow.TaskDropoffArrived, modeHint = Mode.Online,
+                parsed = realFields.copy(subFlow = TaskSubFlow.ARRIVED), target = "dropoff_photo",
+            ),
+            atMs = atMs,
+        )
+
+    /**
+     * The full accept→two-pickup→two-dropoff→**close** drive: the real captured frames + the real
+     * accept click, PLUS the five reconstruction injections at their real device timestamps.
+     */
+    private fun runToClose(): List<SessionReplay.ReplayStep> {
+        val screens = SessionReplay.loadSession(session).map { SessionReplay.ScreenInput(it) }
+        val click = SessionReplay.loadClickFrame("$session/02_accept_offer_click.json")
+        // Mama Margies' real parsed fields, from frame 11's own production recognition.
+        val f11 = screens.first { it.frame.file.startsWith("11_") }.frame
+        val mmFields = SessionReplay.replayRecognition(listOf(f11)).first().parsed as ParsedFields.TaskFields
+        val reconstruction = listOf(
+            driveAway(1_783_285_200_000L),                    // ~16:00:00 — arms Bill Miller's retire
+            SessionReplay.graceCommit(1_783_285_215_000L),    // ~16:00:15 — commits it (>10s grace)
+            mamaMargiesArrival(1_783_285_660_000L, mmFields), // ~16:07:40 — Mama Margies arrives
+            driveAway(1_783_285_690_000L),                    // ~16:08:10 — arms Mama Margies' retire
+            SessionReplay.graceCommit(1_783_285_705_000L),    // ~16:08:25 — commits it + closes the job
+        )
+        return SessionReplay.reduceMixed(screens + click + reconstruction)
+    }
+
+    private fun completions(steps: List<SessionReplay.ReplayStep>): List<DeliveryPayload> =
+        steps.flatMap { it.events }
+            .filter { it.type == AppEventType.DELIVERY_COMPLETED }
+            .mapNotNull { it.payload as? DeliveryPayload }
 
     @Test
     fun `F3 - the accept stash recovers the job's economics through the teardown race`() {
@@ -164,9 +244,11 @@ class TwoPickupStackReplayTest {
         //      parsedPay (the receipt the dasher actually saw), NOT from the row payloads — a #630
         //      withheld receipt (mid-stack exit stamps parsedPay = null on the row) would otherwise
         //      silently drop the whole job from the assertion, hiding the exact shape #630 defends.
-        // (With THIS fixture the documented address-parse residual means no DELIVERY_COMPLETED is
-        // reached — the assertion is then vacuous, driving it to close is #700 — but it pins the
-        // mainline the moment the fixture or the machine closes a job cleanly.)
+        // (With the CAPTURED-only `run()` sequence no DELIVERY_COMPLETED is reached — the assertion
+        // is vacuous here — but it pins the mainline the moment a job closes cleanly. The #700 close
+        // is driven by `runToClose()`; those completions are receipt-LESS shop drops (no per-drop
+        // receipt on this job), so they carry no `dropRealizedPay` and are correctly out of scope for
+        // this receipt-total pin.)
         val steps = run()
 
         // Per job, the receipt total the dasher observed on a PostTask frame (max across the trace —
@@ -194,6 +276,66 @@ class TwoPickupStackReplayTest {
                 summed,
             )
         }
+    }
+
+    // =============================================================================================
+    // #700 — the two drops drive to a clean job close, both completions minted. See the class KDoc
+    // for the reconstruction rationale (db-proven suppressed frames stood in for by `runToClose()`).
+    // =============================================================================================
+
+    @Test
+    fun `drives the two-drop stack to a clean job close - exactly two DELIVERY_COMPLETED, distinct taskIds`() {
+        val completed = completions(runToClose())
+        assertEquals("both drops complete (master/captured-only: 0 — no close reached)", 2, completed.size)
+        assertEquals(
+            "the two completions carry DISTINCT taskIds (one per physical drop, not a doubled drop)",
+            2, completed.map { it.taskId }.toSet().size,
+        )
+    }
+
+    @Test
+    fun `both accept-minted dropoff placeholders are consumed by the two drops`() {
+        val steps = runToClose()
+        // The two dropoff placeholders the accepted offer pre-created (first step that has a job).
+        val placeholderDropoffIds = steps.firstNotNullOf { dd(it)?.activeJob }
+            .tasks.filter { it.phase == TaskPhase.DROPOFF }.map { it.taskId }.toSet()
+        assertEquals("the offer minted two dropoff placeholders", 2, placeholderDropoffIds.size)
+
+        // Every distinct dropoff taskId that ever became active across the drive to close.
+        val activeDropIds = steps.mapNotNull { dd(it)?.activeTask }
+            .filter { it.phase == TaskPhase.DROPOFF }.map { it.taskId }.toSet()
+        assertEquals(
+            "both offer-minted dropoff placeholders were activated (Bill Miller onto one, Mama " +
+                "Margies onto the OTHER — not folded onto a single slot)",
+            2, activeDropIds.size,
+        )
+        assertEquals(
+            "both active drops are the accept-minted placeholder ids (resolved, never fresh-minted)",
+            placeholderDropoffIds, activeDropIds,
+        )
+    }
+
+    @Test
+    fun `both customer-hash to store pairs survive into the closed job's task lineage`() {
+        val completed = completions(runToClose())
+        // The (customerHash, store) pair each completion carries — the join result frozen at close.
+        val pairs = completed.associate { it.customerHash to it.storeName }
+        // The two pickups' customer hashes are the join keys (parsed from the real pickup frames).
+        val steps = runToClose()
+        val pickupHashByStore = steps.flatMap { s ->
+            (dd(s)?.recentTasks.orEmpty() + listOfNotNull(dd(s)?.activeTask))
+                .filter { it.phase == TaskPhase.PICKUP && it.storeName != null && it.customerNameHash != null }
+        }.associate { it.storeName!! to it.customerNameHash!! }
+        val billHash = pickupHashByStore["Bill Miller BBQ"]
+        val mamaHash = pickupHashByStore["Mama Margies"]
+        assertTrue("both pickup customer hashes resolved", billHash != null && mamaHash != null)
+
+        assertEquals(
+            "the closed job completed exactly the two known customers",
+            setOf(billHash, mamaHash), pairs.keys,
+        )
+        assertEquals("Bill Miller's customer joins to Bill Miller BBQ at close", "Bill Miller BBQ", pairs[billHash])
+        assertEquals("Mama Margies' customer joins to Mama Margies at close", "Mama Margies", pairs[mamaHash])
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/TwoPickupStackReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/TwoPickupStackReplayTest.kt
@@ -63,9 +63,12 @@ import java.io.File
  * one synthetic `dropoff_photo`-arrived observation carrying **frame 11's own real parsed Mama
  * Margies fields** (the suppressed arrival), and two `GRACE_COMMIT` timers. This is a hand-authored
  * correct-behaviour invariant (never `replay == db`): given the machine is driven the way the device
- * really was, the current lineage code (#749 per-customer coverage close + the #596 close-out sweep)
- * closes the job and mints exactly two distinct `DELIVERY_COMPLETED`, both offer-minted placeholders
- * consumed, both (customer-hash, store) pairs intact — the assertion #700 restores.
+ * really was, the **strict #596/#615 arm** of `isJobPhysicallyComplete` (both placeholders resolved,
+ * finished, and arrived → the final retire's T1 closes the job) plus the #596 close-out sweep mint
+ * exactly two distinct `DELIVERY_COMPLETED`, both offer-minted placeholders consumed, both
+ * (customer-hash, store) pairs intact — the assertion #700 restores. The #749 per-customer coverage
+ * arm is deliberately NOT exercised here (it short-circuits away when the strict arm succeeds,
+ * mutation-verified — severing it leaves this suite green); its own tests own that arm.
  *
  * Fixture: `snapshots/sessions/two_pickup_stack_2026_07_05/` — real device envelopes, edge-redacted
  * (customers appear only as `[redacted:4ee5]` / `[redacted:d290]` markers; the SAME marker on a
@@ -93,12 +96,15 @@ class TwoPickupStackReplayTest {
     // ---------------------------------------------------------------------------------------------
 
     /** A drive leg away from the just-arrived drop — a real navigation screen the capture layer
-     *  deduped. Its non-task `idle` flow is what arms the drop's `TASK_RETIRE` grace. */
+     *  deduped. Labelled `navigation_generic`, the production rule that matches these suppressed
+     *  mid-dash nav frames (its online branch is flow `idle` + modeHint `online` — a combination
+     *  the classifier really emits; `idle_map` would be modeHint `offline`, impossible here). Its
+     *  non-task `idle` flow is what arms the drop's `TASK_RETIRE` grace. */
     private fun driveAway(atMs: Long): SessionReplay.RawInput = SessionReplay.RawInput(
         Observation.Screen(
-            timestamp = atMs, captureId = null, ruleId = "doordash.screen.idle_map",
+            timestamp = atMs, captureId = null, ruleId = "doordash.screen.navigation_generic",
             metadata = ReplayMetadata.EMPTY, flow = Flow.Idle, modeHint = Mode.Online,
-            parsed = ParsedFields.IdleFields(), target = "idle_map",
+            parsed = ParsedFields.IdleFields(), target = "navigation_generic",
         ),
         atMs = atMs,
     )
@@ -279,8 +285,10 @@ class TwoPickupStackReplayTest {
     }
 
     // =============================================================================================
-    // #700 — the two drops drive to a clean job close, both completions minted. See the class KDoc
-    // for the reconstruction rationale (db-proven suppressed frames stood in for by `runToClose()`).
+    // #700 — the two drops drive to a clean job close, both completions minted. The close fires via
+    // the STRICT #596/#615 arm of `isJobPhysicallyComplete` (both placeholders resolved + finished +
+    // arrived; the #749 coverage arm short-circuits away, deliberately unexercised here). See the
+    // class KDoc for the reconstruction rationale (db-proven suppressed frames → `runToClose()`).
     // =============================================================================================
 
     @Test

--- a/app/src/test/resources/snapshots/sessions/two_pickup_stack_2026_07_05/12_dropoff_complete_billmiller.json
+++ b/app/src/test/resources/snapshots/sessions/two_pickup_stack_2026_07_05/12_dropoff_complete_billmiller.json
@@ -1,0 +1,716 @@
+{
+    "captureId": "f276fef4-ea92-4463-be03-92c592b3ea4e",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1783285146270,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.dropoff_photo",
+    "classificationName": "dropoff_photo",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 136
+                                                        }
+                                                    },
+                                                    {
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 0,
+                                                                                                            "bottom": 136
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 0,
+                                                                                                                    "bottom": 136
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/blocking_loading_overlay",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "desc": "Loading",
+                                                                                                                "id": "com.doordash.driverapp:id/loading_indicator",
+                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 504,
+                                                                                                                    "top": 1206,
+                                                                                                                    "right": 575,
+                                                                                                                    "bottom": 1277
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.widget.ScrollView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2178
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/navbar",
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 261
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/collapsingToolbar_navBar",
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 261
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.doordash.driverapp:id/imageview_nav_bar_background",
+                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 136,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 136
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "id": "com.doordash.driverapp:id/toolbar_navBar",
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 136,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 261
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 136,
+                                                                                                                                            "right": 125,
+                                                                                                                                            "bottom": 261
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 125,
+                                                                                                                                            "top": 136,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 261
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1080,
+                                                                                                                                            "top": 136,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 261
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.ScrollView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 261,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 703
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/steps_screen_content",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 261,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 703
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 261,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 413
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 288,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 377
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 919,
+                                                                                                                                                    "top": 288,
+                                                                                                                                                    "right": 955,
+                                                                                                                                                    "bottom": 288
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 288,
+                                                                                                                                                    "right": 919,
+                                                                                                                                                    "bottom": 372
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "text": "[redacted:ff92]",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 36,
+                                                                                                                                                            "top": 288,
+                                                                                                                                                            "right": 919,
+                                                                                                                                                            "bottom": 372
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 955,
+                                                                                                                                                    "top": 288,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 377
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 955,
+                                                                                                                                                            "top": 288,
+                                                                                                                                                            "right": 1044,
+                                                                                                                                                            "bottom": 377
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 955,
+                                                                                                                                                                    "top": 288,
+                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                    "bottom": 377
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 955,
+                                                                                                                                                                            "top": 288,
+                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                            "bottom": 377
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 413,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 417
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 413,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 417
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 417,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 703
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 417,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 559
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/step_icon",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 453,
+                                                                                                                                                    "right": 89,
+                                                                                                                                                    "bottom": 506
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Verify correct order",
+                                                                                                                                                "id": "com.doordash.driverapp:id/step_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 116,
+                                                                                                                                                    "top": 453,
+                                                                                                                                                    "right": 973,
+                                                                                                                                                    "bottom": 505
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/expansion_icon",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 991,
+                                                                                                                                                    "top": 453,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 506
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 561,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 703
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/step_icon",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 597,
+                                                                                                                                                    "right": 89,
+                                                                                                                                                    "bottom": 650
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Take photo of drop-off location",
+                                                                                                                                                "id": "com.doordash.driverapp:id/step_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 116,
+                                                                                                                                                    "top": 597,
+                                                                                                                                                    "right": 973,
+                                                                                                                                                    "bottom": 649
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/expansion_icon",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 991,
+                                                                                                                                                    "top": 597,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 650
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/footer",
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 2178,
+                                                                                                            "right": 1044,
+                                                                                                            "bottom": 2294
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 2178,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 2294
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 2178,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 2294
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 2178,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 2294
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 2187,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 2294
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 2187,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 2294
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 36,
+                                                                                                                                                            "top": 2187,
+                                                                                                                                                            "right": 1044,
+                                                                                                                                                            "bottom": 2294
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 36,
+                                                                                                                                                                    "top": 2187,
+                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                    "bottom": 2294
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "text": "Complete delivery",
+                                                                                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 351,
+                                                                                                                                                                            "top": 2208,
+                                                                                                                                                                            "right": 729,
+                                                                                                                                                                            "bottom": 2274
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "state": "100 percent.",
+                                                                                                                                                        "class": "android.widget.ProgressBar",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 946,
+                                                                                                                                                            "top": 2201,
+                                                                                                                                                            "right": 1026,
+                                                                                                                                                            "bottom": 2281
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "text": "[redacted:5fec]",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 975,
+                                                                                                                                                            "top": 2223,
+                                                                                                                                                            "right": 997,
+                                                                                                                                                            "bottom": 2259
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/sessions/two_pickup_stack_2026_07_05/13_nav_arriving_mamamargies.json
+++ b/app/src/test/resources/snapshots/sessions/two_pickup_stack_2026_07_05/13_nav_arriving_mamamargies.json
@@ -1,0 +1,676 @@
+{
+ "captureId": "5f432f66-f710-4005-9bbb-906d01dee754",
+ "pipelineId": "accessibility.window",
+ "schemaId": "uinode.v1",
+ "timestamp": 1783285633011,
+ "platform": "doordash",
+ "ruleId": "doordash.screen.nav_arriving",
+ "classificationName": "nav_arriving",
+ "metadata": {
+  "engineVersion": 1,
+  "rulesetFormatVersion": 2,
+  "pipelineVersions": {
+   "accessibility": 1,
+   "accessibility.window": 1,
+   "accessibility.click": 1,
+   "accessibility.long_click": 1,
+   "accessibility.scroll": 1,
+   "accessibility.focus": 1,
+   "notification": 1
+  },
+  "stateMachineApiVersion": "1.0",
+  "appVersion": "0.230.0",
+  "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+ },
+ "payload": {
+  "class": "android.widget.FrameLayout",
+  "isEnabled": true,
+  "bounds": {
+   "left": 0,
+   "top": 0,
+   "right": 1080,
+   "bottom": 2400
+  },
+  "children": [
+   {
+    "class": "android.widget.LinearLayout",
+    "isEnabled": true,
+    "bounds": {
+     "left": 0,
+     "top": 0,
+     "right": 1080,
+     "bottom": 2347
+    },
+    "children": [
+     {
+      "class": "android.widget.FrameLayout",
+      "isEnabled": true,
+      "bounds": {
+       "left": 0,
+       "top": 136,
+       "right": 1080,
+       "bottom": 2347
+      },
+      "children": [
+       {
+        "id": "com.doordash.driverapp:id/action_bar_root",
+        "class": "android.widget.LinearLayout",
+        "isEnabled": true,
+        "bounds": {
+         "left": 0,
+         "top": 136,
+         "right": 1080,
+         "bottom": 2347
+        },
+        "children": [
+         {
+          "id": "android:id/content",
+          "class": "android.widget.FrameLayout",
+          "isEnabled": true,
+          "bounds": {
+           "left": 0,
+           "top": 136,
+           "right": 1080,
+           "bottom": 2347
+          },
+          "children": [
+           {
+            "class": "android.view.ViewGroup",
+            "isEnabled": true,
+            "bounds": {
+             "left": 0,
+             "top": 136,
+             "right": 1080,
+             "bottom": 2347
+            },
+            "children": [
+             {
+              "id": "com.doordash.driverapp:id/contact_sheet_overlay",
+              "class": "androidx.compose.ui.platform.ComposeView",
+              "isEnabled": true,
+              "bounds": {
+               "left": 0,
+               "top": 136,
+               "right": 1080,
+               "bottom": 2347
+              },
+              "children": [
+               {
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                 "left": 0,
+                 "top": 136,
+                 "right": 1080,
+                 "bottom": 2347
+                }
+               }
+              ]
+             },
+             {
+              "id": "com.doordash.driverapp:id/fragment",
+              "class": "android.widget.FrameLayout",
+              "isEnabled": true,
+              "bounds": {
+               "left": 0,
+               "top": 136,
+               "right": 1080,
+               "bottom": 2347
+              },
+              "children": [
+               {
+                "id": "com.doordash.driverapp:id/fragment_navigation_container",
+                "class": "android.view.ViewGroup",
+                "isEnabled": true,
+                "bounds": {
+                 "left": 0,
+                 "top": 136,
+                 "right": 1080,
+                 "bottom": 2347
+                },
+                "children": [
+                 {
+                  "class": "androidx.compose.ui.platform.ComposeView",
+                  "isEnabled": true,
+                  "bounds": {
+                   "left": 0,
+                   "top": 136,
+                   "right": 0,
+                   "bottom": 136
+                  },
+                  "children": [
+                   {
+                    "class": "android.view.View",
+                    "isEnabled": true,
+                    "bounds": {
+                     "left": 0,
+                     "top": 136,
+                     "right": 0,
+                     "bottom": 136
+                    }
+                   }
+                  ]
+                 },
+                 {
+                  "class": "androidx.compose.ui.platform.ComposeView",
+                  "isEnabled": true,
+                  "bounds": {
+                   "left": 0,
+                   "top": 136,
+                   "right": 0,
+                   "bottom": 136
+                  },
+                  "children": [
+                   {
+                    "class": "android.view.View",
+                    "isEnabled": true,
+                    "bounds": {
+                     "left": 0,
+                     "top": 136,
+                     "right": 0,
+                     "bottom": 136
+                    }
+                   }
+                  ]
+                 },
+                 {
+                  "id": "com.doordash.driverapp:id/top_header",
+                  "class": "android.view.ViewGroup",
+                  "isEnabled": true,
+                  "bounds": {
+                   "left": 0,
+                   "top": 136,
+                   "right": 1080,
+                   "bottom": 423
+                  },
+                  "children": [
+                   {
+                    "text": "Arriving at",
+                    "id": "com.doordash.driverapp:id/arriving_at_subtitle",
+                    "class": "android.widget.TextView",
+                    "isEnabled": true,
+                    "bounds": {
+                     "left": 53,
+                     "top": 154,
+                     "right": 230,
+                     "bottom": 196
+                    }
+                   },
+                   {
+                    "text": "[redacted:de6f]",
+                    "id": "com.doordash.driverapp:id/arriving_at_title",
+                    "class": "android.widget.TextView",
+                    "isEnabled": true,
+                    "bounds": {
+                     "left": 53,
+                     "top": 214,
+                     "right": 1027,
+                     "bottom": 387
+                    }
+                   }
+                  ]
+                 },
+                 {
+                  "id": "com.doordash.driverapp:id/navigationView",
+                  "class": "android.widget.FrameLayout",
+                  "isEnabled": true,
+                  "bounds": {
+                   "left": 0,
+                   "top": 423,
+                   "right": 1080,
+                   "bottom": 2347
+                  },
+                  "children": [
+                   {
+                    "id": "com.doordash.driverapp:id/mapViewLayout",
+                    "class": "android.widget.FrameLayout",
+                    "isEnabled": true,
+                    "bounds": {
+                     "left": 0,
+                     "top": 423,
+                     "right": 1080,
+                     "bottom": 2347
+                    },
+                    "children": [
+                     {
+                      "class": "android.widget.FrameLayout",
+                      "isEnabled": true,
+                      "bounds": {
+                       "left": 0,
+                       "top": 423,
+                       "right": 1080,
+                       "bottom": 2347
+                      },
+                      "children": [
+                       {
+                        "class": "android.widget.ImageView",
+                        "isClickable": true,
+                        "isEnabled": true,
+                        "bounds": {
+                         "left": 0,
+                         "top": 2300,
+                         "right": 46,
+                         "bottom": 2347
+                        }
+                       },
+                       {
+                        "class": "android.view.SurfaceView",
+                        "isEnabled": true,
+                        "bounds": {
+                         "left": 0,
+                         "top": 423,
+                         "right": 1080,
+                         "bottom": 2347
+                        }
+                       }
+                      ]
+                     }
+                    ]
+                   },
+                   {
+                    "id": "com.doordash.driverapp:id/coordinatorLayout",
+                    "class": "android.view.ViewGroup",
+                    "isEnabled": true,
+                    "bounds": {
+                     "left": 0,
+                     "top": 423,
+                     "right": 1080,
+                     "bottom": 2347
+                    },
+                    "children": [
+                     {
+                      "id": "com.doordash.driverapp:id/container",
+                      "class": "android.view.ViewGroup",
+                      "isEnabled": true,
+                      "bounds": {
+                       "left": 0,
+                       "top": 423,
+                       "right": 1080,
+                       "bottom": 2347
+                      },
+                      "children": [
+                       {
+                        "id": "com.doordash.driverapp:id/scalebarLayout",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                         "left": 0,
+                         "top": 423,
+                         "right": 0,
+                         "bottom": 423
+                        }
+                       },
+                       {
+                        "id": "com.doordash.driverapp:id/guidanceLayout",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                         "left": 0,
+                         "top": 423,
+                         "right": 1080,
+                         "bottom": 423
+                        }
+                       },
+                       {
+                        "id": "com.doordash.driverapp:id/speedLimitLayout",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                         "left": 18,
+                         "top": 441,
+                         "right": 185,
+                         "bottom": 624
+                        },
+                        "children": [
+                         {
+                          "id": "com.doordash.driverapp:id/speedInfoView",
+                          "class": "android.widget.FrameLayout",
+                          "isClickable": true,
+                          "isEnabled": true,
+                          "bounds": {
+                           "left": 18,
+                           "top": 441,
+                           "right": 168,
+                           "bottom": 624
+                          },
+                          "children": [
+                           {
+                            "id": "com.doordash.driverapp:id/speedInfoMutcdLayout",
+                            "class": "android.view.ViewGroup",
+                            "isEnabled": true,
+                            "bounds": {
+                             "left": 18,
+                             "top": 441,
+                             "right": 168,
+                             "bottom": 624
+                            },
+                            "children": [
+                             {
+                              "id": "com.doordash.driverapp:id/postedSpeedLayoutMutcd",
+                              "class": "android.view.ViewGroup",
+                              "isEnabled": true,
+                              "bounds": {
+                               "left": 22,
+                               "top": 445,
+                               "right": 164,
+                               "bottom": 620
+                              },
+                              "children": [
+                               {
+                                "text": "30",
+                                "id": "com.doordash.driverapp:id/postedSpeedMutcd",
+                                "class": "android.widget.TextView",
+                                "isEnabled": true,
+                                "bounds": {
+                                 "left": 22,
+                                 "top": 467,
+                                 "right": 164,
+                                 "bottom": 551
+                                }
+                               },
+                               {
+                                "text": "mph",
+                                "id": "com.doordash.driverapp:id/postedSpeedUnit",
+                                "class": "android.widget.TextView",
+                                "isEnabled": true,
+                                "bounds": {
+                                 "left": 22,
+                                 "top": 551,
+                                 "right": 164,
+                                 "bottom": 598
+                                }
+                               }
+                              ]
+                             }
+                            ]
+                           }
+                          ]
+                         }
+                        ]
+                       },
+                       {
+                        "id": "com.doordash.driverapp:id/actionListLayout",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                         "left": 893,
+                         "top": 434,
+                         "right": 1062,
+                         "bottom": 692
+                        },
+                        "children": [
+                         {
+                          "id": "com.doordash.driverapp:id/buttonContainer",
+                          "class": "android.widget.LinearLayout",
+                          "isEnabled": true,
+                          "bounds": {
+                           "left": 947,
+                           "top": 434,
+                           "right": 1062,
+                           "bottom": 692
+                          },
+                          "children": [
+                           {
+                            "id": "com.doordash.driverapp:id/buttonsContainerTop",
+                            "class": "android.widget.LinearLayout",
+                            "isEnabled": true,
+                            "bounds": {
+                             "left": 1062,
+                             "top": 434,
+                             "right": 1062,
+                             "bottom": 434
+                            }
+                           },
+                           {
+                            "id": "com.doordash.driverapp:id/buttonsContainerCenter",
+                            "class": "android.widget.LinearLayout",
+                            "isEnabled": true,
+                            "bounds": {
+                             "left": 947,
+                             "top": 434,
+                             "right": 1062,
+                             "bottom": 563
+                            },
+                            "children": [
+                             {
+                              "id": "com.doordash.driverapp:id/buttonsContainerCompass",
+                              "class": "android.widget.FrameLayout",
+                              "isEnabled": true,
+                              "bounds": {
+                               "left": 947,
+                               "top": 434,
+                               "right": 947,
+                               "bottom": 434
+                              }
+                             },
+                             {
+                              "id": "com.doordash.driverapp:id/buttonsContainerCamera",
+                              "class": "android.widget.FrameLayout",
+                              "isEnabled": true,
+                              "bounds": {
+                               "left": 947,
+                               "top": 434,
+                               "right": 1062,
+                               "bottom": 563
+                              },
+                              "children": [
+                               {
+                                "class": "android.widget.FrameLayout",
+                                "isClickable": true,
+                                "isEnabled": true,
+                                "bounds": {
+                                 "left": 947,
+                                 "top": 441,
+                                 "right": 1062,
+                                 "bottom": 556
+                                },
+                                "children": [
+                                 {
+                                  "id": "com.doordash.driverapp:id/container",
+                                  "class": "android.view.ViewGroup",
+                                  "isEnabled": true,
+                                  "bounds": {
+                                   "left": 947,
+                                   "top": 441,
+                                   "right": 1062,
+                                   "bottom": 556
+                                  },
+                                  "children": [
+                                   {
+                                    "id": "com.doordash.driverapp:id/iconImage",
+                                    "class": "android.widget.ImageView",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                     "left": 969,
+                                     "top": 463,
+                                     "right": 1040,
+                                     "bottom": 534
+                                    }
+                                   },
+                                   {
+                                    "id": "com.doordash.driverapp:id/buttonText",
+                                    "class": "android.widget.TextView",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                     "left": 1042,
+                                     "top": 477,
+                                     "right": 1060,
+                                     "bottom": 521
+                                    }
+                                   }
+                                  ]
+                                 }
+                                ]
+                               }
+                              ]
+                             },
+                             {
+                              "id": "com.doordash.driverapp:id/buttonsContainerRecenter",
+                              "class": "android.widget.FrameLayout",
+                              "isEnabled": true,
+                              "bounds": {
+                               "left": 947,
+                               "top": 563,
+                               "right": 947,
+                               "bottom": 563
+                              }
+                             },
+                             {
+                              "id": "com.doordash.driverapp:id/buttonsContainerAudio",
+                              "class": "android.widget.FrameLayout",
+                              "isEnabled": true,
+                              "bounds": {
+                               "left": 947,
+                               "top": 563,
+                               "right": 947,
+                               "bottom": 563
+                              }
+                             }
+                            ]
+                           },
+                           {
+                            "id": "com.doordash.driverapp:id/buttonsContainerBottom",
+                            "class": "android.widget.LinearLayout",
+                            "isEnabled": true,
+                            "bounds": {
+                             "left": 947,
+                             "top": 563,
+                             "right": 1062,
+                             "bottom": 692
+                            },
+                            "children": [
+                             {
+                              "class": "android.widget.FrameLayout",
+                              "isClickable": true,
+                              "isEnabled": true,
+                              "bounds": {
+                               "left": 947,
+                               "top": 570,
+                               "right": 1062,
+                               "bottom": 685
+                              },
+                              "children": [
+                               {
+                                "id": "com.doordash.driverapp:id/container",
+                                "class": "android.view.ViewGroup",
+                                "isEnabled": true,
+                                "bounds": {
+                                 "left": 947,
+                                 "top": 570,
+                                 "right": 1062,
+                                 "bottom": 685
+                                },
+                                "children": [
+                                 {
+                                  "id": "com.doordash.driverapp:id/iconImage",
+                                  "class": "android.widget.ImageView",
+                                  "isEnabled": true,
+                                  "bounds": {
+                                   "left": 969,
+                                   "top": 592,
+                                   "right": 1040,
+                                   "bottom": 663
+                                  }
+                                 },
+                                 {
+                                  "id": "com.doordash.driverapp:id/buttonText",
+                                  "class": "android.widget.TextView",
+                                  "isEnabled": true,
+                                  "bounds": {
+                                   "left": 1042,
+                                   "top": 606,
+                                   "right": 1060,
+                                   "bottom": 650
+                                  }
+                                 }
+                                ]
+                               }
+                              ]
+                             }
+                            ]
+                           }
+                          ]
+                         }
+                        ]
+                       },
+                       {
+                        "id": "com.doordash.driverapp:id/emptyLeftContainer",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                         "left": 18,
+                         "top": 1309,
+                         "right": 18,
+                         "bottom": 1309
+                        }
+                       },
+                       {
+                        "id": "com.doordash.driverapp:id/emptyRightContainer",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                         "left": 1062,
+                         "top": 1334,
+                         "right": 1062,
+                         "bottom": 1334
+                        }
+                       },
+                       {
+                        "id": "com.doordash.driverapp:id/roadNameLayout",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                         "left": 394,
+                         "top": 1976,
+                         "right": 686,
+                         "bottom": 2083
+                        },
+                        "children": [
+                         {
+                          "text": "[redacted]",
+                          "id": "com.doordash.driverapp:id/roadNameView",
+                          "class": "android.widget.TextView",
+                          "isEnabled": true,
+                          "bounds": {
+                           "left": 394,
+                           "top": 1976,
+                           "right": 686,
+                           "bottom": 2083
+                          }
+                         }
+                        ]
+                       }
+                      ]
+                     },
+                     {
+                      "id": "com.doordash.driverapp:id/infoPanelLayout",
+                      "class": "android.widget.FrameLayout",
+                      "isEnabled": true,
+                      "bounds": {
+                       "left": 0,
+                       "top": 2116,
+                       "right": 1080,
+                       "bottom": 2347
+                      }
+                     }
+                    ]
+                   }
+                  ]
+                 }
+                ]
+               }
+              ]
+             }
+            ]
+           }
+          ]
+         }
+        ]
+       }
+      ]
+     }
+    ]
+   }
+  ]
+ }
+}


### PR DESCRIPTION
## Summary

Closes #700. Extends `TwoPickupStackReplayTest` to drive the 07-05 two-pickup stack (Bill Miller BBQ + Mama Margies) all the way to a clean **job close**, restoring the two `DELIVERY_COMPLETED` completions the on-device machine emitted (db `app_events` seq 28/29) — the assertion the captured-only fixture could not reach.

### What changed

**Fixture** (`snapshots/sessions/two_pickup_stack_2026_07_05/`):
- `12_dropoff_complete_billmiller.json` — Bill Miller "Complete delivery" screen (`dropoff_photo` `5e1208`, 15:59:06).
- `13_nav_arriving_mamamargies.json` — Mama Margies `nav_arriving` overlay (`223802`, 16:07:13).

Both are real device envelopes copied verbatim from the source captures (already edge-redacted, #598). The existing 11 frames are untouched.

**Test** (`TwoPickupStackReplayTest`):
- New `runToClose()` helper + three #700 assertions: exactly **2** `DELIVERY_COMPLETED` with **distinct taskIds**; **both** accept-minted dropoff placeholder ids consumed (`activeDropIds.size == 2`); both **(customerHash, store)** pairs intact in the closed job's task lineage (Bill Miller BBQ / Mama Margies).
- The existing per-frame tests (F1/F2/F3, placeholder resolution, #630 pin, PII-safe) are unchanged in intent; stale comments corrected (the drops' parsed join hashes are `8df9fd`/`96b81d`; the file redaction markers are `4ee5`/`d290`).

**`OdometerPredicateEquivalenceTest`**: the two new screen frames shift the `two_pickup_stack` odometer-divergence pin from screen-step 9 → 11 (same shape — no new divergence introduced).

### Assertion delta vs the recipe (judgment note #5)

The issue's recipe expected the close to be reachable from the captured frames + `graceCommit` injections alone. Investigation showed it is **not**, for three concrete reasons, so the close is driven with a small, explicitly-labelled reconstruction of the device frames the capture layer **suppressed** (proven to have occurred by the db, seq 24–27):

1. **The 8-minute drive gap (15:59:06 → 16:07:13) has zero captures** — the navigation frames that drove db seq 24 `DELIVERY_CONFIRMED` + seq 25 `DELIVERY_NAV_STARTED` (Bill Miller's retire, 15:59:07) were identity/content deduped. The recipe's cited `dropoff_navigation 15:59:07` genuinely does not exist on disk (confirmed — nearest are 15:16 and 16:56).
2. **Mama Margies' arrival fell to `UNKNOWN`** ("Leave it at the door", no completion CTA the rules key on) — it drove db seq 26 `DELIVERY_ARRIVED` (16:07:34) but is not a recognized envelope.
3. **No captured frame parses a `customerAddressHash`**, so the #565 address-keyed stacked-dropoff split cannot fire either — which is exactly why #700 targets the `TASK_RETIRE` grace + customer-less placeholder-resolution path.

So `runToClose()` folds the **real** captured frames + the **real** accept click PLUS: two synthetic `idle` "drive-away" observations (labelled `doordash.screen.navigation_generic`, the production rule that matches these suppressed mid-dash nav frames — its online branch really is flow `idle` + modeHint `online`), one synthetic `dropoff_photo`-arrived observation carrying **frame 11's own real parsed Mama Margies fields** (the suppressed arrival), and two `GRACE_COMMIT` timers. This is a hand-authored correct-behaviour invariant (never `replay == db`): driven the way the device really was, the job closes via the **strict #596/#615 arm** of `isJobPhysicallyComplete` — both placeholders resolved + finished + arrived, so the final retire's T1 closes the job and the #596 close-out sweep mints exactly two distinct completions. The **#749 per-customer coverage arm is deliberately NOT exercised** by this replay (it short-circuits away when the strict arm succeeds — mutation-verified in review: severing it leaves all 10 tests green; its own tests own that arm). The class KDoc documents every injection and its db provenance.

The `#630` receipt-total pin remains vacuous on this job (receipt-less shop drops carry no `dropRealizedPay`) — noted in-line.

## Security / privacy posture

Test-only change; recognition/pipeline/effects code untouched. Both new fixture frames are a **Pledge surface** (customer PII):
- The device captures arrive **already edge-redacted** (#598) — `[redacted:xxxx]` masks for customer name/address; frame 10 is byte-identical to its source, confirming no additional redaction was normally needed.
- **Manual scan** of every field of both new frames: frame 12 carries only `[redacted:ff92]` / `[redacted:5fec]` + benign UI strings; frame 13 carried an **un-redacted `roadNameView` street label ("Gallery Ridge ")** — a customer-address residual the edge redact missed (the nav_arriving rule only masks `arriving_at_title`). I masked it to `[redacted]` (fail-closed plain form, per #623). Recognition is unaffected — `nav_arriving` keys on id-suffixes, not that text.
- Post-redaction scan confirms: zero non-redacted/non-benign text, "Gallery" fully removed, no street-number/phone digit runs. The fixture's `PII-safe` test (sensitive-marker scan + customer-prefix redaction check) passes over all 13 frames.
- **Documented residual:** the fixture PII-safe scanner is structurally blind to prefix-less street labels like the `roadNameView` text masked above (it keys on sensitive markers + known customer prefixes, and a bare road name carries neither) — the manual per-field scan was the real control for that class, and remains the required step when adding session frames.
- Store names (Bill Miller BBQ, Mama Margies) are kept — merchant names are driver-owned, not customer PII.

No network, no new logging, no persisted PII.

### Design-goal review

- **UDF (1):** test-only; drives the real pure `StateMachine` through `SessionReplay.reduceMixed`; no reducer/edge changes.
- **SSOT (5):** the synthetic Mama Margies arrival reuses **frame 11's own production recognition** rather than hand-typing a hash; store/customer join values are read from state, not hardcoded (only the two store display names are literal, matching the existing tests).
- **Security & privacy (6):** stated above — the load-bearing change is the `roadNameView` redaction + the manual scan; captures stay hashed-at-edge.
- **Platform-agnostic core (8):** no platform literals added to any `:core:*`/`:domain` code; the test lives in `:app` and refers to `Platform.DoorDash` only as fixture selection (same as the sibling replay tests). No rule JSON changed.

Not touched: MAD, single-responsibility, Kotlin practices, logging, Reactive UI.

### Testing
`./gradlew :app:testDebugUnitTest` — fully green (808 tests). `ParseOutputGoldenTest` unaffected (`sessions/` is not golden corpus).
