### PR TITLE
chore(#122): lower minSdk 35 → 30 — broaden device support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,9 @@ epics.)
 ./gradlew :core:database:build
 ```
 
-Dependencies are managed via the version catalog at `gradle/libs.versions.toml`. Min SDK is 35,
-target SDK is 36, Kotlin 2.3.20, JVM 21.
+Dependencies are managed via the version catalog at `gradle/libs.versions.toml`. Min SDK is 30
+(guarded: `bubblePreference` API 31 falls back to `areBubblesAllowed` below 31), target SDK is 36,
+Kotlin 2.3.20, JVM 21.
 
 ## Module Structure
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         applicationId = "cloud.trotter.dashbuddy"
-        minSdk = 35
+        minSdk = 30
         targetSdk = 36
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         versionCode = 1

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/permissions/PermissionBottomSheet.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/permissions/PermissionBottomSheet.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.ui.main.setup.permissions
 
 import android.Manifest
 import android.content.Intent
+import android.os.Build
 import android.provider.Settings
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -153,7 +154,18 @@ fun PermissionsBottomSheet(
                         }
 
                         is PermissionType.PostNotifications -> {
-                            notifLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                notifLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                            } else {
+                                // POST_NOTIFICATIONS doesn't exist pre-33 — the runtime
+                                // request insta-denies with no dialog. Deep-link the app's
+                                // notification settings instead (ON_RESUME re-checks state).
+                                val intent =
+                                    Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                                        putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                                    }
+                                context.startActivity(intent)
+                            }
                         }
 
                         is PermissionType.Bubbles -> {

--- a/app/src/main/java/cloud/trotter/dashbuddy/util/PermissionUtils.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/util/PermissionUtils.kt
@@ -6,6 +6,7 @@ import android.app.NotificationManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import android.view.accessibility.AccessibilityManager
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
@@ -71,6 +72,12 @@ object PermissionUtils {
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-        return notificationManager.bubblePreference == NotificationManager.BUBBLE_PREFERENCE_ALL
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            notificationManager.bubblePreference == NotificationManager.BUBBLE_PREFERENCE_ALL
+        } else {
+            // bubblePreference is API 31+; on API 30 fall back to the closest
+            // semantic equivalent — "are bubbles allowed for this app".
+            notificationManager.areBubblesAllowed()
+        }
     }
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 35
+        minSdk = 30
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 35
+        minSdk = 30
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 35
+        minSdk = 30
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -10,7 +10,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 35
+        minSdk = 30
 
         consumerProguardFiles("consumer-rules.pro")
     }

--- a/core/location/build.gradle.kts
+++ b/core/location/build.gradle.kts
@@ -11,7 +11,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 35
+        minSdk = 30
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -20,7 +20,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 35
+        minSdk = 30
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/core/pipeline/build.gradle.kts
+++ b/core/pipeline/build.gradle.kts
@@ -19,7 +19,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 35
+        minSdk = 30
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/core/state/build.gradle.kts
+++ b/core/state/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 35
+        minSdk = 30
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")


### PR DESCRIPTION
Closes #122.

## What changed

- **minSdk 35 → 30** in all 9 module `build.gradle.kts` files (`:app`, `:core:data`, `:core:database`, `:core:datastore`, `:core:designsystem`, `:core:location`, `:core:network`, `:core:pipeline`, `:core:state`).
- **Runtime guard 1** — `PermissionUtils.hasFullBubblePreference()`: `NotificationManager.bubblePreference` is API 31+, so on `SDK_INT >= S` the existing `bubblePreference == BUBBLE_PREFERENCE_ALL` check is kept, and below 31 it falls back to `areBubblesAllowed()` (API 29+, the closest semantic equivalent — "are bubbles allowed for this app"). A real `Build.VERSION.SDK_INT` guard, not a `@RequiresApi` suppression.
- **Runtime guard 2 (review finding, LOW)** — `PermissionBottomSheet.kt` PostNotifications card: pre-33, `POST_NOTIFICATIONS` doesn't exist, so `notifLauncher.launch(...)` insta-denied with no dialog and the card could never clear (a dead-end on API 30–32 when the user had blocked notifications). Now, below `TIRAMISU` the grant button deep-links `Settings.ACTION_APP_NOTIFICATION_SETTINGS` (with `EXTRA_APP_PACKAGE`) — the same pattern the file already uses for the bubble card — and the existing `ON_RESUME` re-check clears the card. The 33+ runtime-request path is unchanged.
- **CLAUDE.md** Build Commands minSdk line updated in the same PR (context-update rule).

## Investigation correction

The prior #122 investigation's claim that `AccessibilityService.takeScreenshot` (API 30) was the **only** API floor above 30 was **incomplete**: the lint gate surfaced a second site — `NotificationManager.getBubblePreference` (API 31) in `PermissionUtils.kt`. It is guarded in this PR as described above. No other NewApi sites exist.

## Verification receipts

- `./gradlew :app:assembleDebug` — **BUILD SUCCESSFUL**
- `./gradlew testDebugUnitTest :domain:test` — **BUILD SUCCESSFUL** (all modules)
- `./gradlew :app:lintDebug` — **NewApi = 0 graph-wide** (was 1 before the guard); the previously-flagged `InlinedApi` warning at the PostNotifications launch site is also gone after the pre-33 guard. Lint's only errors are 437 pre-existing `MissingTranslation` (es) — untouched by this diff. Note lint is not a CI gate in `pr-check.yml`.

## Scope notes

- **minSdk has no SSOT** — it is duplicated across 9 module build files. Flagged per principle 5 (SSOT); restructuring build logic (e.g. a convention plugin or version-catalog value) is deliberately **out of scope** for this PR — all 9 sites were changed consistently.
- **Below API 30 remains out of scope** (`AccessibilityService.takeScreenshot` is the API 30 floor).

### Design-goal review

- **P2 (MAD):** No structural change to the MAD setup; the flip stays in the standard per-module `android {}` blocks, and both guards use the canonical `Build.VERSION.SDK_INT` pattern.
- **P4 (Kotlin/Android best practices):** Runtime SDK guards with semantically equivalent fallbacks (`areBubblesAllowed()`; settings deep-link matching the file's existing bubble-card pattern), not `@RequiresApi`/`@TargetApi` suppressions; idiomatic `if`-expression return.
- **P5 (SSOT):** Explicit, recorded violation — minSdk is declared 9× with no single owner. Pre-existing, changed consistently at every site, and restructuring build logic is out of scope here (flagged above rather than silently absorbed).

### Adversarial review

Fable review: **APPROVE** with one LOW (the pre-33 PostNotifications dead-end, fixed in-PR as guard 2 above) and a PR-body precision fix (lint claim now states NewApi = 0 graph-wide rather than "lint passes"; lint is not a CI gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
