### PR TITLE
feat(#765): dasher-friendly store cards + detail bottom sheet

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.ui.main.analytics
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,13 +13,25 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -242,10 +255,21 @@ private fun positiveRamp(fraction: Float, c: AppColors): Color =
 
 // ── Store report cards ──────────────────────────────────────────────────
 
-/** The per-store report cards, newest-visited first (the repository already orders by last-seen). */
+/**
+ * The per-store report cards, newest-visited first (the repository already orders by last-seen).
+ *
+ * #765: the card **face** is deliberately glanceable — store name + location chip and just the three
+ * decision-driving numbers (net, usual wait, deliveries) in plain language (no "median"/"p95"
+ * statistical vocabulary). Tapping a card opens [StoreDetailSheet] with the full detail (pickups,
+ * gross, the dwell distribution with its precise stat terms, first/last seen). Selection is a
+ * local [rememberSaveable] `selectedStoreKey` (UDF — state down, the tap event up); the sheet body
+ * re-derives from the same [cards] list, so a projector re-emit keeps it fresh with no extra state.
+ */
 @Composable
 private fun StoresCard(cards: List<StoreReportCard>) {
     val c = AppTheme.colors
+    var selectedStoreKey by rememberSaveable { mutableStateOf<String?>(null) }
+
     AppCard(modifier = Modifier.fillMaxWidth()) {
         Text(text = stringResource(R.string.patterns_tab_stores_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(4.dp))
@@ -268,18 +292,35 @@ private fun StoresCard(cards: List<StoreReportCard>) {
         } else {
             cards.forEachIndexed { index, card ->
                 if (index > 0) Spacer(Modifier.height(14.dp))
-                StoreRow(card)
+                StoreRow(card, onClick = { selectedStoreKey = card.storeKey })
             }
+        }
+    }
+
+    // The selected store is looked up from the live list by key, so the sheet re-derives on re-emit
+    // (and silently closes if the store vanishes from a refold). Dismiss = swipe/scrim (M3 default).
+    selectedStoreKey?.let { key ->
+        cards.firstOrNull { it.storeKey == key }?.let { card ->
+            StoreDetailSheet(card = card, onDismiss = { selectedStoreKey = null })
         }
     }
 }
 
-/** One store: chain name + location discriminator, address, counts + gross/net, dwell, first/last seen. */
+/**
+ * The glanceable card **face** (#765): store name + location chip, a tap-affordance chevron, and the
+ * three decision-driving numbers in plain language — net, "usual wait", deliveries. Everything else
+ * (pickups, gross, the dwell distribution, first/last seen) lives in [StoreDetailSheet] behind a tap.
+ * "Usual wait" is the median dwell rendered without the statistical label.
+ */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun StoreRow(card: StoreReportCard) {
+private fun StoreRow(card: StoreReportCard, onClick: () -> Unit) {
     val c = AppTheme.colors
-    Column(Modifier.fillMaxWidth()) {
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+    ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
                 text = card.chainDisplay,
@@ -287,83 +328,182 @@ private fun StoreRow(card: StoreReportCard) {
                 color = c.text,
                 modifier = Modifier.weight(1f),
             )
-            if (card.locationKnown && card.runningKey != null) {
-                // #773: an address-derived key (`@12125`) is a provenance marker, not a label — show the
-                // street line of the store address instead of the raw `@number`. (#765 redesigns this card.)
-                val runningKey = card.runningKey!!
-                val chipText = if (runningKey.startsWith("@")) {
-                    card.address?.substringBefore(",")?.trim()?.takeIf { it.isNotEmpty() } ?: runningKey
-                } else {
-                    runningKey
-                }
-                AppChip(text = chipText, uppercase = false)
-            } else {
-                AppChip(
-                    text = stringResource(R.string.patterns_tab_location_unknown),
-                    color = c.warn,
-                    container = c.warnBg,
-                    uppercase = false,
-                )
-            }
-        }
-        card.address?.let {
-            Spacer(Modifier.height(2.dp))
-            Text(text = it, style = MaterialTheme.typography.bodySmall, color = c.text3)
+            StoreLocationChip(card)
+            Spacer(Modifier.width(4.dp))
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = stringResource(R.string.patterns_tab_store_details_cd, card.chainDisplay),
+                tint = c.text3,
+                modifier = Modifier.size(20.dp),
+            )
         }
 
         Spacer(Modifier.height(8.dp))
-        FlowRow(horizontalArrangement = Arrangement.spacedBy(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            StoreStat(stringResource(R.string.patterns_tab_store_pickups_label), Formats.commaInt(card.pickups))
-            StoreStat(stringResource(R.string.patterns_tab_store_deliveries_label), Formats.commaInt(card.deliveries))
-            StoreStat(stringResource(R.string.patterns_tab_store_gross_label), Formats.money(card.gross))
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(24.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             StoreStat(
                 stringResource(R.string.patterns_tab_store_net_label),
                 Formats.money(card.net),
                 valueColor = if (card.net >= 0.0) c.good else c.bad,
             )
-        }
-
-        Spacer(Modifier.height(6.dp))
-        val dwellText = card.avgDwellMillis?.let { avg ->
-            val base = stringResource(
-                R.string.patterns_tab_store_dwell_format,
-                formatDuration(avg.toLong()),
+            StoreStat(
+                stringResource(R.string.patterns_tab_store_usual_wait_label),
                 card.p50DwellMillis?.let { formatDuration(it) } ?: EMPTY_VALUE,
-                card.p95DwellMillis?.let { formatDuration(it) } ?: EMPTY_VALUE,
             )
-            // A chain-only ("location unknown") card blends multiple physical stores (F6) — mark dwell partial.
-            if (card.locationKnown) base else base + stringResource(R.string.patterns_tab_store_dwell_partial_suffix)
-        } ?: stringResource(R.string.patterns_tab_store_dwell_none)
-        Text(text = dwellText, style = MaterialTheme.typography.bodySmall, color = c.text3)
+            StoreStat(stringResource(R.string.patterns_tab_store_deliveries_label), Formats.commaInt(card.deliveries))
+        }
+    }
+}
 
-        Spacer(Modifier.height(2.dp))
-        Text(
-            text = stringResource(
-                R.string.patterns_tab_store_seen_format,
-                formatShortDate(card.firstSeenAt),
-                formatShortDate(card.lastSeenAt),
-            ),
-            style = MaterialTheme.typography.bodySmall,
-            color = c.text3,
-        )
+/**
+ * The full-detail bottom sheet (#765) for one store: totals grid (pickups/deliveries/gross/net), the
+ * dwell distribution where precision is welcome — labeled dasher-first with the stat term secondary
+ * ("Usual wait (median)", "Longest waits (p95)") — and the visited-range line. Dismiss = swipe/scrim
+ * (M3 [ModalBottomSheet] default). Pure data in, one `onDismiss` lambda out (UDF).
+ */
+@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
+@Composable
+private fun StoreDetailSheet(card: StoreReportCard, onDismiss: () -> Unit) {
+    val c = AppTheme.colors
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 24.dp)
+                .navigationBarsPadding(),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = card.chainDisplay,
+                    style = MaterialTheme.typography.titleLarge,
+                    color = c.text,
+                    modifier = Modifier.weight(1f),
+                )
+                StoreLocationChip(card)
+            }
+            card.address?.let {
+                Text(text = it, style = MaterialTheme.typography.bodyMedium, color = c.text3)
+            }
 
-        // F6: for a chain-only entity, state that per-location stats are partial by construction.
-        if (!card.locationKnown) {
-            Spacer(Modifier.height(2.dp))
+            HorizontalDivider(color = c.line)
+
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(28.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                StoreStat(stringResource(R.string.patterns_tab_store_pickups_label), Formats.commaInt(card.pickups))
+                StoreStat(stringResource(R.string.patterns_tab_store_deliveries_label), Formats.commaInt(card.deliveries))
+                StoreStat(stringResource(R.string.patterns_tab_store_gross_label), Formats.money(card.gross))
+                StoreStat(
+                    stringResource(R.string.patterns_tab_store_net_label),
+                    Formats.money(card.net),
+                    valueColor = if (card.net >= 0.0) c.good else c.bad,
+                )
+            }
+
+            HorizontalDivider(color = c.line)
+
             Text(
-                text = stringResource(R.string.patterns_tab_stats_partial, card.chainDisplay),
-                style = MaterialTheme.typography.labelSmall,
-                color = c.warn,
+                text = stringResource(R.string.patterns_tab_store_detail_wait_title),
+                style = MaterialTheme.typography.labelMedium,
+                color = c.text3,
+            )
+            if (card.avgDwellMillis == null) {
+                Text(
+                    text = stringResource(R.string.patterns_tab_store_dwell_none),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = c.text3,
+                )
+            } else {
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    DetailStatRow(
+                        stringResource(R.string.patterns_tab_store_detail_median),
+                        card.p50DwellMillis?.let { formatDuration(it) },
+                    )
+                    DetailStatRow(
+                        stringResource(R.string.patterns_tab_store_detail_p95),
+                        card.p95DwellMillis?.let { formatDuration(it) },
+                    )
+                    DetailStatRow(
+                        stringResource(R.string.patterns_tab_store_detail_avg),
+                        formatDuration(card.avgDwellMillis!!.toLong()),
+                    )
+                }
+                // F6: a chain-only ("location unknown") entity blends multiple physical stores.
+                if (!card.locationKnown) {
+                    Text(
+                        text = stringResource(R.string.patterns_tab_stats_partial, card.chainDisplay),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = c.warn,
+                    )
+                }
+            }
+
+            HorizontalDivider(color = c.line)
+
+            Text(
+                text = stringResource(
+                    R.string.patterns_tab_store_seen_format,
+                    formatShortDate(card.firstSeenAt),
+                    formatShortDate(card.lastSeenAt),
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = c.text3,
             )
         }
     }
 }
 
-/** A compact label-over-value stat cell for the store row (not a bordered [AppStatTile] — inline). */
+/** The store location chip: the #773 street line for an address-derived key, else the running key,
+ *  else a "location unknown" warn chip. Shared by the card face and the detail sheet. */
+@Composable
+private fun StoreLocationChip(card: StoreReportCard) {
+    val c = AppTheme.colors
+    val runningKey = card.runningKey
+    if (card.locationKnown && runningKey != null) {
+        // #773: an address-derived key (`@12125`) is a provenance marker, not a label — show the
+        // street line of the store address instead of the raw `@number`.
+        val chipText = if (runningKey.startsWith("@")) {
+            card.address?.substringBefore(",")?.trim()?.takeIf { it.isNotEmpty() } ?: runningKey
+        } else {
+            runningKey
+        }
+        AppChip(text = chipText, uppercase = false)
+    } else {
+        AppChip(
+            text = stringResource(R.string.patterns_tab_location_unknown),
+            color = c.warn,
+            container = c.warnBg,
+            uppercase = false,
+        )
+    }
+}
+
+/** A compact label-over-value stat cell for the store card face + sheet grid (inline, not a bordered [AppStatTile]). */
 @Composable
 private fun StoreStat(label: String, value: String, valueColor: Color = AppTheme.colors.text) {
     Column {
         Text(text = label.uppercase(), style = AppTheme.num.chip, color = AppTheme.colors.text3)
         Text(text = value, style = AppTheme.num.smNum, color = valueColor, textAlign = TextAlign.Start)
+    }
+}
+
+/** A label ↔ value row for the detail sheet's dwell distribution (dasher-friendly label left, stat right). */
+@Composable
+private fun DetailStatRow(label: String, value: String?) {
+    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = AppTheme.colors.text2,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = value ?: EMPTY_VALUE,
+            style = AppTheme.num.smNum,
+            color = AppTheme.colors.text,
+        )
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -38,6 +39,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.R
@@ -263,12 +265,22 @@ private fun positiveRamp(fraction: Float, c: AppColors): Color =
  * statistical vocabulary). Tapping a card opens [StoreDetailSheet] with the full detail (pickups,
  * gross, the dwell distribution with its precise stat terms, first/last seen). Selection is a
  * local [rememberSaveable] `selectedStoreKey` (UDF — state down, the tap event up); the sheet body
- * re-derives from the same [cards] list, so a projector re-emit keeps it fresh with no extra state.
+ * re-derives from the same [cards] list, so a projector re-emit keeps it fresh with no extra state
+ * (a selection whose store leaves the list is explicitly cleared).
  */
 @Composable
 private fun StoresCard(cards: List<StoreReportCard>) {
     val c = AppTheme.colors
     var selectedStoreKey by rememberSaveable { mutableStateOf<String?>(null) }
+
+    // If the selected store leaves the list (e.g. a projector refold re-keys it), clear the
+    // selection explicitly — otherwise the stale key would linger in rememberSaveable and could
+    // silently re-open the sheet if that key ever reappeared.
+    LaunchedEffect(cards, selectedStoreKey) {
+        if (selectedStoreKey != null && cards.none { it.storeKey == selectedStoreKey }) {
+            selectedStoreKey = null
+        }
+    }
 
     AppCard(modifier = Modifier.fillMaxWidth()) {
         Text(text = stringResource(R.string.patterns_tab_stores_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
@@ -297,8 +309,8 @@ private fun StoresCard(cards: List<StoreReportCard>) {
         }
     }
 
-    // The selected store is looked up from the live list by key, so the sheet re-derives on re-emit
-    // (and silently closes if the store vanishes from a refold). Dismiss = swipe/scrim (M3 default).
+    // The selected store is looked up from the live list by key, so the sheet re-derives on re-emit;
+    // a vanished store is explicitly cleared by the LaunchedEffect above. Dismiss = swipe/scrim (M3 default).
     selectedStoreKey?.let { key ->
         cards.firstOrNull { it.storeKey == key }?.let { card ->
             StoreDetailSheet(card = card, onDismiss = { selectedStoreKey = null })
@@ -316,10 +328,12 @@ private fun StoresCard(cards: List<StoreReportCard>) {
 @Composable
 private fun StoreRow(card: StoreReportCard, onClick: () -> Unit) {
     val c = AppTheme.colors
+    // The row itself is the explicit button (role + onClickLabel); the chevron is decorative.
+    val detailsLabel = stringResource(R.string.patterns_tab_store_details_cd, card.chainDisplay)
     Column(
         Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick),
+            .clickable(onClickLabel = detailsLabel, role = Role.Button, onClick = onClick),
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
@@ -332,7 +346,7 @@ private fun StoreRow(card: StoreReportCard, onClick: () -> Unit) {
             Spacer(Modifier.width(4.dp))
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = stringResource(R.string.patterns_tab_store_details_cd, card.chainDisplay),
+                contentDescription = null,
                 tint = c.text3,
                 modifier = Modifier.size(20.dp),
             )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -387,10 +387,16 @@
     <string name="patterns_tab_store_deliveries_label">Deliveries</string>
     <string name="patterns_tab_store_gross_label">Gross</string>
     <string name="patterns_tab_store_net_label">Net</string>
-    <string name="patterns_tab_store_dwell_format">dwell avg %1$s · median %2$s · p95 %3$s</string>
-    <string name="patterns_tab_store_dwell_partial_suffix"> (partial)</string>
+    <!-- #765: card face shows "usual wait" (the median dwell, no stat vocabulary). -->
+    <string name="patterns_tab_store_usual_wait_label">Usual wait</string>
+    <string name="patterns_tab_store_details_cd">Details for %1$s</string>
     <string name="patterns_tab_store_dwell_none">no pickup dwell recorded yet</string>
     <string name="patterns_tab_store_seen_format">first %1$s · last %2$s</string>
+    <!-- #765: detail bottom sheet — dasher-friendly wait labels, stat term kept secondary. -->
+    <string name="patterns_tab_store_detail_wait_title">Wait times</string>
+    <string name="patterns_tab_store_detail_median">Usual wait (median)</string>
+    <string name="patterns_tab_store_detail_p95">Longest waits (p95)</string>
+    <string name="patterns_tab_store_detail_avg">Average wait</string>
 
     <!-- setup/wizard/WizardScreen.kt -->
     <string name="wizard_screen_goal_option1_title">Cherry Picker</string>

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,16 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — Patterns tab store cards: glanceable face + detail bottom sheet (#765 / PR TBD).**
+  The store report cards were redesigned: the card **face** now shows only store name + location chip
+  and three plain-language numbers (Net / Usual wait / Deliveries) — no "median"/"p95" vocabulary —
+  with a `>` chevron affordance. Tapping a card opens a **bottom sheet** with the full detail (pickups,
+  gross, the dwell distribution labeled "Usual wait (median)" / "Longest waits (p95)" / "Average wait",
+  and first/last-seen). **What to watch:** open Analytics → Patterns; the store cards read at a glance
+  (2–3 numbers, no stats jargon on the face); tapping a card opens the sheet with the fuller breakdown;
+  swipe/scrim dismisses it; "usual wait" on the face matches the median in the sheet; a location-unknown
+  (chain-only) card still shows its "partial" note inside the sheet.
+  - Confirmed: 0/2
 - **🆕 NEW — Recognition hot-path pack: pre-map package skip must not drop real frames (#435 / PR #791).**
   ContentChanged/StateChanged now read the active window's package FIRST and skip the full tree
   mapping when it isn't a watched platform (bubble overlay, launcher). The skip must only ever fire

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,7 +78,7 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
-- **🆕 NEW — Patterns tab store cards: glanceable face + detail bottom sheet (#765 / PR TBD).**
+- **🆕 NEW — Patterns tab store cards: glanceable face + detail bottom sheet (#765 / PR #799).**
   The store report cards were redesigned: the card **face** now shows only store name + location chip
   and three plain-language numbers (Net / Usual wait / Deliveries) — no "median"/"p95" vocabulary —
   with a `>` chevron affordance. Tapping a card opens a **bottom sheet** with the full detail (pickups,


### PR DESCRIPTION
Closes #765.

Field feedback (2026-07-12) on the shipped #315 H5 Patterns tab: the store report cards were too word-dense and the "median"/"p95" statistical vocabulary didn't land with the audience. Dev decision (2026-07-18): minimal glanceable card face **plus** a tap-into bottom-sheet flyout that keeps the full detail (precision allowed there).

## What changed

Only `PatternsTab.kt` (store-cards section), `strings.xml`, and the field-test checklist. **No data-layer / domain / read-model changes** — same `StoreReportCard` inputs.

### Card face — before → after

**Before** (one dense card per store):
- Chain name + location chip
- Full address line
- `Pickups` · `Deliveries` · `Gross` · `Net`
- `dwell avg 5m · median 4m · p95 12m (partial)`
- `first Jan 3 · last Jul 12`
- partial-stats warning line (chain-only)

**After** (glanceable face):
- Chain name + location chip + `>` chevron (tap affordance)
- Three plain-language numbers only:
  - **NET** — money, colored good/bad
  - **USUAL WAIT** — the median dwell, rendered with no stat label (`—` when none)
  - **DELIVERIES** — count

No "median"/"p95"/percentile words anywhere on the face. Sort/grouping unchanged (repository still orders newest-visited first).

### Detail bottom sheet (new)

Tapping a card opens a Material 3 `ModalBottomSheet` for that store with everything removed from the face:
- Header: store name + location chip; full address line
- Totals grid: `Pickups` · `Deliveries` · `Gross` · `Net`
- **Wait times** section, dasher-first labels with the stat term kept secondary:
  - `Usual wait (median)`
  - `Longest waits (p95)`
  - `Average wait`
  - chain-only "partial stats" note (F6) lives here now
- Visited range: `first … · last …`
- Dismiss = swipe / scrim (M3 default)

## Copy decisions (exact card-face lines)

| Face slot | String | Value |
|---|---|---|
| stat 1 | `Net` (existing) | `Formats.money(net)`, colored |
| stat 2 | `Usual wait` (new `patterns_tab_store_usual_wait_label`) | `formatDuration(p50)` or `—` |
| stat 3 | `Deliveries` (existing) | `commaInt(deliveries)` |

Dropped from the face into the sheet: pickups, gross, avg/p95 dwell, first/last-seen, the full address line, the partial-stats warning. New sheet strings: `patterns_tab_store_detail_wait_title` = "Wait times", `_median` = "Usual wait (median)", `_p95` = "Longest waits (p95)", `_avg` = "Average wait", `_details_cd` = "Details for %1$s" (chevron content description). Removed the now-unused `patterns_tab_store_dwell_format` / `_dwell_partial_suffix`. The em-dash reuses the existing analytics `EMPTY_VALUE` constant (SSOT) rather than a new string.

Strings note (#428): the Patterns tab already uses hardcoded English `strings.xml` entries (no resource-migration abstraction yet), so the new strings follow that same convention — they'll ride the eventual #428 migration with the rest of the file.

## Screenshots

N/A — no emulator available in this environment. Layout described in words above; the card face is a single clickable `Column` (name-row + one `FlowRow` of three inline `StoreStat` cells), the sheet is a `ModalBottomSheet` with a `Column` of divider-separated sections.

## Tests

`./gradlew testDebugUnitTest :domain:test` — BUILD SUCCESSFUL. `:app:compileDebugKotlin` clean. No render/UI test exists for the card composables (the analytics tab's tests are Robolectric string-resource / ViewModel tests, not `composeTestRule`), and this is a UI-copy + layout change over unchanged data, so no cheap test pattern applies to extend — the #773 street-chip logic is a pure move into the shared `StoreLocationChip`, behavior identical.

## Security / privacy

No new surface. Store/merchant names + addresses are merchant data (already rendered here); no customer PII reaches this composable (sha256'd upstream). No network, no logging, no capture.

### Design-goal review

- **1 (UDF / Reactive UI):** State down (`storeCards` list), events up (card tap → `onClick` lambda → local `rememberSaveable selectedStoreKey`); no repository writes. The sheet is looked up from the live list by key each recomposition, so a projector re-emit re-derives it (a selection whose store leaves the list is explicitly cleared by a `LaunchedEffect`, so no stale key lingers). No ticker added — these are historical aggregates that can't go stale while viewed (Reactive UI rule: nothing time-derived here).
- **3 (Clean code / SRR):** File stays focused; extracted the shared `StoreLocationChip` and `DetailStatRow` helpers; the face composable is small and the sheet is a separate small composable. `PatternsTab.kt` well under the ~900-line concern.
- **4 (Kotlin/Android):** Idiomatic Compose (`rememberSaveable`, `ModalBottomSheet`, `rememberModalBottomSheetState`), immutable data in, lambdas out.
- **5 (SSOT):** Reused the existing `EMPTY_VALUE` em-dash rather than minting a duplicate; the #773 chip logic now has one owner shared by face + sheet instead of two copies.
- Principles 2/6/7/8 untouched (no MAD structural change, no security/logging/platform-coupling surface).

### Adversarial review

Fable-tier adversarial pass (correctness / principles / copy): APPROVE. Verified independently: the diff is genuinely UI-only, the removed dwell strings have zero remaining references, the face carries no statistical vocabulary while the sheet leads with dasher-first labels (matching the dev's 2026-07-18 decision), and EMPTY_VALUE/Formats/formatDuration SSOT reuse holds with honest '—' rendering for absent dwell. One LOW applied in-PR: the stale selectedStoreKey is now explicitly cleared when the store leaves the list (was un-render-without-clear). Merge simulation against post-#798 master is conflict-free; compileDebugKotlin + full unit tests + :domain:test green.

