### PR TITLE
fix(#794): block DasherDirect 'Transfer out' variant — sensitive rule + marker backstop + SENSITIVE fixtures

### DIFF
--- a/app/src/test/resources/snapshots/SENSITIVE/2026-07-17_21-29-18__doordash__dasher_direct_transfer_out__1ecab2.json
+++ b/app/src/test/resources/snapshots/SENSITIVE/2026-07-17_21-29-18__doordash__dasher_direct_transfer_out__1ecab2.json
@@ -1,0 +1,360 @@
+{
+    "captureId": "02719f26-48c8-4c13-a47d-4486678678e4",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784341758423,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 1594
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 1594
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 1594
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 1594
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Navigate up",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 144,
+                                                                            "right": 125,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 1080,
+                                                                            "top": 144,
+                                                                            "right": 1080,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/dxdr_nav_host_fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 278,
+                                                            "right": 1080,
+                                                            "bottom": 1594
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/dxdr_nav_host_fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 278,
+                                                                    "right": 1080,
+                                                                    "bottom": 1594
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 278,
+                                                                            "right": 1080,
+                                                                            "bottom": 1594
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 278,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1594
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 278,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1594
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 278,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1594
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 278,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 1594
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 314,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 488
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Transfer out",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 314,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 380
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "[redacted] available",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 389,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 436
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 572,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 1594
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "$0",
+                                                                                                                        "class": "android.widget.EditText",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 661,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 829
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 661,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 829
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 1415,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 1558
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 1451,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1558
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Continue",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 444,
+                                                                                                                                    "top": 1479,
+                                                                                                                                    "right": 635,
+                                                                                                                                    "bottom": 1531
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1451,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1558
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/snackbar_anchor",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 1594,
+                                                            "right": 1080,
+                                                            "bottom": 1594
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/SENSITIVE/2026-07-17_21-29-25__doordash__dasher_direct_transfer_out__aebcfc.json
+++ b/app/src/test/resources/snapshots/SENSITIVE/2026-07-17_21-29-25__doordash__dasher_direct_transfer_out__aebcfc.json
@@ -1,0 +1,386 @@
+{
+    "captureId": "0c3d70f8-3a8a-461d-8cc4-231bc33b5165",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784341765074,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/loading_layout",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "desc": "Loading",
+                                                                "id": "com.doordash.driverapp:id/loading_indicator",
+                                                                "class": "android.widget.ImageView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 505,
+                                                                    "top": 1206,
+                                                                    "right": 576,
+                                                                    "bottom": 1277
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Navigate up",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 144,
+                                                                            "right": 125,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 1080,
+                                                                            "top": 144,
+                                                                            "right": 1080,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/dxdr_nav_host_fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 278,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/dxdr_nav_host_fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 278,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 278,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 278,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 278,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 278,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 278,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 314,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 488
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Transfer out",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 314,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 380
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "[redacted] available",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 389,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 436
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 572,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2347
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "[redacted]",
+                                                                                                                        "class": "android.widget.EditText",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 661,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 829
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 661,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 829
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 2168,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 2311
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 2204,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 2311
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Continue",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 444,
+                                                                                                                                    "top": 2232,
+                                                                                                                                    "right": 635,
+                                                                                                                                    "bottom": 2284
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 2204,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 2311
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/snackbar_anchor",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2347,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
@@ -55,6 +55,14 @@ object SensitiveTextMarkers {
         // sensitive.savings branch, these markers are the fail-closed backstop.
         "Savings jar",
         "You transferred",
+        // DasherDirect "Transfer out" balance screen (#794) — leaked the plaintext
+        // balance to two UNKNOWN captures on the 2026-07-17 dash (copy "Transfer out"
+        // / "$X.XX available" is missed by "Transfer to bank" and "Available Balance").
+        // The rule-side block is the sensitive.transfer_out branch; this marker is the
+        // fail-closed backstop and the shareable-log scrub anchor. "Transfer out" appears
+        // on no recognized customer-facing surface in the corpus (verified per the #738
+        // uniqueness discipline), so it cannot over-block a delivery screen.
+        "Transfer out",
         // Alcohol-delivery DOCUMENT-capture surfaces only (#463): the license-scan
         // camera (an image of a government ID) and the signature pad/handoff.
         // The ID-CHECK instruction screen and the alcohol arrival card are NOT

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,18 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — DasherDirect "Transfer out" balance screen now blocked as sensitive (#794, Pledge surface).**
+  The DasherDirect "Transfer out" amount-entry screen (heading "Transfer out" over "$X.XX available")
+  evaded BOTH defense layers on the 2026-07-17 dash and leaked the plaintext balance to two UNKNOWN
+  debug captures. Now covered on two layers: a `sensitive.transfer_out` rule branch (priority-0 block)
+  AND a "Transfer out" `SensitiveTextMarkers` backstop keyword.
+  **What to watch:** navigating the DasherDirect Transfer-out flow no longer produces UNKNOWN captures
+  carrying any balance/"Transfer out"/"available" text. **Desk-side:** grep the pull's UNKNOWN capture
+  tree for "Transfer out" — must be ZERO hits after this build (it was 53 window + 24 click hits on the
+  07-17 pull); and `sensitiveDropped` in `PipelineStats` should increment on those DasherDirect windows
+  rather than `unknownCaptured`.
+  - Confirmed: 0/2 (#794)
+
 - **🆕 NEW — Recognition hot-path pack: pre-map package skip must not drop real frames (#435 / PR #791).**
   ContentChanged/StateChanged now read the active window's package FIRST and skip the full tree
   mapping when it isn't a watched platform (bubble overlay, launcher). The skip must only ever fire

--- a/matchers/rules/doordash/sensitive.json5
+++ b/matchers/rules/doordash/sensitive.json5
@@ -82,6 +82,32 @@
           }
         },
         {
+          // DasherDirect "Transfer out" balance/amount-entry screen (#794): heading
+          // "Transfer out" over a "$<balance> available" line, an amount EditText, and a
+          // "Continue" button — the dasher's own bank balance. A one-variant coverage gap
+          // that leaked the plaintext balance to two UNKNOWN debug captures on 2026-07-17
+          // (the copy is "Transfer out"/"$X.XX available", which the "Transfer to bank" rule
+          // and "Available Balance" marker both miss). Anchored on the "Transfer out" heading
+          // AND a co-present "available" balance line (the same AND shape as sensitive.withdraw
+          // /sensitive.savings) — "Transfer out" appears on no recognized customer-facing
+          // surface in the corpus, so the pair cannot catch offer/pickup/dropoff/chat screens.
+          "intent": "sensitive.transfer_out",
+          "require": {
+            "all": [
+              {
+                "exists": {
+                  "hasText": "Transfer out"
+                }
+              },
+              {
+                "exists": {
+                  "hasTextContaining": "available"
+                }
+              }
+            ]
+          }
+        },
+        {
           "intent": "sensitive.savings",
           "require": {
             "any": [


### PR DESCRIPTION
Closes #794.

The DasherDirect **"Transfer out"** balance/amount-entry screen (texts `["Transfer out", "$6.93 available", "$6.93", "Continue"]`) evaded **both** defense layers on the 2026-07-17 dash and wrote the plaintext balance to two UNKNOWN debug capture envelopes — a Pledge violation (the dasher's own banking screens must never be parsed or stored). This was a one-variant coverage gap: ~44 sibling DasherDirect frames in the same window WERE blocked (`sensitiveDropped` 27→56), so the fix is a targeted addition, not a systemic repair.

**Why both layers missed:** the sensitive rules carry "Transfer to bank" (not "Transfer out"); the balance renders as "$X.XX available" which the "Available Balance" marker never substring-matches.

## Both layers (defense-in-depth)

1. **Sensitive rule** (`matchers/rules/doordash/sensitive.json5`) — new `sensitive.transfer_out` branch in `doordash.screen.sensitive.known` (priority-0 partition, `overrideable: false`). Anchored on `hasText: "Transfer out"` **AND** `hasTextContaining: "available"` (the balance line) — the same AND shape as the existing `sensitive.withdraw` / `sensitive.savings` branches.
2. **Marker backstop** (`SensitiveTextMarkers.KEYWORDS`) — added `"Transfer out"`. This is the rules-independent fail-closed backstop (UNKNOWN-capture scan when a ruleset misses a variant) and the `shareable.log` scrub anchor.
3. **SENSITIVE fixtures** — the two real envelopes, redacted (balance masked to `[redacted]`), added to `snapshots/SENSITIVE/`. The `AllMatchersSuite` golden guard now proves both are caught by a sensitive rule.

## Anchor corpus-uniqueness proof (the #738 lesson)

Grepped `"Transfer out"` (case-insensitive) across the entire committed snapshot corpus and the full pulled captures tree:

- **Committed snapshot corpus** (`app/src/test/resources/snapshots/`): **zero** occurrences in any recognized/category folder; zero in INBOX. (One unrelated pre-existing SENSITIVE banking snapshot is the only prior hit — consistent with it being a dasher-banking surface.)
- **Full device pull** (`~/dashbuddy/logs`): every screen-envelope hit is under `accessibility.window/UNKNOWN` (53) or `accessibility.click/UNKNOWN` (24) — **zero** hits in any recognized customer-facing category (offer / pickup / dropoff / chat / nav). The only non-UNKNOWN hits are click-event JSONL logs (the dasher tapping the Transfer-out button — banking, not a screen) and one 2026-04-10 SENSITIVE banking snapshot.

So `"Transfer out"` — and *a fortiori* the `"Transfer out"` + `"available"` AND-pair — cannot catch a customer-facing or recognized delivery surface. The AND-pair is strictly narrower than the marker.

## Marker false-positive analysis

`"Transfer out"` is added as a `SensitiveTextMarkers` keyword, which is consumed by: (a) the UNKNOWN-capture drop scan, (b) the `SnapshotSecurityScanner` toxicity guard, and (c) the `LogScrubber` shareable-log sink. Over-block on the dasher-banking side is the safe direction (a banking screen dropped is correct; a delivery screen dropped is a recognition regression). The corpus proof above shows `"Transfer out"` appears on no recognized customer/delivery surface, so it cannot scrub a legitimate recognized frame. The full `:core:pipeline` + `:app` + `:domain` suites (which include `CustomerTextMarkersTest`, `CaptureBackstopCorpusTest`, and the recognition golden guard) stay green. I deliberately did **not** add a bare `"available"` / `" available"` marker — that substring is common enough to risk scrubbing legitimate frames, and it is unnecessary since `"Transfer out"` uniquely identifies the screen.

## Coverage-test / ledger changes

None required. `SensitiveMarkerAssetCoverageTest`: the new `sensitive.transfer_out` branch is an `AllOf("Transfer out", "available")` → COVERED (the `"Transfer out"` leaf now fires `findMarker`), so no new `KNOWN_GAPS` entry. `"Transfer out"` overlaps none of the existing `KNOWN_GAPS` anchors (`"transfer was initiated"`, `"Transfer in"`, etc.), so no entry became stale — the ledger is unchanged (still shrink-only).

## Test results

- `./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` — **BUILD SUCCESSFUL** (golden guard now catches both new SENSITIVE fixtures).
- `./gradlew testDebugUnitTest :domain:test` — **BUILD SUCCESSFUL** (full suite).
- `ParseOutputGoldenTest` — unaffected, no regen (sensitive screens produce no parse output, as expected).
- Committed fixtures verified free of plaintext balance: `git diff --cached | grep 6.93` → empty; only `"$0"` (the empty input field, literally zero, non-PII) remains.

## Security / privacy posture

This is Pledge-surface work. **Trusted:** nothing new — recognition input remains untrusted third-party UI. **Blocked (never parsed/stored):** the DasherDirect Transfer-out screen now classifies `sensitive` at priority-0 (`overrideable: false`), so it is dropped before any parse/capture, exactly like the sibling banking screens. **Scrubbed:** the rules-independent `SensitiveTextMarkers` backstop drops any UNKNOWN capture (and scrubs any shareable-log line) carrying `"Transfer out"`, so even if the rule fails to load the balance never reaches disk. No raw balance PII is stored anywhere; the committed fixtures mask the balance to `[redacted]`. No parse output is produced (a sensitive screen yields none), so no PII enters the read-model or event log. The unredacted device originals are left in place per task instructions (coordinator purges post-merge).

### Design-goal review

- **Principle 6 (Security & privacy first) — MANDATORY.** Directly upholds the Pledge: the dasher's banking screen is blocked at the matcher layer (priority-0, `overrideable: false`), never parsed or stored, with a rules-independent fail-closed backstop behind it. The recognition change *raises* the block side and stores no new PII (fixtures are redacted). Two independent layers so a ruleset load failure cannot re-open the leak. Corpus-uniqueness proof establishes the anchors cannot downgrade recognition of any customer-facing surface.
- **Principle 8 (Platform-agnostic core).** Recognition stays data: the new block is a rule branch in `matchers/rules/doordash/`, not code. No platform literal added to `:core:*`/`:domain` logic. The `SensitiveTextMarkers` addition is a cross-platform data list (a string in a `KEYWORDS` `listOf`), matching the existing DoorDash/Uber entries — no `== Platform.X` branching.
- **Principle 5 (SSOT).** `SensitiveTextMarkers.KEYWORDS` remains the single backstop marker list shared by production and `SnapshotSecurityScanner`; the sensitive rule remains the single rule-layer definition. No duplicated matcher.
- **Principle 3 (single responsibility).** Additive only — one rule branch, one marker string, two fixtures, one checklist item. No file grew structurally.

### Adversarial review

Pending — mandatory fable-tier `/code-review` + `/security-review` (Pledge surface) before merge, per CLAUDE.md. Not merging.
