### PR TITLE
feat(#422): capability consent surface — per-source grant chips with Play-consistent disclosure copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,7 +484,7 @@ Every new feature or refactor holds to these — they are forefront design input
      capability key (#417): rule loads enumerate capabilities and reconcile them into the
      grant store *before* rules go live; bundled (asset) sources auto-grant, remote sources
      never will. A dasher-pressed Accept/Decline is its own consent (integrity checks still
-     apply). The consent surface (#422 PR 3) — Settings → Data &amp; Privacy → **Automation &amp;
+     apply). The consent surface (#422 PR 3) — Settings → Data & Privacy → **Automation &
      Consent** — lists each enumerated capability per ruleset source with Play-consistent
      disclosure copy and a grant/revoke switch (`CapabilityConsentScreen`/`ViewModel`, writing
      through `RuleCapabilityGrants.setGranted`); it is a consent *record*, never a second gate —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,7 +484,12 @@ Every new feature or refactor holds to these — they are forefront design input
      capability key (#417): rule loads enumerate capabilities and reconcile them into the
      grant store *before* rules go live; bundled (asset) sources auto-grant, remote sources
      never will. A dasher-pressed Accept/Decline is its own consent (integrity checks still
-     apply). Consent UI = #422 PR 3.
+     apply). The consent surface (#422 PR 3) — Settings → Data &amp; Privacy → **Automation &amp;
+     Consent** — lists each enumerated capability per ruleset source with Play-consistent
+     disclosure copy and a grant/revoke switch (`CapabilityConsentScreen`/`ViewModel`, writing
+     through `RuleCapabilityGrants.setGranted`); it is a consent *record*, never a second gate —
+     enforcement stays at the `PerformRuleAction` seam, and a revoke persists an explicit denial
+     so the next asset load can't silently re-grant it (fail-closed).
    When a change touches recognition, capture, network, or effects, state its security/privacy
    posture in the PR — what's trusted, what's gated, what's scrubbed.
 7. **Semantic, PII-safe logging.** Log levels carry *meaning*, not volume convenience, and the log is

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
@@ -39,6 +39,7 @@ import timber.log.Timber
 import cloud.trotter.dashbuddy.ui.main.ratings.RatingsScreen
 import cloud.trotter.dashbuddy.ui.main.settings.AboutScreen
 import cloud.trotter.dashbuddy.ui.main.settings.EconomySettingsScreen
+import cloud.trotter.dashbuddy.ui.main.settings.CapabilityConsentScreen
 import cloud.trotter.dashbuddy.ui.main.settings.DataExportScreen
 import cloud.trotter.dashbuddy.ui.main.settings.EvidenceSettingsScreen
 import cloud.trotter.dashbuddy.ui.main.settings.GeneralSettingsScreen
@@ -182,6 +183,13 @@ class MainActivity : ComponentActivity() {
                         // 3a. Export Data (CSV, #319)
                         composable(Screen.DataExport.route) {
                             DataExportScreen(
+                                onBack = { navController.popBackStack() }
+                            )
+                        }
+
+                        // 3c. Automation & Consent (capability grants, #422)
+                        composable(Screen.ConsentSettings.route) {
+                            CapabilityConsentScreen(
                                 onBack = { navController.popBackStack() }
                             )
                         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
@@ -31,6 +31,7 @@ sealed class Screen(val route: String) {
     data object StrategySettings : Screen("settings/strategy")
     data object EvidenceSettings : Screen("settings/evidence")
     data object DataExport : Screen("settings/data-export")
+    data object ConsentSettings : Screen("settings/consent")
     data object EconomySettings : Screen("settings/economy")
     data object GeneralSettings : Screen("settings/general")
     data object DeveloperSettings : Screen("settings/developer")
@@ -47,6 +48,7 @@ sealed class Screen(val route: String) {
         val allRoutes: Set<String> by lazy { setOf(
             Dashboard.route, Analytics.route, SettingsHome.route, AboutSettings.route,
             StrategySettings.route, EvidenceSettings.route, DataExport.route,
+            ConsentSettings.route,
             EconomySettings.route, GeneralSettings.route, DeveloperSettings.route,
             PlatformSettings.route,
         ) }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/CapabilityConsentScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/CapabilityConsentScreen.kt
@@ -1,0 +1,203 @@
+package cloud.trotter.dashbuddy.ui.main.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.state.Platform
+
+/**
+ * Capability-consent surface (#422 PR 3): a Google-Play-consistent
+ * prominent-disclosure header plus, per ruleset source, one row per automation
+ * tap the rules enable — each with honest disclosure copy and a grant/revoke
+ * switch. The switch writes THROUGH [CapabilityConsentViewModel.setGranted] into
+ * the same grant store the fail-closed engine gate (#417) reads at fire time;
+ * revoking a capability makes the next automation tap abort to manual.
+ *
+ * All copy is app-owned string resources keyed off the [RuleAction] vocabulary,
+ * never rule-supplied text (see `docs/design/rule-capability-consent.md`).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CapabilityConsentScreen(
+    onBack: () -> Unit,
+    viewModel: CapabilityConsentViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.consent_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_content_desc_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Spacer(Modifier.height(8.dp))
+            DisclosureHeader()
+
+            if (uiState.sources.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.consent_empty),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(24.dp),
+                )
+            } else {
+                uiState.sources.forEach { group ->
+                    Spacer(Modifier.height(16.dp))
+                    ConsentSourceSection(
+                        group = group,
+                        onSetGranted = viewModel::setGranted,
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(32.dp))
+        }
+    }
+}
+
+/** The prominent, Play-consistent disclosure of the Accessibility usage overall. */
+@Composable
+private fun DisclosureHeader() {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        tonalElevation = 2.dp,
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.consent_disclosure_heading),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.consent_disclosure_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConsentSourceSection(
+    group: ConsentSourceGroup,
+    onSetGranted: (key: String, granted: Boolean) -> Unit,
+) {
+    val platformName = group.platform
+        .takeIf { it != Platform.Unknown }
+        ?.displayName
+        ?: stringResource(R.string.consent_platform_unknown)
+
+    val header = if (group.isBundled) {
+        stringResource(R.string.consent_source_bundled_format, platformName)
+    } else {
+        stringResource(R.string.consent_source_downloaded_format, platformName)
+    }
+    val note = if (group.isBundled) {
+        stringResource(R.string.consent_source_bundled_note)
+    } else {
+        stringResource(R.string.consent_source_downloaded_note)
+    }
+
+    Column(Modifier.fillMaxWidth()) {
+        Text(
+            text = header,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 4.dp),
+        )
+        Text(
+            text = note,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 24.dp).padding(bottom = 8.dp),
+        )
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            shape = MaterialTheme.shapes.medium,
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            tonalElevation = 2.dp,
+        ) {
+            Column {
+                group.capabilities.forEach { cap ->
+                    val copy = capabilityCopy(cap.action, platformName)
+                    SwitchRow(
+                        label = copy.title,
+                        subtitle = copy.description,
+                        checked = cap.granted,
+                        onCheckedChange = { onSetGranted(cap.key, it) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** App-owned disclosure copy for one action, in the platform app's name. */
+private data class CapabilityCopy(val title: String, val description: String)
+
+@Composable
+private fun capabilityCopy(action: RuleAction, platformName: String): CapabilityCopy = when (action) {
+    RuleAction.ACCEPT_OFFER -> CapabilityCopy(
+        stringResource(R.string.consent_cap_accept_title),
+        stringResource(R.string.consent_cap_accept_desc, platformName),
+    )
+    RuleAction.DECLINE_OFFER -> CapabilityCopy(
+        stringResource(R.string.consent_cap_decline_title),
+        stringResource(R.string.consent_cap_decline_desc, platformName),
+    )
+    RuleAction.CONFIRM_DECLINE -> CapabilityCopy(
+        stringResource(R.string.consent_cap_confirm_decline_title),
+        stringResource(R.string.consent_cap_confirm_decline_desc, platformName),
+    )
+    RuleAction.EXPAND_EARNINGS -> CapabilityCopy(
+        stringResource(R.string.consent_cap_expand_title),
+        stringResource(R.string.consent_cap_expand_desc, platformName),
+    )
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/CapabilityConsentViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/CapabilityConsentViewModel.kt
@@ -1,0 +1,110 @@
+package cloud.trotter.dashbuddy.ui.main.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.capability.RuleCapability
+import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
+import cloud.trotter.dashbuddy.domain.state.Platform
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Drives the capability-consent surface (#422 PR 3): the per-source list of the
+ * automation taps a loaded ruleset enables, each with its grant state and a
+ * grant/revoke control. State flows down as [ConsentUiState] (UDF); the only
+ * write is [setGranted], which routes THROUGH [RuleCapabilityGrants] — the same
+ * grant store the fail-closed engine gate (#417) reads at fire time. This screen
+ * is a consent *record*, never a second enforcement point (SSOT: enforcement
+ * stays at the `PerformRuleAction` seam in `SideEffectEngine`).
+ *
+ * The ViewModel holds no Android resources — human disclosure copy is resolved
+ * from the app-owned [RuleAction] vocabulary in the composable (never from
+ * rule-supplied text; see `docs/design/rule-capability-consent.md`).
+ */
+@HiltViewModel
+class CapabilityConsentViewModel @Inject constructor(
+    private val grants: RuleCapabilityGrants,
+) : ViewModel() {
+
+    val uiState: StateFlow<ConsentUiState> =
+        combine(grants.capabilities, grants.grantedKeys) { capabilities, grantedKeys ->
+            buildConsentUiState(capabilities, grantedKeys)
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = ConsentUiState(),
+        )
+
+    /** Grant or revoke one capability. Revoking is fail-closed (persists a denial). */
+    fun setGranted(key: String, granted: Boolean) {
+        viewModelScope.launch { grants.setGranted(key, granted) }
+    }
+}
+
+/** Immutable per-screen state (UDF). Empty [sources] ⇒ the empty-state copy. */
+data class ConsentUiState(
+    val sources: List<ConsentSourceGroup> = emptyList(),
+)
+
+/** One ruleset source (a bundled asset file, or a future downloaded source). */
+data class ConsentSourceGroup(
+    val source: String,
+    /** The platform whose rules this source carries — display only. */
+    val platform: Platform,
+    /**
+     * True for a bundled (asset) source — auto-granted by default (#417). False
+     * for a downloaded (CDN/fork) source, which is never auto-granted: its
+     * capabilities render pending until the user turns each on here.
+     */
+    val isBundled: Boolean,
+    val capabilities: List<ConsentCapabilityRow>,
+)
+
+/** One (rule, action) capability the user may grant or revoke. */
+data class ConsentCapabilityRow(
+    /** The grant key the store keys on — the write target for [CapabilityConsentViewModel.setGranted]. */
+    val key: String,
+    /** The app-owned action; the composable maps it to disclosure copy. */
+    val action: RuleAction,
+    val granted: Boolean,
+)
+
+/**
+ * Pure UiState assembly (testable without Android): group the enumerated
+ * capabilities by source, resolve each source's platform + bundled flag, and
+ * join each capability's grant state from [grantedKeys]. Deterministic ordering:
+ * bundled sources first, then by source string; within a source by action then
+ * rule id, so the list never reshuffles between recompositions.
+ */
+fun buildConsentUiState(
+    capabilities: List<RuleCapability>,
+    grantedKeys: Set<String>,
+): ConsentUiState {
+    val groups = capabilities
+        .groupBy { it.source }
+        .map { (source, caps) ->
+            val isBundled = source.startsWith(RuleCapabilityGrants.ASSET_SOURCE_PREFIX)
+            ConsentSourceGroup(
+                source = source,
+                platform = Platform.fromRuleId(caps.firstOrNull()?.ruleId),
+                isBundled = isBundled,
+                capabilities = caps
+                    .sortedWith(compareBy({ it.action.ordinal }, { it.ruleId }))
+                    .map { cap ->
+                        ConsentCapabilityRow(
+                            key = cap.key,
+                            action = cap.action,
+                            granted = cap.key in grantedKeys,
+                        )
+                    },
+            )
+        }
+        .sortedWith(compareByDescending<ConsentSourceGroup> { it.isBundled }.thenBy { it.source })
+    return ConsentUiState(sources = groups)
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.RocketLaunch
+import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Icon
@@ -133,6 +134,12 @@ fun SettingsHomeScreen(
                     title = stringResource(R.string.settings_home_item_export_title),
                     subtitle = stringResource(R.string.settings_home_item_export_subtitle),
                     onClick = { onNavigate(Screen.DataExport.route) }
+                )
+                SettingsNavItem(
+                    icon = Icons.Default.Security,
+                    title = stringResource(R.string.settings_home_item_consent_title),
+                    subtitle = stringResource(R.string.settings_home_item_consent_subtitle),
+                    onClick = { onNavigate(Screen.ConsentSettings.route) }
                 )
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -239,7 +239,7 @@
     <!-- settings/CapabilityConsentScreen.kt (#422) — Google-Play-consistent automation disclosure -->
     <string name="consent_title">Automation &amp; Consent</string>
     <string name="consent_disclosure_heading">How DashBuddy uses the Accessibility service</string>
-    <string name="consent_disclosure_body">DashBuddy uses Android\'s Accessibility service to read the screens of the delivery apps you turn on, so it can recognize offers, pickups, and deliveries. This recognition runs entirely on your phone.\n\nDashBuddy can also tap buttons in a delivery app for you — but only the specific actions you allow below, only inside that delivery app, only on a button whose label matches the action, and only when you ask for it (you press the button) or when you have armed automation. Nothing here acts on its own until you turn it on, and turning an action off means DashBuddy will not tap it — you do it manually.</string>
+    <string name="consent_disclosure_body">DashBuddy uses Android\'s Accessibility service to read the screens of the delivery apps you turn on, so it can recognize offers, pickups, and deliveries. This recognition runs entirely on your phone.\n\nDashBuddy can also tap buttons in a delivery app for you — but only the specific actions you allow below, only inside that delivery app, and only on a button whose label matches the action — except the icon-only pay-details arrow, which is verified by app boundary only. Accept and Decline taps fire when you press the button in DashBuddy or when you have armed that automation. Actions bundled with DashBuddy start on — the pay-details tap runs whenever a completed delivery\'s pay breakdown is collapsed. Turn any action off below and DashBuddy will not tap it — you do it manually.</string>
     <string name="consent_empty">No automation actions are available yet. They appear here once your delivery-app rules load and a rule enables an action such as Accept or Decline.</string>
     <string name="consent_platform_unknown">Delivery app</string>
     <string name="consent_source_bundled_format">%1$s · bundled with DashBuddy</string>
@@ -253,7 +253,7 @@
     <string name="consent_cap_confirm_decline_title">Confirm a decline</string>
     <string name="consent_cap_confirm_decline_desc">Lets DashBuddy tap the second \"Decline\" button on %1$s\'s confirmation dialog, so a decline you started finishes in one step. It only fires when you have turned on quick declines, and only inside the %1$s app.</string>
     <string name="consent_cap_expand_title">Open the pay breakdown</string>
-    <string name="consent_cap_expand_desc">Lets DashBuddy tap the arrow that expands the pay details on a completed %1$s delivery, so it can read the payout for your records. A read-only tap inside the %1$s app — it changes nothing.</string>
+    <string name="consent_cap_expand_desc">Lets DashBuddy tap the arrow that expands the pay details on a completed %1$s delivery, so it can read the payout for your records. It only opens the pay details — it doesn\'t change your delivery, your pay, or any setting.</string>
 
     <!-- settings/components/FakeOfferCard.kt -->
     <string name="fake_offer_score_format" translatable="false">"%1$s  ·  %2$dpts"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -236,6 +236,25 @@
     <string name="data_export_log_success_format">Exported dashbuddy-log.txt — %1$d line(s) were auto-scrubbed.</string>
     <string name="data_export_log_error_format">Log export failed: %1$s</string>
 
+    <!-- settings/CapabilityConsentScreen.kt (#422) — Google-Play-consistent automation disclosure -->
+    <string name="consent_title">Automation &amp; Consent</string>
+    <string name="consent_disclosure_heading">How DashBuddy uses the Accessibility service</string>
+    <string name="consent_disclosure_body">DashBuddy uses Android\'s Accessibility service to read the screens of the delivery apps you turn on, so it can recognize offers, pickups, and deliveries. This recognition runs entirely on your phone.\n\nDashBuddy can also tap buttons in a delivery app for you — but only the specific actions you allow below, only inside that delivery app, only on a button whose label matches the action, and only when you ask for it (you press the button) or when you have armed automation. Nothing here acts on its own until you turn it on, and turning an action off means DashBuddy will not tap it — you do it manually.</string>
+    <string name="consent_empty">No automation actions are available yet. They appear here once your delivery-app rules load and a rule enables an action such as Accept or Decline.</string>
+    <string name="consent_platform_unknown">Delivery app</string>
+    <string name="consent_source_bundled_format">%1$s · bundled with DashBuddy</string>
+    <string name="consent_source_bundled_note">These automation rules ship inside the app and are on by default. Turn any off to require a manual tap instead.</string>
+    <string name="consent_source_downloaded_format">%1$s · downloaded rules</string>
+    <string name="consent_source_downloaded_note">Downloaded rules are never turned on automatically. Each action stays off until you turn it on here.</string>
+    <string name="consent_cap_accept_title">Accept offers</string>
+    <string name="consent_cap_accept_desc">Lets DashBuddy tap the Accept button in the %1$s app for you — when you press Accept in DashBuddy, or when you have armed auto-accept. It only taps a button labeled \"Accept\" inside the %1$s app, and never without your go-ahead.</string>
+    <string name="consent_cap_decline_title">Decline offers</string>
+    <string name="consent_cap_decline_desc">Lets DashBuddy tap the Decline button in the %1$s app for you — when you press Decline in DashBuddy, or when you have armed auto-decline. It only taps a button labeled \"Decline\" inside the %1$s app, and never without your go-ahead.</string>
+    <string name="consent_cap_confirm_decline_title">Confirm a decline</string>
+    <string name="consent_cap_confirm_decline_desc">Lets DashBuddy tap the second \"Decline\" button on %1$s\'s confirmation dialog, so a decline you started finishes in one step. It only fires when you have turned on quick declines, and only inside the %1$s app.</string>
+    <string name="consent_cap_expand_title">Open the pay breakdown</string>
+    <string name="consent_cap_expand_desc">Lets DashBuddy tap the arrow that expands the pay details on a completed %1$s delivery, so it can read the payout for your records. A read-only tap inside the %1$s app — it changes nothing.</string>
+
     <!-- settings/components/FakeOfferCard.kt -->
     <string name="fake_offer_score_format" translatable="false">"%1$s  ·  %2$dpts"</string>
     <string name="fake_offer_pay_line_format" translatable="false">"%1$s gross  →  %2$s net"</string>
@@ -320,6 +339,8 @@
     <string name="settings_home_item_evidence_subtitle">Manage screenshots and logs</string>
     <string name="settings_home_item_export_title">Export Data (CSV)</string>
     <string name="settings_home_item_export_subtitle">Mileage &amp; earnings for a spreadsheet or tax prep</string>
+    <string name="settings_home_item_consent_title">Automation &amp; Consent</string>
+    <string name="settings_home_item_consent_subtitle">Control which taps DashBuddy may perform for you</string>
     <string name="settings_home_group_app_system">App System</string>
     <string name="settings_home_item_general_title">General</string>
     <string name="settings_home_item_general_subtitle">Theme, Pro Mode, and Defaults</string>

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/settings/CapabilityConsentViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/settings/CapabilityConsentViewModelTest.kt
@@ -1,0 +1,153 @@
+package cloud.trotter.dashbuddy.ui.main.settings
+
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.capability.RuleCapability
+import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * #422 PR 3 — the consent surface. Covers the pure read projection
+ * ([buildConsentUiState]: per-source grouping, bundled vs downloaded, grant-state
+ * join, deterministic ordering) and that the ViewModel's only write routes THROUGH
+ * [RuleCapabilityGrants] with the correct grant/revoke boolean — the SSOT the
+ * fail-closed engine gate reads. The fake records the write; it never becomes a
+ * second gate.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CapabilityConsentViewModelTest {
+
+    /** In-memory [RuleCapabilityGrants] — the enumeration + granted set are drivable, writes recorded. */
+    private class FakeGrants : RuleCapabilityGrants {
+        private val _capabilities = MutableStateFlow<List<RuleCapability>>(emptyList())
+        private val _granted = MutableStateFlow<Set<String>>(emptySet())
+        override val capabilities: StateFlow<List<RuleCapability>> = _capabilities
+        override val grantedKeys: StateFlow<Set<String>> = _granted
+
+        val setGrantedCalls = mutableListOf<Pair<String, Boolean>>()
+
+        fun setEnumeration(caps: List<RuleCapability>) { _capabilities.value = caps }
+        fun setGrantedKeys(keys: Set<String>) { _granted.value = keys }
+
+        override suspend fun reconcile(capabilities: List<RuleCapability>) = error("unused")
+        override suspend fun isActionGranted(ruleId: String?, action: RuleAction) = error("unused")
+
+        override suspend fun setGranted(key: String, granted: Boolean) {
+            setGrantedCalls += key to granted
+            // Mirror the real store so the UI reflects the change reactively.
+            _granted.value = if (granted) _granted.value + key else _granted.value - key
+        }
+    }
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @Before fun setUp() = Dispatchers.setMain(dispatcher)
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    private fun cap(
+        key: String,
+        ruleId: String,
+        action: RuleAction,
+        source: String,
+    ) = RuleCapability(
+        ruleId = ruleId,
+        action = action,
+        targetBindName = action.targetBindName,
+        key = key,
+        source = source,
+    )
+
+    // =========================================================================
+    // buildConsentUiState — the pure read projection
+    // =========================================================================
+
+    @Test
+    fun `groups by source, marks bundled, joins grant state, orders deterministically`() {
+        val state = buildConsentUiState(
+            capabilities = listOf(
+                // Deliberately out of order: decline before accept, fork before asset.
+                cap("fork-accept", "uber.screen.offer", RuleAction.ACCEPT_OFFER, "fork:community"),
+                cap("dd-decline", "doordash.screen.offer_popup", RuleAction.DECLINE_OFFER, "asset:rules/doordash.json"),
+                cap("dd-accept", "doordash.screen.offer_popup", RuleAction.ACCEPT_OFFER, "asset:rules/doordash.json"),
+            ),
+            grantedKeys = setOf("dd-accept"), // asset accept granted; decline revoked; fork pending
+        )
+
+        assertEquals(2, state.sources.size)
+        // Bundled source sorts first.
+        val bundled = state.sources[0]
+        assertTrue(bundled.isBundled)
+        assertEquals(Platform.DoorDash, bundled.platform)
+        assertEquals(2, bundled.capabilities.size)
+        // ACCEPT_OFFER (ordinal 0) before DECLINE_OFFER (ordinal 1) — deterministic.
+        assertEquals(RuleAction.ACCEPT_OFFER, bundled.capabilities[0].action)
+        assertTrue("granted key reflects true", bundled.capabilities[0].granted)
+        assertFalse("revoked key reflects false", bundled.capabilities[1].granted)
+
+        val downloaded = state.sources[1]
+        assertFalse(downloaded.isBundled)
+        assertEquals(Platform.Uber, downloaded.platform)
+        assertFalse("a downloaded source is pending by default", downloaded.capabilities[0].granted)
+    }
+
+    @Test
+    fun `empty enumeration yields empty state`() {
+        assertTrue(buildConsentUiState(emptyList(), emptySet()).sources.isEmpty())
+    }
+
+    // =========================================================================
+    // ViewModel — reactive state + write routing
+    // =========================================================================
+
+    @Test
+    fun `uiState reflects the enumeration reactively`() = runTest {
+        val grants = FakeGrants()
+        grants.setEnumeration(
+            listOf(cap("k1", "doordash.screen.offer_popup", RuleAction.ACCEPT_OFFER, "asset:rules/doordash.json")),
+        )
+        grants.setGrantedKeys(setOf("k1"))
+        val vm = CapabilityConsentViewModel(grants)
+
+        // WhileSubscribed: collecting is what starts the upstream combine.
+        val state = vm.uiState.first { it.sources.isNotEmpty() }
+        assertEquals(1, state.sources.size)
+        assertTrue(state.sources[0].capabilities[0].granted)
+    }
+
+    @Test
+    fun `setGranted grant routes through the grant store`() = runTest {
+        val grants = FakeGrants()
+        val vm = CapabilityConsentViewModel(grants)
+
+        vm.setGranted("k1", true)
+
+        assertEquals(listOf("k1" to true), grants.setGrantedCalls)
+    }
+
+    @Test
+    fun `setGranted revoke routes through the grant store as false and drops the key`() = runTest {
+        val grants = FakeGrants()
+        grants.setGrantedKeys(setOf("k1"))
+        val vm = CapabilityConsentViewModel(grants)
+
+        vm.setGranted("k1", false)
+
+        assertEquals(listOf("k1" to false), grants.setGrantedCalls)
+        // Revocation surfaces on the read side immediately (the engine gate then fails closed).
+        assertFalse(grants.grantedKeys.value.contains("k1"))
+    }
+}

--- a/app/src/test/resources/timber-tag-guard-allowlist.txt
+++ b/app/src/test/resources/timber-tag-guard-allowlist.txt
@@ -21,7 +21,6 @@ app/src/main/java/cloud/trotter/dashbuddy/state/effects/OdometerEffectHandler.kt
 app/src/main/java/cloud/trotter/dashbuddy/state/effects/ScreenShotHandler.kt 8
 app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt 1
 app/src/main/java/cloud/trotter/dashbuddy/util/AccNodeUtils.kt 3
-core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityRepository.kt 2
 core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/DiskCaptureBus.kt 1
 core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/NoOpCaptureBus.kt 1
 core/data/src/main/java/cloud/trotter/dashbuddy/core/data/event/AppEventRepo.kt 2

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityRepository.kt
@@ -35,31 +35,44 @@ class RuleCapabilityRepository @Inject constructor(
 ) : RuleCapabilityGrants {
 
     /**
-     * Capabilities enabled by the CURRENTLY loaded rulesets, keyed by
-     * (ruleId, action). Set by [reconcile] before the loader swaps the
-     * compiled rules live, so the gate never sees rules without their
-     * enumeration.
+     * Capabilities enabled by the CURRENTLY loaded rulesets — the SSOT for both
+     * the fire-time gate ([isActionGranted] filters it by (ruleId, action)) and
+     * the consent surface ([capabilities] exposes it). Set by [reconcile] before
+     * the loader swaps the compiled rules live, so the gate never sees rules
+     * without their enumeration.
      */
-    private val enumerated =
-        MutableStateFlow<Map<Pair<String, RuleAction>, List<RuleCapability>>>(emptyMap())
+    private val enumerated = MutableStateFlow<List<RuleCapability>>(emptyList())
+
+    override val capabilities: StateFlow<List<RuleCapability>> = enumerated
 
     override val grantedKeys: StateFlow<Set<String>> = dataSource.granted
         .stateIn(scope, SharingStarted.Eagerly, emptySet())
 
     override suspend fun reconcile(capabilities: List<RuleCapability>) {
-        enumerated.value = capabilities.groupBy { it.ruleId to it.action }
+        enumerated.value = capabilities
         dataSource.update { granted, denied ->
             (granted + autoGrantSelection(capabilities, denied)) to denied
         }
-        Timber.i(
-            "RuleCapabilityRepository: reconciled %d capabilit(ies) from rule load",
+        Timber.tag(TAG).i(
+            "reconciled %d capabilit(ies) from rule load",
             capabilities.size,
         )
     }
 
+    override suspend fun setGranted(key: String, granted: Boolean) {
+        dataSource.update { grantedKeys, deniedKeys ->
+            applyGrantChange(key, granted, grantedKeys, deniedKeys)
+        }
+        // INFO milestone — a consent change is user-meaningful and PII-safe (the
+        // key is a sha256 hash, no store/customer text).
+        Timber.tag(TAG).i("consent %s for capability key %s", if (granted) "granted" else "revoked", key)
+    }
+
     override suspend fun isActionGranted(ruleId: String?, action: RuleAction): Boolean {
         if (ruleId == null) return false // no provenance → not consentable
-        val keys = enumerated.value[ruleId to action]?.map { it.key }
+        val keys = enumerated.value
+            .filter { it.ruleId == ruleId && it.action == action }
+            .map { it.key }
         val granted = try {
             // Authoritative read at fire time — the persisted store, not a
             // cached copy, so a revocation suppresses the very next fire.
@@ -67,10 +80,14 @@ class RuleCapabilityRepository @Inject constructor(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Timber.e(e, "Grant read failed — denying %s for '%s' (fail closed)", action.wire, ruleId)
+            Timber.tag(TAG).e(e, "Grant read failed — denying %s for '%s' (fail closed)", action.wire, ruleId)
             return false
         }
         return actionKeysCovered(keys, granted)
+    }
+
+    private companion object {
+        const val TAG = "Consent"
     }
 }
 
@@ -89,6 +106,23 @@ fun autoGrantSelection(capabilities: List<RuleCapability>, denied: Set<String>):
         .map { it.key }
         .filterNot { it in denied }
         .toSet()
+
+/**
+ * Consent grant/revoke set transform (#422 PR 3), pure and top-level so it is
+ * testable without DataStore. Granting a [key] adds it to [granted] and clears
+ * any prior denial; **revoking persists an explicit denial** so the next rule
+ * load's asset auto-grant ([autoGrantSelection] excludes denied keys) cannot
+ * silently re-grant it. Returns the new (granted, denied) pair for one atomic
+ * [RuleCapabilityDataSource.update].
+ */
+fun applyGrantChange(
+    key: String,
+    grant: Boolean,
+    granted: Set<String>,
+    denied: Set<String>,
+): Pair<Set<String>, Set<String>> =
+    if (grant) (granted + key) to (denied - key)
+    else (granted - key) to (denied + key)
 
 /**
  * ALL-keys-granted semantics (#417): when one (rule, action) pair enumerates

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityPolicyTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityPolicyTest.kt
@@ -80,4 +80,41 @@ class RuleCapabilityPolicyTest {
         assertFalse(actionKeysCovered(null, granted = setOf("k1")))
         assertFalse(actionKeysCovered(emptyList(), granted = setOf("k1")))
     }
+
+    // =========================================================================
+    // applyGrantChange — the consent grant/revoke set transform (#422 PR 3)
+    // =========================================================================
+
+    @Test
+    fun `granting adds the key and clears any prior denial`() {
+        val (granted, denied) = applyGrantChange(
+            key = "k1",
+            grant = true,
+            granted = setOf("k0"),
+            denied = setOf("k1", "k2"),
+        )
+        assertEquals(setOf("k0", "k1"), granted)
+        assertEquals(setOf("k2"), denied)
+    }
+
+    @Test
+    fun `revoking removes the grant and persists an explicit denial`() {
+        // The explicit denial is what keeps the next load's asset auto-grant from
+        // silently re-granting a revoked capability (fail-closed revocation).
+        val (granted, denied) = applyGrantChange(
+            key = "k1",
+            grant = false,
+            granted = setOf("k1", "k2"),
+            denied = emptySet(),
+        )
+        assertEquals(setOf("k2"), granted)
+        assertEquals(setOf("k1"), denied)
+
+        // And the persisted denial excludes it from a subsequent asset auto-grant.
+        val reGranted = autoGrantSelection(
+            listOf(cap("k1", "asset:rules/doordash.json")),
+            denied = denied,
+        )
+        assertTrue(reGranted.isEmpty())
+    }
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/LoadAtomicityTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/LoadAtomicityTest.kt
@@ -38,10 +38,12 @@ class LoadAtomicityTest {
     private class RecordingGrants : RuleCapabilityGrants {
         val reconcileCalls = mutableListOf<List<RuleCapability>>()
         override val grantedKeys: StateFlow<Set<String>> = MutableStateFlow(emptySet())
+        override val capabilities: StateFlow<List<RuleCapability>> = MutableStateFlow(emptyList())
         override suspend fun reconcile(capabilities: List<RuleCapability>) {
             reconcileCalls += capabilities
         }
         override suspend fun isActionGranted(ruleId: String?, action: RuleAction): Boolean = false
+        override suspend fun setGranted(key: String, granted: Boolean) = Unit
     }
 
     private fun interpreter(grants: RuleCapabilityGrants) =

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,23 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — Capability consent surface: honest copy + revoke aborts automation to manual (#422 PR 3).**
+  Settings → Data &amp; Privacy → **Automation &amp; Consent** now lists, per bundled ruleset source, every
+  automation tap the rules enable (Accept, Decline, Confirm a decline, Open the pay breakdown) with a
+  Google-Play-consistent disclosure header and one grant/revoke switch each. Bundled (asset) capabilities
+  show as on by default; the switch writes through the same grant store the fail-closed engine gate (#417)
+  reads at fire time.
+  **What to watch:** (1) the screen lists the DoorDash capabilities with plain, accurate copy — each says
+  what DashBuddy taps, inside which app, and that it never acts without your go-ahead (no marketing fluff).
+  (2) **Revocation is fail-closed:** turn OFF "Confirm a decline" (or "Open the pay breakdown"), then on the
+  next dash confirm that automation *aborts to manual* — the quick-decline second tap no longer fires
+  (you confirm the decline yourself) / the summary no longer auto-expands — while the same action left ON
+  still fires. Turning it back ON restores the tap. **Desk-side:** the `Consent` INFO line
+  `consent revoked/granted for capability key <sha256>` on each toggle (PII-safe — hash only), and the
+  `Effects` WARN `Denied <action> — no granted capability for rule '…' (fail closed)` when a revoked
+  action would have fired.
+  - Confirmed: 0/2
+
 - **🆕 NEW — Recognition hot-path pack: pre-map package skip must not drop real frames (#435 / PR #791).**
   ContentChanged/StateChanged now read the active window's package FIRST and skip the full tree
   mapping when it isn't a watched platform (bubble overlay, launcher). The skip must only ever fire

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -79,7 +79,7 @@ that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#4
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
 - **🆕 NEW — Capability consent surface: honest copy + revoke aborts automation to manual (#422 PR 3).**
-  Settings → Data &amp; Privacy → **Automation &amp; Consent** now lists, per bundled ruleset source, every
+  Settings → Data & Privacy → **Automation & Consent** now lists, per bundled ruleset source, every
   automation tap the rules enable (Accept, Decline, Confirm a decline, Open the pay breakdown) with a
   Google-Play-consistent disclosure header and one grant/revoke switch each. Bundled (asset) capabilities
   show as on by default; the switch writes through the same grant store the fail-closed engine gate (#417)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capability/RuleCapabilityGrants.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capability/RuleCapabilityGrants.kt
@@ -27,6 +27,28 @@ interface RuleCapabilityGrants {
     val grantedKeys: StateFlow<Set<String>>
 
     /**
+     * The capabilities the CURRENTLY loaded rulesets enumerate — the same list
+     * the last [reconcile] published, replaced wholesale on each rule load. The
+     * consent surface (#422 PR 3) joins this with [grantedKeys] to render one
+     * chip per capability with its provenance ([RuleCapability.source]) and grant
+     * state. Read-only projection of the enumeration the gate already holds — the
+     * UI is a consent *record*, never a second enforcement point.
+     */
+    val capabilities: StateFlow<List<RuleCapability>>
+
+    /**
+     * Grant ([granted] = true) or revoke ([granted] = false) one capability
+     * [key] from the consent surface (#422 PR 3). Both sides write atomically:
+     * granting adds [key] to the granted set and clears any prior denial;
+     * **revoking persists an explicit denial** so the next rule load's asset
+     * auto-grant can't silently undo it (the point of the separate denied set).
+     * A revocation surfaces on [grantedKeys] immediately, so the fail-closed
+     * fire-time gate ([isActionGranted]) suppresses the very next automation
+     * tap — revocation is fail-closed.
+     */
+    suspend fun setGranted(key: String, granted: Boolean)
+
+    /**
      * Publish the capabilities the just-loaded rulesets enable — REPLACING
      * the previous enumeration — and apply the source auto-grant policy:
      * capabilities from a bundled asset source ([ASSET_SOURCE_PREFIX]) are


### PR DESCRIPTION
Closes #422 (PR 3 — the consent chips UI over the landed #417 grant store + #425 RuleAction registry).

Built from `docs/design/rule-capability-consent.md` §"What the user actually consents to" + the dev decision (2026-07-18): copy must be **consistent with Google Play's AccessibilityService prominent-disclosure expectations** — what is accessed, why, and what automation may do — with no marketing softening.

## What this adds

A new **Settings → Data & Privacy → Automation & Consent** screen. It lists, per ruleset source, every automation tap the loaded rules enable, each with app-owned disclosure copy and a grant/revoke switch. It is a consent **record surface**, not a second gate: the sole enforcement point stays the fail-closed `SideEffectEngine.PerformRuleAction` seam (#417), which reads the grant store authoritatively at fire time.

## Every file in the diff

**`:domain` — `domain/.../capability/RuleCapabilityGrants.kt`** (interface, +2 members)
- `val capabilities: StateFlow<List<RuleCapability>>` — read-only projection of the enumeration the gate already holds (the UI's list source).
- `suspend fun setGranted(key: String, granted: Boolean)` — grant (add to granted, clear denial) / revoke (remove grant, **persist explicit denial**), atomic.

**`:core:data` — `core/data/.../capability/RuleCapabilityRepository.kt`**
- Internal enumeration SSOT changed from a `Map<Pair<ruleId,action>, List<..>>` to a flat `MutableStateFlow<List<RuleCapability>>`, exposed as `capabilities`. `isActionGranted` now `filter`s that list by `(ruleId, action)` — **same** `actionKeysCovered` all-keys-granted / fail-closed semantics, no map second-copy (SSOT).
- New `override suspend fun setGranted(...)` → `dataSource.update { g, d -> applyGrantChange(...) }`.
- New pure top-level `applyGrantChange(key, grant, granted, denied): Pair<Set,Set>` (revoke persists a denial so the next asset auto-grant can't silently re-grant — `autoGrantSelection` already excludes denied).
- Logging: the two previously-bare `Timber.i`/`Timber.e` sites are now `Timber.tag("Consent")`; the new consent-change site is INFO and PII-safe (sha256 key + granted/revoked only).

**`:app` — new `ui/main/settings/CapabilityConsentViewModel.kt`**
- `@HiltViewModel`, injects the `RuleCapabilityGrants` **interface** (Hilt resolves to the repository). `uiState: StateFlow<ConsentUiState>` = `combine(grants.capabilities, grants.grantedKeys)` via pure `buildConsentUiState` (group by source, bundled-vs-downloaded, join grant state, deterministic order). Only write = `setGranted` → `grants.setGranted`.

**`:app` — new `ui/main/settings/CapabilityConsentScreen.kt`**
- Prominent-disclosure header + per-source sections (reuses the existing `SwitchRow`). Disclosure copy resolved from `RuleAction` via string resources; platform display name from `Platform.fromRuleId` (display only). Empty-state copy when no capabilities are enumerated.

**`:app` — nav wiring:** `DashBuddyRoutes.kt` (`ConsentSettings` route + `allRoutes` allowlist), `SettingsHomeScreen.kt` (nav item under Data & Privacy), `MainActivity.kt` (NavHost `composable`).

**`app/src/main/res/values/strings.xml`** — new `consent_*` + `settings_home_item_consent_*` block (all strings listed below).

**Tests:** `CapabilityConsentViewModelTest.kt` (new), `RuleCapabilityPolicyTest.kt` (+`applyGrantChange`), `LoadAtomicityTest.kt` (fake updated for the 2 new interface members), `timber-tag-guard-allowlist.txt` (RuleCapabilityRepository entry burned down to 0).

**Docs:** `CLAUDE.md` (consent-UI now shipped), `docs/field-testing/README.md` (new checklist item).

## Repository / grant-store calls (the write path)
- Read: `RuleCapabilityGrants.capabilities` (StateFlow) + `.grantedKeys` (StateFlow) — both already backed by `RuleCapabilityDataSource.granted` / the in-memory enumeration.
- Write: `RuleCapabilityGrants.setGranted(key, granted)` → `RuleCapabilityDataSource.update { granted, denied -> applyGrantChange(...) }` (one atomic `ds.edit`).
- No new DataStore, no new permission, no new network. The datastore already had `granted`/`denied` string-set keys; only `setGranted` newly writes them from the UI.

## Every new user-facing string
- `consent_title` = "Automation & Consent"
- `consent_disclosure_heading` = "How DashBuddy uses the Accessibility service"
- `consent_disclosure_body` = "DashBuddy uses Android's Accessibility service to read the screens of the delivery apps you turn on, so it can recognize offers, pickups, and deliveries. This recognition runs entirely on your phone.\n\nDashBuddy can also tap buttons in a delivery app for you — but only the specific actions you allow below, only inside that delivery app, and only on a button whose label matches the action — except the icon-only pay-details arrow, which is verified by app boundary only. Accept and Decline taps fire when you press the button in DashBuddy or when you have armed that automation. Actions bundled with DashBuddy start on — the pay-details tap runs whenever a completed delivery's pay breakdown is collapsed. Turn any action off below and DashBuddy will not tap it — you do it manually." *(reworded per security review)*
- `consent_empty` = "No automation actions are available yet. They appear here once your delivery-app rules load and a rule enables an action such as Accept or Decline."
- `consent_platform_unknown` = "Delivery app"
- `consent_source_bundled_format` = "%1$s · bundled with DashBuddy"
- `consent_source_bundled_note` = "These automation rules ship inside the app and are on by default. Turn any off to require a manual tap instead."
- `consent_source_downloaded_format` = "%1$s · downloaded rules"
- `consent_source_downloaded_note` = "Downloaded rules are never turned on automatically. Each action stays off until you turn it on here."
- `consent_cap_accept_title` = "Accept offers"
- `consent_cap_accept_desc` = "Lets DashBuddy tap the Accept button in the %1$s app for you — when you press Accept in DashBuddy, or when you have armed auto-accept. It only taps a button labeled \"Accept\" inside the %1$s app, and never without your go-ahead."
- `consent_cap_decline_title` = "Decline offers"
- `consent_cap_decline_desc` = "Lets DashBuddy tap the Decline button in the %1$s app for you — when you press Decline in DashBuddy, or when you have armed auto-decline. It only taps a button labeled \"Decline\" inside the %1$s app, and never without your go-ahead."
- `consent_cap_confirm_decline_title` = "Confirm a decline"
- `consent_cap_confirm_decline_desc` = "Lets DashBuddy tap the second \"Decline\" button on %1$s's confirmation dialog, so a decline you started finishes in one step. It only fires when you have turned on quick declines, and only inside the %1$s app."
- `consent_cap_expand_title` = "Open the pay breakdown"
- `consent_cap_expand_desc` = "Lets DashBuddy tap the arrow that expands the pay details on a completed %1$s delivery, so it can read the payout for your records. It only opens the pay details — it doesn't change your delivery, your pay, or any setting." *(reworded per security review)*
- `settings_home_item_consent_title` = "Automation & Consent"
- `settings_home_item_consent_subtitle` = "Control which taps DashBuddy may perform for you"

## Security / privacy posture (Pledge-adjacent)
- **What's surfaced:** the enumerated `(rule, action)` capabilities and their granted/denied state — no third-party UI text, no PII. Grant keys are sha256 hashes.
- **Enforcement unchanged / SSOT:** the UI never gates anything. The only enforcement point is `SideEffectEngine`'s `PerformRuleAction` branch (`isActionGranted(sourceRuleId, action)` + OS tier + tap-time verification). The screen writes grant state; the engine reads it authoritatively at fire time.
- **Revocation is fail-closed:** revoke removes the key from `granted` AND adds it to `denied` in one atomic edit; `grantedKeys` (backed by the persisted store) surfaces the change immediately, so the very next automation tap fails closed to manual. The explicit denial also blocks the next asset load's auto-grant from silently re-granting it.
- **Copy is app-owned, never rule-supplied** — resolved from the `RuleAction` vocabulary + string resources; the untrusted ruleset contributes only a bind name + predicate (never shown). Consistent with the design doc's "never rule-supplied text" rule.
- **No new attack surface:** no new permission, DataStore, or network path; the untrusted-input boundary (rule compile/enumerate) is untouched.
- **Logging:** consent changes log at INFO under the `Consent` tag, PII-safe (hash + granted/revoked). Gate denials remain WARN at the engine.

## Tests
- `RuleCapabilityPolicyTest` (+`applyGrantChange`: grant clears denial; revoke persists denial and is then excluded from auto-grant) — green.
- `CapabilityConsentViewModelTest` — pure `buildConsentUiState` (grouping / bundled / grant-join / deterministic order / empty), reactive `uiState`, grant & revoke write-routing — green.
- `SideEffectEngineTest` #417 gate suite + `RuleCapabilityEnumerationTest`/`LoadAtomicityTest` — unchanged behavior, green.
- Full `./gradlew testDebugUnitTest :domain:test` — **BUILD SUCCESSFUL** (incl. `TimberTagGuardTest`).

### Design-goal review
- **1 (UDF):** State flows down (`StateFlow<ConsentUiState>`, immutable data classes); events up (`setGranted`) to the ViewModel, which writes only through the repository — never a repository write from the composable. No reducer/wall-clock involvement (a settings surface, not a HUD).
- **3 (Single responsibility):** New screen + VM are small and focused; the read projection and the grant transform are extracted as pure top-level functions (`buildConsentUiState`, `applyGrantChange`). No file grew oversized; `SwitchRow` is reused, not re-implemented.
- **5 (SSOT):** The enumeration is now a **single** flat list serving both the gate and the UI (deleted the parallel grouped map). Enforcement has one owner (the engine gate); the UI derives from `grantedKeys`, never caching grant state. Disclosure copy is one owner (string resources keyed off `RuleAction`).
- **6 (Security & privacy):** Enforcement stays at the fail-closed engine seam; revoke is fail-closed (grant removed + denial persisted, surfaced immediately). No new permission/network/data path. Copy is app-owned, not rule-supplied. Grant keys are hashes; consent logging is PII-safe. Full posture above.
- **Reactive UI:** No time-derived values on this surface, so the ticker rules don't apply; the switches are driven reactively by `grantedKeys` (a revoke elsewhere would re-render the switch).
- **8 (platform-agnostic):** No new platform literal in logic — `Platform.fromRuleId` (display only) and `RuleAction` (the app-owned enumerated vocabulary) carry all per-platform variance; adding a platform needs no edit here. No new rule↔state vocabulary.

### Adversarial review

Independent fable-tier security review (2026-07-18): FIX FIRST → fixes applied. The #417 mechanics survived attack — revoke is one atomic ds.edit (grant removed + denial persisted), the persisted denial provably excludes the key from autoGrantSelection on the next asset load (pinned in RuleCapabilityPolicyTest), the engine gate still reads the committed store per fire, and the UI introduces no second enforcement point and cannot widen a grant beyond the enumerated, content-pinned keys. The findings were in the copy itself: the disclosure header claimed universal label verification (false for the label-free EXPAND_EARNINGS tap) and per-instance consent (false for bundled auto-granted auto-expand), and the expand row's 'it changes nothing' overstated a real UI interaction; all three strings reworded to state exactly what fires, when, and under which verification. Adjudication: 'never without your go-ahead' on Accept/Decline is honest because the same sentence names the standing arm as a trigger; the header was not, and now is. Docs nit fixed: literal &amp; entities. Full suite green including TimberTagGuardTest and the #417/#590 gate/atomicity suites.
