### PR TITLE
privacy(pipeline): #806 — UNKNOWN-screen customer scrub + "Pickup for " marker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,11 +203,15 @@ first token + second-token initial), so a customer's mask/hash is stable across 
 DoorDash renders their name in ("Brandy S" vs "Brandy Smith"). Coverage spans the recognized offer/pickup/dropoff/chat/
 nav/camera **screen** surfaces AND **notification** envelopes (#620 — chat title/body,
 order-ready customer name via a per-field notif `redact`; store names kept). A rules-independent
-**recognized-frame** backstop (`CustomerTextMarkers`, #624/#632/#666 — distinct from `SensitiveTextMarkers`,
-which drops the dasher's banking screens) scrubs a node (screen tree) or whole field (notification —
-#632, incl. `actionLabels` — #666) that ships a customer-PII marker a rule forgot to redact; the
-marker SSOT is cross-platform DATA ("Deliver to "/"Message from " for DoorDash, "Leave the order at
-"/"Meet at door for " for Uber pushes, #585 — not DoorDash-only), with a documented residual for
+customer-PII **marker backstop** (`CustomerTextMarkers`, #624/#632/#666/#806 — distinct from
+`SensitiveTextMarkers`, which drops the dasher's banking screens) scrubs a node (screen tree) or whole
+field (notification — #632, incl. `actionLabels` — #666) that ships a customer-PII marker — on the
+**recognized** path (a rule forgot to redact) AND, since #806, on the **UNKNOWN screen / notification /
+click** envelopes too (a customer-bearing surface no rule recognized — the "Deliver to "/"Pickup for "
+task-detail views — that `SensitiveTextMarkers` correctly ignores; fail toward privacy), before the
+envelope hits disk; the
+marker SSOT is cross-platform DATA ("Deliver to "/"Pickup for "/"Message from " for DoorDash, "Leave the
+order at "/"Meet at door for " for Uber pushes, #585 — not DoorDash-only), with a documented residual for
 shapes a prefix scan can't own (a name-at-start body, and store-ambiguous prefixes like Uber's
 "Going to " that precede stores AND addresses) where the rule-declared `redact` is the primary
 control; the compiler rejects branch-level `redact` and skips a file with duplicate rule ids (#624),
@@ -222,7 +226,9 @@ backstop both also scan `actionLabels` now (#666) — a push action button label
 the envelope the same as the text fields and was previously excluded from every scrub layer.
 UNKNOWN frames and UNKNOWN clicks remain the documented
 debug-only exception (behind the release `NoOpCaptureBus` #346 + the `SensitiveTextMarkers`
-backstop); the id-less building-name line residual is still tracked. `PipelineV2.events` is a HOT `shareIn` stream — one upstream pass feeds
+drop backstop + the #806 `CustomerTextMarkers` scrub on the UNKNOWN screen/notification/click
+envelopes); the prefix-less residual (a name-at-start body, an address/gate-code line with no
+customer lead-in) persists on UNKNOWN frames until the surface is recognized (#806 direction 1). `PipelineV2.events` is a HOT `shareIn` stream — one upstream pass feeds
 all collectors, so side effects (captures, dedup state) can never double-run (#361). The merged
 upstream is supervised — a crash logs + counts a restart and resubscribes with backoff instead of
 silencing all sensing (#430) — and `PipelineStats` counts every gate decision, mapping failure,

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureBackstopCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureBackstopCorpusTest.kt
@@ -47,7 +47,11 @@ class CaptureBackstopCorpusTest {
                 } catch (_: Exception) {
                     return@forEach
                 }
-                // UNKNOWN frames route through SensitiveTextMarkers, not this backstop.
+                // This test validates the RECOGNIZED path only (rule → its redact →
+                // backstop scan). UNKNOWN frames are also scrubbed by this backstop now
+                // (#806, on the CaptureWriter UNKNOWN screen/notif/click paths), but the
+                // committed corpus here is all recognized, redacted fixtures — an
+                // unmatched frame has no rule redact to mirror, so it's skipped.
                 val match = screenRuleset.matchFirst(node) ?: return@forEach
                 // Mirror captureScreen: recognized rule's redact first, then backstop scan.
                 val redacted = screenRuleset.ruleById(match.ruleId)

--- a/app/src/test/resources/timber-tag-guard-allowlist.txt
+++ b/app/src/test/resources/timber-tag-guard-allowlist.txt
@@ -29,7 +29,6 @@ core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DataTypeConver
 core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt 1
 core/location/src/main/java/cloud/trotter/dashbuddy/core/location/FusedLocationDataSource.kt 6
 core/network/src/main/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/EpaVehicleDataSource.kt 5
-core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt 5
 core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/FrameGate.kt 1
 core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt 1
 core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineSupervision.kt 1

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
@@ -55,7 +55,7 @@ class CaptureWriter @Inject constructor(
             val marker = SensitiveTextMarkers.findMarker(event.tree)
             if (marker != null) {
                 stats.onScrubbedUnknownCapture()
-                Timber.w("Capture scrubbed: UNKNOWN screen hit sensitive marker '%s'", marker)
+                Timber.tag("Pipeline").w("Capture scrubbed: UNKNOWN screen hit sensitive marker '%s'", marker)
                 return obs
             }
         }
@@ -76,33 +76,50 @@ class CaptureWriter @Inject constructor(
         // must MASK it in the serialized envelope. The redacted copy is
         // envelope-only — recognition, parse, the state machine, and the dedup
         // contentHash all ran / run on the ORIGINAL tree (event.tree). UNKNOWN
-        // frames have no ruleId and are governed by the SensitiveTextMarkers
-        // backstop above instead.
+        // frames have no ruleId, so this consults nothing (redactedTree == event.tree).
         val redact = obs.ruleId?.let { redactionSource.redactFor(it) }
         val redactedTree = redact?.apply(event.tree) ?: event.tree
-        // #624 recognized-frame customer-PII backstop (defense-in-depth): the
-        // #598 sha256→redact compile gate only fires for a rule that HASHES PII.
-        // A recognized rule that ships raw customer text with NO redact block (or
-        // a future downloaded rule that simply omits one) stays silent. Scan the
-        // envelope-bound tree for a customer-PII marker whose node was NOT already
-        // redacted and scrub it, so a rule that FORGOT to redact still ships a
-        // scrubbed capture. UNKNOWN frames are handled by SensitiveTextMarkers above.
-        val payloadTree = if (obs.target != UNKNOWN_TARGET) {
+        // Customer-PII text-marker backstop over the envelope-bound tree, for BOTH
+        // frame classes (one marker SSOT, cross-platform DATA — principle 8):
+        //  - RECOGNIZED (#624 defense-in-depth): the #598 sha256→redact compile gate
+        //    only fires for a rule that HASHES PII, so a recognized rule that ships
+        //    raw customer text with NO redact block (or a future CDN rule that omits
+        //    one) stays silent. Scrub the offending node so a forgotten redact still
+        //    ships a scrubbed capture.
+        //  - UNKNOWN (#806): a customer-bearing surface no rule recognized (the
+        //    "Deliver to "/"Pickup for " task-detail views) would otherwise persist
+        //    name/address/gate-code verbatim. SensitiveTextMarkers above (dasher-
+        //    banking) correctly ignores customer content, so this scan is the ONLY
+        //    customer control on the UNKNOWN screen path. Fail toward privacy:
+        //    scrubbing a benign marker-shaped string is the accepted cost.
+        // The VET V1 already-redacted skip keeps a rule's OWN redact output from
+        // re-tripping. FrameGate's UNKNOWN suppressor already dedups UNKNOWN frames
+        // upstream, so the WARN below is at most one per admitted frame — no storm.
+        val payloadTree = run {
             val marker = CustomerTextMarkers.firstUnredactedMarker(redactedTree)
-            if (marker != null) {
-                stats.onRedactBackstopScrub()
-                // Principle 7: log the MARKER + rule id only — NEVER the leaked value.
-                Timber.w(
-                    "Capture backstop: recognized frame carried un-redacted customer marker '%s' " +
-                        "(ruleId=%s) — scrubbing node from envelope",
-                    marker, obs.ruleId,
-                )
-                CustomerTextMarkers.scrub(redactedTree)
-            } else {
-                redactedTree
+            when {
+                marker == null -> redactedTree
+                obs.target == UNKNOWN_TARGET -> {
+                    stats.onUnknownCustomerScrub()
+                    // Principle 7: log the MARKER PREFIX only — NEVER the leaked value.
+                    Timber.tag("Pipeline").w(
+                        "Capture backstop: UNKNOWN screen carried customer marker '%s' — " +
+                            "scrubbing node from envelope",
+                        marker,
+                    )
+                    CustomerTextMarkers.scrub(redactedTree)
+                }
+                else -> {
+                    stats.onRedactBackstopScrub()
+                    // Principle 7: log the MARKER + rule id only — NEVER the leaked value.
+                    Timber.tag("Pipeline").w(
+                        "Capture backstop: recognized frame carried un-redacted customer marker " +
+                            "'%s' (ruleId=%s) — scrubbing node from envelope",
+                        marker, obs.ruleId,
+                    )
+                    CustomerTextMarkers.scrub(redactedTree)
+                }
             }
-        } else {
-            redactedTree
         }
         val capture = EnvelopeBuilder.build(
             pipelineId = AccessibilityPipeline.SCREEN_PIPELINE_ID,
@@ -146,7 +163,7 @@ class CaptureWriter @Inject constructor(
             val marker = SensitiveTextMarkers.findMarker(event.node)
             if (marker != null) {
                 stats.onScrubbedUnknownCapture()
-                Timber.w("Capture scrubbed: UNKNOWN click hit sensitive marker '%s'", marker)
+                Timber.tag("Pipeline").w("Capture scrubbed: UNKNOWN click hit sensitive marker '%s'", marker)
                 return obs
             }
         }
@@ -201,7 +218,7 @@ class CaptureWriter @Inject constructor(
                 ?: raw.actionLabels.firstNotNullOfOrNull { SensitiveTextMarkers.findMarker(it) }
             if (marker != null) {
                 stats.onScrubbedUnknownCapture()
-                Timber.w("Capture scrubbed: UNKNOWN notification hit sensitive marker '%s'", marker)
+                Timber.tag("Pipeline").w("Capture scrubbed: UNKNOWN notification hit sensitive marker '%s'", marker)
                 return obs
             }
         }
@@ -232,7 +249,7 @@ class CaptureWriter @Inject constructor(
             if (marker != null) {
                 stats.onNotifRedactBackstopScrub()
                 // Principle 7: log the MARKER + rule id only — NEVER the leaked value.
-                Timber.w(
+                Timber.tag("Pipeline").w(
                     "Capture backstop: recognized notification carried un-redacted customer " +
                         "marker '%s' (ruleId=%s) — scrubbing field from envelope",
                     marker, obs.ruleId,

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
@@ -167,6 +167,30 @@ class CaptureWriter @Inject constructor(
                 return obs
             }
         }
+        // #806 customer-PII backstop for the UNKNOWN click node: a tap on a
+        // "Deliver to <name>"/"Pickup for <name>" row on an unrecognized screen would
+        // otherwise persist the raw customer text in the click envelope. Rule-matched
+        // clicks are app-vocabulary buttons (Accept/Decline/confirm) whose labels carry
+        // no PII, so — like the recognized-screen path — only UNKNOWN clicks are scanned
+        // (recognized clicks stay byte-identical). Fail toward privacy. The dedup hash
+        // below is still on the ORIGINAL node (the scrub is envelope-only).
+        val payloadNode = if (obs.target == UNKNOWN_TARGET) {
+            val marker = CustomerTextMarkers.firstUnredactedMarker(event.node)
+            if (marker != null) {
+                stats.onUnknownCustomerScrub()
+                // Principle 7: log the MARKER PREFIX only — NEVER the leaked value.
+                Timber.tag("Pipeline").w(
+                    "Capture backstop: UNKNOWN click node carried customer marker '%s' — " +
+                        "scrubbing node from envelope",
+                    marker,
+                )
+                CustomerTextMarkers.scrub(event.node)
+            } else {
+                event.node
+            }
+        } else {
+            event.node
+        }
         val platform = Platform.fromPackage(event.packageName).wire
         val capture = EnvelopeBuilder.build(
             pipelineId = AccessibilityPipeline.CLICK_PIPELINE_ID,
@@ -174,7 +198,7 @@ class CaptureWriter @Inject constructor(
             platform = platform,
             ruleId = obs.ruleId,
             classificationName = obs.target,
-            payload = ClickCapturePayload(node = event.node, screenTarget = screenTarget),
+            payload = ClickCapturePayload(node = payloadNode, screenTarget = screenTarget),
             contentHash = clickDedupHash(event.node, screenTarget),
             metadata = obs.metadata,
         )
@@ -229,37 +253,52 @@ class CaptureWriter @Inject constructor(
         // serialized envelope only. The masked copy is envelope-only — recognition
         // and parse ran on the ORIGINAL raw, and its contentHash is the dedup
         // identity, captured BEFORE masking (a masked .copy() recomputes a
-        // DIFFERENT hash). UNKNOWN notifications have no ruleId and are governed by
-        // the SensitiveTextMarkers backstop above instead.
+        // DIFFERENT hash). UNKNOWN notifications have no ruleId so this rule-declared
+        // redact is a no-op for them; their customer-PII control is the marker
+        // backstop below (#806) plus the SensitiveTextMarkers drop above.
         val originalContentHash = raw.contentHash
         val notifRedact = obs.ruleId?.let { redactionSource.notifRedactFor(it) }
         val redactedRaw = notifRedact?.apply(raw) ?: raw
-        // #632 recognized-notification customer-PII backstop (defense-in-depth):
-        // the notif analogue of the #624 screen backstop. The #598 sha256→redact
-        // compile gate only fires for a rule that HASHES PII; a recognized
-        // notification rule that ships raw customer text with NO redact block (or a
-        // future downloaded rule that omits one) stays silent. Scan the masked flat
-        // fields for a customer-PII marker whose field was NOT already redacted and
-        // scrub the whole field, so a rule that FORGOT to redact still ships a
-        // scrubbed envelope. The contentHash is still originalContentHash (the dedup
-        // identity, #620 VET V7). UNKNOWN notifications are handled by
-        // SensitiveTextMarkers above; here they have no ruleId so nothing changes.
-        val payloadRaw = if (obs.target != UNKNOWN_TARGET) {
+        // Customer-PII notification backstop over the envelope-bound raw, for BOTH
+        // frame classes (one marker SSOT — the scan covers all 5 flat text fields via
+        // RawNotificationData.textFields() AND actionLabels, #666):
+        //  - RECOGNIZED (#632 defense-in-depth): the notif analogue of the #624 screen
+        //    backstop. The #598 sha256→redact compile gate only fires for a rule that
+        //    HASHES PII; a recognized notification rule that ships raw customer text
+        //    with NO redact block (or a future CDN rule that omits one) stays silent.
+        //    Scrub the offending whole field so a forgotten redact still ships clean.
+        //  - UNKNOWN (#806): an unrecognized customer-bearing push (a "Message from
+        //    <name>"/"Meet at door for <name>" body an OTA rule doesn't cover yet)
+        //    would otherwise persist the customer name verbatim. SensitiveTextMarkers
+        //    above (dasher-banking) ignores customer content, so this scan is the only
+        //    customer control on the UNKNOWN notification path. Fail toward privacy.
+        // The contentHash is still originalContentHash (the dedup identity, #620 VET
+        // V7) either way. UNKNOWN notifs have no ruleId so redactedRaw == raw.
+        val payloadRaw = run {
             val marker = CustomerTextMarkers.firstUnredactedMarkerInNotif(redactedRaw)
-            if (marker != null) {
-                stats.onNotifRedactBackstopScrub()
-                // Principle 7: log the MARKER + rule id only — NEVER the leaked value.
-                Timber.tag("Pipeline").w(
-                    "Capture backstop: recognized notification carried un-redacted customer " +
-                        "marker '%s' (ruleId=%s) — scrubbing field from envelope",
-                    marker, obs.ruleId,
-                )
-                CustomerTextMarkers.scrubNotif(redactedRaw)
-            } else {
-                redactedRaw
+            when {
+                marker == null -> redactedRaw
+                obs.target == UNKNOWN_TARGET -> {
+                    stats.onUnknownCustomerScrub()
+                    // Principle 7: log the MARKER PREFIX only — NEVER the leaked value.
+                    Timber.tag("Pipeline").w(
+                        "Capture backstop: UNKNOWN notification carried customer marker '%s' — " +
+                            "scrubbing field from envelope",
+                        marker,
+                    )
+                    CustomerTextMarkers.scrubNotif(redactedRaw)
+                }
+                else -> {
+                    stats.onNotifRedactBackstopScrub()
+                    // Principle 7: log the MARKER + rule id only — NEVER the leaked value.
+                    Timber.tag("Pipeline").w(
+                        "Capture backstop: recognized notification carried un-redacted customer " +
+                            "marker '%s' (ruleId=%s) — scrubbing field from envelope",
+                        marker, obs.ruleId,
+                    )
+                    CustomerTextMarkers.scrubNotif(redactedRaw)
+                }
             }
-        } else {
-            redactedRaw
         }
         val capture = EnvelopeBuilder.build(
             pipelineId = NotificationPipeline.PIPELINE_ID,

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
@@ -15,13 +15,14 @@ import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
  * - [SensitiveTextMarkers] guards the UNKNOWN path against the DASHER's OWN
  *   sensitive screens (banking/identity) by DROPPING the whole capture.
  * - This SSOT guards CUSTOMER PII by SCRUBBING only the offending node/field to
- *   `[redacted]` (the capture still ships, minus the leaked PII), on THREE paths:
- *   RECOGNIZED frames whose rule SHOULD have declared a `redact` block but didn't
- *   (#624/#632), and — since #806 — UNKNOWN SCREEN frames, a customer-bearing
- *   surface no rule recognized (the "Deliver to "/"Pickup for " task-detail views)
- *   that would otherwise persist name/address/gate-code verbatim, since
- *   [SensitiveTextMarkers] (dasher-banking) correctly ignores customer content.
- *   The UNKNOWN-screen scan is fail-toward-privacy: a benign marker-shaped string
+ *   `[redacted]` (the capture still ships, minus the leaked PII), on both frame
+ *   classes: RECOGNIZED frames whose rule SHOULD have declared a `redact` block
+ *   but didn't (#624/#632), and — since #806 — UNKNOWN screen, notification, AND
+ *   click envelopes, customer-bearing surfaces no rule recognized (the "Deliver
+ *   to "/"Pickup for " task-detail views) that would otherwise persist
+ *   name/address/gate-code verbatim, since [SensitiveTextMarkers]
+ *   (dasher-banking) correctly ignores customer content.
+ *   The UNKNOWN-path scan is fail-toward-privacy: a benign marker-shaped string
  *   is scrubbed too (losing triage-useful text is the accepted cost).
  *
  * Why it's needed: the #598 `sha256`→`redact` compile gate only fires for a rule

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
@@ -14,9 +14,15 @@ import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
  * The two SSOTs differ in both target and action:
  * - [SensitiveTextMarkers] guards the UNKNOWN path against the DASHER's OWN
  *   sensitive screens (banking/identity) by DROPPING the whole capture.
- * - This SSOT guards RECOGNIZED frames whose rule SHOULD have declared a
- *   `redact` block but didn't, and it SCRUBS only the offending node/field to
- *   `[redacted]` (the capture still ships, minus the leaked PII).
+ * - This SSOT guards CUSTOMER PII by SCRUBBING only the offending node/field to
+ *   `[redacted]` (the capture still ships, minus the leaked PII), on THREE paths:
+ *   RECOGNIZED frames whose rule SHOULD have declared a `redact` block but didn't
+ *   (#624/#632), and — since #806 — UNKNOWN SCREEN frames, a customer-bearing
+ *   surface no rule recognized (the "Deliver to "/"Pickup for " task-detail views)
+ *   that would otherwise persist name/address/gate-code verbatim, since
+ *   [SensitiveTextMarkers] (dasher-banking) correctly ignores customer content.
+ *   The UNKNOWN-screen scan is fail-toward-privacy: a benign marker-shaped string
+ *   is scrubbed too (losing triage-useful text is the accepted cost).
  *
  * Why it's needed: the #598 `sha256`→`redact` compile gate only fires for a rule
  * that HASHES PII in its parse. A rule that ships raw customer text WITHOUT
@@ -52,6 +58,7 @@ object CustomerTextMarkers {
     val MARKERS: List<String> = listOf(
         // DoorDash screen + notification vocabulary.
         "Deliver to ",
+        "Pickup for ", // DoorDash pickup / "Current task" task-detail views -> customer name (#806).
         "Order for ",
         "Verify items for ",
         "Delivery for ",

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt
@@ -35,6 +35,7 @@ class PipelineStats @Inject constructor() {
     private val droppedAwaitingRules = AtomicLong()
     private val scrubbedUnknownCaptures = AtomicLong()
     private val redactBackstopScrubs = AtomicLong()
+    private val unknownCustomerScrubs = AtomicLong()
     private val notifRedactBackstopScrubs = AtomicLong()
     private val notifListenerConnects = AtomicLong()
     private val notifListenerDisconnects = AtomicLong()
@@ -50,6 +51,7 @@ class PipelineStats @Inject constructor() {
     val droppedAwaitingRulesCount: Long get() = droppedAwaitingRules.get()
     val scrubbedUnknownCaptureCount: Long get() = scrubbedUnknownCaptures.get()
     val redactBackstopScrubCount: Long get() = redactBackstopScrubs.get()
+    val unknownCustomerScrubCount: Long get() = unknownCustomerScrubs.get()
     val notifRedactBackstopScrubCount: Long get() = notifRedactBackstopScrubs.get()
     val notifListenerConnectCount: Long get() = notifListenerConnects.get()
     val notifListenerDisconnectCount: Long get() = notifListenerDisconnects.get()
@@ -99,6 +101,14 @@ class PipelineStats @Inject constructor() {
         redactBackstopScrubs.incrementAndGet()
     }
 
+    /** An UNKNOWN screen carrying a customer-PII marker (a customer-bearing surface
+     *  no rule recognized); the offending node was scrubbed in the envelope by the
+     *  #806 UNKNOWN-screen customer backstop. Distinct from [onScrubbedUnknownCapture]
+     *  (which DROPS the whole capture for the dasher's own sensitive screens). */
+    fun onUnknownCustomerScrub() {
+        unknownCustomerScrubs.incrementAndGet()
+    }
+
     /** A RECOGNIZED NOTIFICATION whose rule shipped an un-redacted customer marker;
      *  the offending flat field was scrubbed in the envelope by the #632
      *  defense-in-depth notification backstop (the notif analogue of #624). */
@@ -138,6 +148,7 @@ class PipelineStats @Inject constructor() {
             " awaitingRulesDropped=${droppedAwaitingRules.get()}" +
             " unknownScrubbed=${scrubbedUnknownCaptures.get()}" +
             " redactBackstopScrubs=${redactBackstopScrubs.get()}" +
+            " unknownCustomerScrubs=${unknownCustomerScrubs.get()}" +
             " notifRedactBackstopScrubs=${notifRedactBackstopScrubs.get()}" +
             " notifListenerConnects=${notifListenerConnects.get()}" +
             " notifListenerDisconnects=${notifListenerDisconnects.get()}" +

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
@@ -198,9 +198,17 @@ class CaptureRedactionTest {
         val json = capturedEnvelope()
         assertFalse("leaked customer name scrubbed", json.contains("Jane D."))
         assertTrue("scrubbed node became [redacted]", json.contains("[redacted]"))
-        // Non-marker nodes on an UNKNOWN frame are untouched (only marker-bearing
-        // nodes scrub) — address/gate-code lines lack a customer lead-in prefix.
+        // Non-marker node untouched (only marker-bearing nodes scrub).
         assertTrue("non-marker node intact", json.contains("Directions"))
+        // KNOWN RESIDUAL until #806 direction 1 (recognize + redact these surfaces):
+        // a prefix scan can only own nodes that START with a customer lead-in marker.
+        // The address and gate-code lines carry no such prefix, so they persist RAW on
+        // an UNKNOWN frame by design — direction 2 (this backstop) is a best-effort net,
+        // not a full control. Recognition rules (direction 1) are the control that
+        // removes these frames from UNKNOWN entirely; pinned here so the residual is
+        // honest and a future direction-1 fix flips these assertions deliberately.
+        assertTrue("address line persists RAW (residual until #806 dir 1)", json.contains("1600 Secret Ave, Apt 4"))
+        assertTrue("gate code persists RAW (residual until #806 dir 1)", json.contains("Gate code- #4821"))
         // Counted on the #806 path, NOT the recognized-frame counter.
         assertEquals(1L, stats.unknownCustomerScrubCount)
         assertEquals(0L, stats.redactBackstopScrubCount)

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
@@ -176,16 +176,62 @@ class CaptureRedactionTest {
     }
 
     @Test
-    fun `UNKNOWN frame is not scrubbed by the recognized-frame backstop`() {
-        // The #624 backstop only guards RECOGNIZED frames; UNKNOWN frames route
-        // through the SensitiveTextMarkers drop path instead. A benign UNKNOWN
-        // marker-shaped string must not trip the recognized-frame scrub.
+    fun `UNKNOWN screen carrying a customer marker is scrubbed by the 806 backstop`() {
+        // #806: an UNKNOWN customer-bearing surface (the "Deliver to "/"Pickup for "
+        // task-detail views) that no rule recognized would otherwise persist raw
+        // customer name/address/gate-code. The customer backstop now guards the
+        // UNKNOWN screen path too (SensitiveTextMarkers only covers dasher-banking),
+        // scrubbing the offending node before the envelope hits disk.
         whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull()))
             .thenReturn("cap-1")
-        val tree = UiNode(children = listOf(UiNode(text = "Order for pickup nearby")))
+        val tree = UiNode(
+            children = listOf(
+                UiNode(text = "Pickup for Jane D."),
+                UiNode(text = "1600 Secret Ave, Apt 4"),
+                UiNode(text = "Gate code- #4821"),
+                UiNode(text = "Directions"),
+            ),
+        )
         val obs = recognizedObs(UNKNOWN_TARGET, UNKNOWN_TARGET).copy(ruleId = null)
         writer(sourceFor("x", dropoffRedact)).captureScreen(obs, screenEvent(tree))
-        assertTrue(capturedEnvelope().contains("Order for pickup nearby"))
+
+        val json = capturedEnvelope()
+        assertFalse("leaked customer name scrubbed", json.contains("Jane D."))
+        assertTrue("scrubbed node became [redacted]", json.contains("[redacted]"))
+        // Non-marker nodes on an UNKNOWN frame are untouched (only marker-bearing
+        // nodes scrub) — address/gate-code lines lack a customer lead-in prefix.
+        assertTrue("non-marker node intact", json.contains("Directions"))
+        // Counted on the #806 path, NOT the recognized-frame counter.
+        assertEquals(1L, stats.unknownCustomerScrubCount)
+        assertEquals(0L, stats.redactBackstopScrubCount)
+    }
+
+    @Test
+    fun `UNKNOWN screen Deliver to leak class is scrubbed by the 806 backstop`() {
+        // The original #806 find: unrecognized "Deliver to <name>" task-detail views.
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull()))
+            .thenReturn("cap-1")
+        val tree = UiNode(children = listOf(UiNode(text = "Deliver to Jane Q. Doe")))
+        val obs = recognizedObs(UNKNOWN_TARGET, UNKNOWN_TARGET).copy(ruleId = null)
+        writer(sourceFor("x", dropoffRedact)).captureScreen(obs, screenEvent(tree))
+
+        val json = capturedEnvelope()
+        assertFalse("leaked customer name scrubbed", json.contains("Jane Q. Doe"))
+        assertTrue("scrubbed node became [redacted]", json.contains("[redacted]"))
+        assertEquals(1L, stats.unknownCustomerScrubCount)
+    }
+
+    @Test
+    fun `a clean UNKNOWN screen with no customer marker persists unchanged`() {
+        // Fail-toward-privacy only fires on a marker hit; a benign UNKNOWN frame is
+        // untouched and never consults the redaction source (ruleId is null).
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull()))
+            .thenReturn("cap-1")
+        val tree = UiNode(children = listOf(UiNode(text = "Some benign promo")))
+        val obs = recognizedObs(UNKNOWN_TARGET, UNKNOWN_TARGET).copy(ruleId = null)
+        writer(sourceFor("x", dropoffRedact)).captureScreen(obs, screenEvent(tree))
+        assertTrue(capturedEnvelope().contains("Some benign promo"))
+        assertEquals(0L, stats.unknownCustomerScrubCount)
         assertEquals(0L, stats.redactBackstopScrubCount)
     }
 

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
@@ -11,10 +11,12 @@ import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.UNKNOWN_TARGET
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -161,5 +163,76 @@ class CaptureScrubTest {
 
         verify(captureBus, times(1)).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
         assertEquals(0L, stats.scrubbedUnknownCaptureCount)
+    }
+
+    // #806: the UNKNOWN customer-PII scrub now covers the notification and click
+    // paths too (not just screens) — an unrecognized customer-bearing push / a tap
+    // on an unrecognized "Deliver to <name>" row must not persist raw customer text.
+
+    /** The envelope JSON offered to the bus (5th positional arg of offer). */
+    private fun offeredEnvelope(): String {
+        val cap = argumentCaptor<String>()
+        verify(captureBus).offer(any(), any(), anyOrNull(), any(), cap.capture(), anyOrNull())
+        return cap.lastValue
+    }
+
+    @Test
+    fun `UNKNOWN notification with a customer marker in the title is scrubbed`() {
+        writer.captureNotification(unknownNotifObs(), rawNotif(title = "Message from Jane"))
+        val json = offeredEnvelope()
+        assertFalse("leaked customer name scrubbed", json.contains("Jane"))
+        assertTrue("field became [redacted]", json.contains("[redacted]"))
+        assertEquals(1L, stats.unknownCustomerScrubCount)
+        // The sensitive-DROP counter is untouched — this is a customer scrub, not a drop.
+        assertEquals(0L, stats.scrubbedUnknownCaptureCount)
+        assertEquals(0L, stats.notifRedactBackstopScrubCount)
+    }
+
+    @Test
+    fun `UNKNOWN notification with a customer marker in the body is scrubbed`() {
+        val raw = rawNotif(title = "New order").copy(text = "Meet at door for Jane Q Doe")
+        writer.captureNotification(unknownNotifObs(), raw)
+        val json = offeredEnvelope()
+        assertFalse("leaked customer name scrubbed", json.contains("Jane Q Doe"))
+        assertTrue("field became [redacted]", json.contains("[redacted]"))
+        assertEquals(1L, stats.unknownCustomerScrubCount)
+    }
+
+    @Test
+    fun `UNKNOWN notification with a customer marker ONLY in an action label is scrubbed`() {
+        val raw = rawNotif(title = "New order", actionLabels = listOf("Message from Bob", "Dismiss"))
+        writer.captureNotification(unknownNotifObs(), raw)
+        val json = offeredEnvelope()
+        assertFalse("leaked customer name scrubbed", json.contains("Bob"))
+        assertTrue("action label became [redacted]", json.contains("[redacted]"))
+        assertTrue("clean action label intact", json.contains("Dismiss"))
+        assertEquals(1L, stats.unknownCustomerScrubCount)
+    }
+
+    @Test
+    fun `UNKNOWN click node with a customer marker is scrubbed`() {
+        val node = UiNode(text = "Deliver to Jane D.", isClickable = true)
+        writer.captureClick(
+            unknownClickObs(),
+            PipelineEvent.Click(timestamp = 1_000L, node = node, packageName = "com.doordash.driverapp"),
+            screenTarget = null,
+        )
+        val json = offeredEnvelope()
+        assertFalse("leaked customer name scrubbed", json.contains("Jane D."))
+        assertTrue("node became [redacted]", json.contains("[redacted]"))
+        assertEquals(1L, stats.unknownCustomerScrubCount)
+        assertEquals(0L, stats.scrubbedUnknownCaptureCount)
+    }
+
+    @Test
+    fun `a benign UNKNOWN click node with no customer marker persists unchanged`() {
+        val node = UiNode(text = "Some new button", isClickable = true)
+        writer.captureClick(
+            unknownClickObs(),
+            PipelineEvent.Click(timestamp = 1_000L, node = node, packageName = "com.doordash.driverapp"),
+            screenTarget = null,
+        )
+        assertTrue(offeredEnvelope().contains("Some new button"))
+        assertEquals(0L, stats.unknownCustomerScrubCount)
     }
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkersTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkersTest.kt
@@ -34,6 +34,15 @@ class CustomerTextMarkersTest {
     }
 
     @Test
+    fun `the Pickup for task-detail marker is detected (#806)`() {
+        // The DoorDash pickup / "Current task" bottom-sheet lead-in that leaked the
+        // customer name to UNKNOWN captures; redacted on recognized captures already.
+        assertEquals("Pickup for ", CustomerTextMarkers.unredactedMarker("Pickup for Jane D."))
+        // Already-redacted form (VET V1) is skipped so a rule's own output can't re-trip.
+        assertNull(CustomerTextMarkers.unredactedMarker("Pickup for [redacted:ab12]"))
+    }
+
+    @Test
     fun `an already-redacted node is skipped (VET V1)`() {
         // The distinctness suffix form and the plain form both contain "[redacted".
         assertNull(CustomerTextMarkers.unredactedMarker("Deliver to [redacted:ab12]"))


### PR DESCRIPTION
## What

Closes the UNKNOWN-screen customer-PII blind spot from #806 (2026-07-18/07-19 desk passes): unrecognized DoorDash task-detail views ("Deliver to <name>" / "Pickup for <name>" detail + "Current task" bottom-sheet) landed in UNKNOWN captures carrying **plaintext customer name / full address / gate code**, because customer hashing lives in recognized rules' `parse`/`redact` and the `CustomerTextMarkers` backstop only guarded recognized frames + notifications. UNKNOWN screens only passed `SensitiveTextMarkers` (dasher-banking), which correctly ignores customer content.

**Fix-direction 2 only** (extend the UNKNOWN-screen scrub), plus the marker add:

1. **`"Pickup for "` added to the `CustomerTextMarkers` cross-platform SSOT** (it already carried "Deliver to "/"Order for "/"Message from " etc.). No collision with existing markers (`startsWith`, none is a prefix of another) or with `SensitiveTextMarkers` (substring set — none contains "Pickup for "). Corpus false-positive guard (`CaptureBackstopCorpusTest`) stays green: the only committed "Pickup for" text is already `[redacted]` (VET V1 skip).
2. **The `CustomerTextMarkers` backstop now runs on the UNKNOWN screen, notification, AND click envelopes** (`CaptureWriter.captureScreen`/`captureNotification`/`captureClick`). Previously the customer-scrub was gated to `obs.target != UNKNOWN_TARGET` on the screen + notification paths and absent entirely from clicks; it's now unified over both frame classes on all three (the notif scan covers all 5 flat text fields via `RawNotificationData.textFields()` + `actionLabels`, #666). The `SensitiveTextMarkers` drop check still runs FIRST (a sensitive UNKNOWN frame is still dropped whole; customer-marker frames are scrubbed node/field-wise, not dropped). Recognized paths are byte-identical (rule-matched clicks are app-vocabulary buttons, so only UNKNOWN clicks are scanned); the dedup contentHash stays on the ORIGINAL node/raw. FrameGate dedup unchanged.

**Residual (honest):** direction 2 is a prefix scan — it masks only nodes/fields that START with a customer lead-in marker. On an UNKNOWN frame the address and gate-code lines carry no such prefix and therefore **persist raw** until the surfaces are recognized (fix-direction 1). This residual is pinned by explicit assertions in the new UNKNOWN screen test and documented in CLAUDE.md.
3. **New `PipelineStats.onUnknownCustomerScrub()` counter** (`unknownCustomerScrubCount`, in the summary line) — distinct from `scrubbedUnknownCaptures` (sensitive DROP) and `redactBackstopScrubs` (recognized-frame scrub), so the three privacy events stay observable apart.

### Deferred: fix-direction 1 (recognition rules)

The issue's preferred direction 1 — recognizing + redacting the "Deliver to "/"Pickup for " task-detail / "Current task" bottom-sheet surfaces so they leave UNKNOWN entirely — is **deferred to a next-dash recapture**. The original receipt fixtures were purged from the device + pull per the standing PII procedure, and the surface is trivially re-capturable, so writing rules now would be guesswork with no corpus to gate them. Direction 2 (this PR) is the durable backstop that also covers the #803 family and any future unrecognized customer surface; direction 1 remains open on #806 as the follow-up that removes these frames from UNKNOWN.

## Tests

- `CustomerTextMarkersTest` — new `Pickup for ` detection + VET V1 already-redacted skip.
- `CaptureRedactionTest` — new: (a) UNKNOWN screen with `Pickup for Jane D.` scrubs the node (counted on the #806 path, not the recognized counter); (b) UNKNOWN `Deliver to` leak-class scrubbed; (c) clean UNKNOWN persists unchanged + never consults the redaction source. The pre-existing "UNKNOWN frame is not scrubbed by the recognized-frame backstop" test (which asserted a marker-shaped UNKNOWN string was preserved) was rewritten — that premise is exactly what #806 inverts.
- Recognized-path behavior unchanged: existing `CaptureRedactionTest` recognized cases + `CaptureBackstopCorpusTest` (zero corpus false positives with the new marker) stay green.
- `./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` — green. `./gradlew testDebugUnitTest :domain:test` — green (916 app tests). No rule JSON / corpus / parse-golden change (verified: `approved-parse-output.json` untouched).

## Security / privacy posture (Pledge surface)

- **What's scrubbed:** on an UNKNOWN screen envelope, any node whose `text`/`contentDescription` starts with a customer-PII marker prefix is masked to `[redacted]` **before the envelope reaches the CaptureBus / disk**. This is a strict widening of scrub coverage — no path that previously scrubbed now stops.
- **Fail-closed direction:** the scan fails **toward privacy** — a benign marker-shaped string is scrubbed too (losing triage-useful text is the accepted cost, per the issue). The scrub runs on a hit only (clean UNKNOWN frames are byte-identical to before). Sensitive (dasher-banking) UNKNOWN frames are still **dropped whole** by `SensitiveTextMarkers`, evaluated first — stronger control wins.
- **What's untrusted / bounded:** input is the third-party accessibility tree. No new ingestion surface; the scan reuses the existing `allText` walk (no new traversal) and the copy is built only on a hit.
- **No PII in logs (Principle 7):** the WARN logs the **marker prefix constant only** ("Pickup for "), never the leaked value. Level is WARN (a defended invariant fired); one WARN at most per admitted UNKNOWN frame — FrameGate's UNKNOWN suppressor already dedups upstream, so no storm. While here, CaptureWriter's six INFO+ Timber sites were **tagged** (`Timber.tag("Pipeline")`) and the file **removed from the `timber-tag-guard-allowlist`** (debt burned to 0, per the ratchet).

### Design-goal review

- **6 (Security & privacy):** primary intent — widens customer-PII scrub to the UNKNOWN screen path, fail-toward-privacy, edge scrub before persistence. Sensitive-drop precedence preserved.
- **7 (Semantic, PII-safe logging):** WARN level for a defended invariant; marker-prefix only, no raw PII; per-frame bounded. CaptureWriter tagged + burned off the allowlist.
- **8 (Platform-agnostic core):** markers stay cross-platform DATA in the one `CustomerTextMarkers` SSOT — no platform literal added to logic; the new `Pickup for ` entry sits beside the existing DoorDash/Uber vocabulary.
- **5 (SSOT):** one marker list drives recognized-frame, notification, and now UNKNOWN-screen scrubs; new counter is a single owner for the new event class.
- **1/3 (UDF / single responsibility):** scrub stays at the capture edge (`CaptureWriter`), reducers untouched; the customer-scrub block is unified rather than duplicated across the two frame classes.

### Adversarial review

_(fable adversarial review block to be posted by the coordinator; APPROVE-WITH-FIXES, all three findings applied in this branch: F1 extend scrub to UNKNOWN notification + click paths; F2 codify the prefix-less address/gate-code residual with explicit test assertions + PR/CLAUDE.md note; F3 fix stale `CustomerTextMarkers` docs in CLAUDE.md + CaptureBackstopCorpusTest comment.)_
