### PR TITLE
fix(rules): #801 — delivery_summary_collapsed 0.230.0 parse variant

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
@@ -263,10 +263,12 @@ class ParseOutputGoldenTest {
     @Test
     fun `dedupeKey templates reference fields the rule actually parses`() {
         val template = Regex("\\{(\\w+)}")
-        // (ruleId, field) → did ANY corpus match of that rule parse it non-null?
-        // Unsubstituted braces surviving in a matched effect's dedupeKey mean
-        // the field was null on THAT match; only never-non-null-anywhere is a
-        // violation (a sometimes-null field is legitimate).
+        // dedupeKeys are scanned POST-resolution, so a `{field}` token only
+        // reaches `template.findAll` on a frame where that field parsed null (it
+        // survived interpolation). A frame that parsed the field non-null resolved
+        // its key and registers nothing. So the effective bar here is "null on ≥1
+        // frame" — a (ruleId, field) lands in `dead` iff SOME corpus frame left its
+        // token unresolved (matching [knownDeadDedupeTemplates]'s KDoc).
         val seen = mutableMapOf<Pair<String, String>, Boolean>()
         val exampleKey = mutableMapOf<Pair<String, String>, String>()
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
@@ -236,9 +236,20 @@ class ParseOutputGoldenTest {
      *   the extractor regressed. The expanded key still differentiates per
      *   delivery via its `{totalPay}` half, so dedupe works; clean up the dead
      *   half when the summary rules are next touched.
-     * - `delivery_summary_collapsed:totalPay` — the mirror image: collapsed
-     *   receipts parse sessionEarnings but never the per-delivery totalPay
-     *   (it's behind the expand); the `{sessionEarnings}` half differentiates.
+     * - `delivery_summary_collapsed:totalPay` — dedupeKeys are scanned
+     *   POST-resolution here, so a `{field}` token only reaches this lint on a
+     *   frame where the field parsed null (it survived interpolation). Most
+     *   collapsed cards DO parse `totalPay` (it resolves and never registers),
+     *   but two expand-only corpus frames render no `final_value`, so their
+     *   `delivery-ss-collapsed-{totalPay}` survives and pins this entry. The
+     *   `{totalPay}` parse is NOT dead — do not delete it; this mirrors the
+     *   same-key entry in [knownDeadArgTemplates]. (#801: 0.230.0 also dropped
+     *   the `earnings_ticker` id, so the collapsed dedupeKey was retired from
+     *   `{totalPay}-{sessionEarnings}` to `{totalPay}` — keeping the
+     *   `{sessionEarnings}` half would have made the new 0.230.0 frames, which
+     *   parse `sessionEarnings` null, register a *new* dead
+     *   `collapsed:sessionEarnings` entry; dropping it is what keeps this set
+     *   unchanged.)
      * (The third original entry, `offer_popup:offerHash`, was the #427 bug —
      * fixed by the reserved `{parsedHash}` token, resolved post-factory by the
      * classifier via [DedupeTokens].)

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/ActuationBindingResolutionTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/ActuationBindingResolutionTest.kt
@@ -198,8 +198,12 @@ class ActuationBindingResolutionTest {
 
             // The independently-computed expected target: the sole expandable_view whose
             // subtree does NOT carry the stats section's stable 'Total online time' row.
+            // Suffix-match the id (not exact-equality): corpus fixtures mix suffix-form
+            // ids (legacy captures) with full-form `com.doordash.driverapp:id/expandable_view`
+            // (modern envelope captures), and recognition itself keys on `hasIdSuffix`.
             val payNode = node.findNodes {
-                it.viewIdResourceName == "expandable_view" && !subtreeHasText(it, "Total online time")
+                it.viewIdResourceName?.endsWith("expandable_view") == true &&
+                    !subtreeHasText(it, "Total online time")
             }.singleOrNull()
             assertNotNull("$filename: exactly one pay-section expandable_view must exist", payNode)
 

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -850,6 +850,38 @@
         "shape": null,
         "fields": {}
     },
+    "delivery_summary_collapsed/2026-07-17_19-54-53-408__doordash__accessibility.window__delivery_summary_collapsed__692508.json": {
+        "ruleId": "doordash.screen.delivery_summary_collapsed",
+        "intent": "delivery_summary_collapsed",
+        "shape": "post_task",
+        "fields": {
+            "appPay": null,
+            "customerTips": null,
+            "expandButtonId": "expandable_view",
+            "isExpanded": false,
+            "offersAccepted": null,
+            "offersTotal": null,
+            "parsedPay": null,
+            "sessionEarnings": null,
+            "totalPay": 17.72
+        }
+    },
+    "delivery_summary_collapsed/2026-07-17_21-01-53-772__doordash__accessibility.window__delivery_summary_collapsed__4d9ab2.json": {
+        "ruleId": "doordash.screen.delivery_summary_collapsed",
+        "intent": "delivery_summary_collapsed",
+        "shape": "post_task",
+        "fields": {
+            "appPay": null,
+            "customerTips": null,
+            "expandButtonId": "expandable_view",
+            "isExpanded": false,
+            "offersAccepted": null,
+            "offersTotal": null,
+            "parsedPay": null,
+            "sessionEarnings": null,
+            "totalPay": 13.45
+        }
+    },
     "delivery_summary_collapsed/20260128_163015_182_DELIVERY_SUMMARY_COLLAPSED.json": {
         "ruleId": "doordash.screen.delivery_summary_collapsed",
         "intent": "delivery_summary_collapsed",

--- a/app/src/test/resources/snapshots/delivery_summary_collapsed/2026-07-17_19-54-53-408__doordash__accessibility.window__delivery_summary_collapsed__692508.json
+++ b/app/src/test/resources/snapshots/delivery_summary_collapsed/2026-07-17_19-54-53-408__doordash__accessibility.window__delivery_summary_collapsed__692508.json
@@ -1,0 +1,785 @@
+{
+    "captureId": "20df4daf-3d4f-4103-8f17-a09a4ab31989",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784336093384,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.delivery_summary_collapsed",
+    "classificationName": "delivery_summary_collapsed",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2368,
+                    "right": 1080,
+                    "bottom": 4715
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 2504,
+                            "right": 1080,
+                            "bottom": 4715
+                        },
+                        "children": [
+                            {
+                                "id": "action_bar_root",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 2504,
+                                    "right": 1080,
+                                    "bottom": 4715
+                                },
+                                "children": [
+                                    {
+                                        "id": "content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2504,
+                                            "right": 1080,
+                                            "bottom": 4715
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "layout_bottom_sheet",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 2504,
+                                                    "right": 1080,
+                                                    "bottom": 4715
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "overlay_view",
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2504,
+                                                            "right": 1080,
+                                                            "bottom": 4715
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "prism_sheet",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 3991,
+                                                            "right": 1080,
+                                                            "bottom": 4715
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "prism_sheet_collar_view",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 3991,
+                                                                    "right": 1080,
+                                                                    "bottom": 4027
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "handle_overlay",
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 3991,
+                                                                            "right": 1080,
+                                                                            "bottom": 4027
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "handle_overlay_image",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 4009,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4018
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "id": "prism_sheet_content_parent_container",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4027,
+                                                                    "right": 1080,
+                                                                    "bottom": 4679
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "nested_scroll_view",
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 4027,
+                                                                            "right": 1080,
+                                                                            "bottom": 4679
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "prism_content_container",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 4027,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4536
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "bottomsheet_content_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 4027,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 4536
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "recycler",
+                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 4027,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 4536
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 4027,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 4249
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 4063,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 4222
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "This dash so far",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 4063,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 4121
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 4148,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 4222
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 4148,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 4222
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 402,
+                                                                                                                                            "top": 4148,
+                                                                                                                                            "right": 508,
+                                                                                                                                            "bottom": 4222
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "$",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 433,
+                                                                                                                                                    "top": 4148,
+                                                                                                                                                    "right": 477,
+                                                                                                                                                    "bottom": 4214
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 439,
+                                                                                                                                            "top": 4148,
+                                                                                                                                            "right": 545,
+                                                                                                                                            "bottom": 4222
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "1",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 477,
+                                                                                                                                                    "top": 4148,
+                                                                                                                                                    "right": 507,
+                                                                                                                                                    "bottom": 4214
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 473,
+                                                                                                                                            "top": 4148,
+                                                                                                                                            "right": 580,
+                                                                                                                                            "bottom": 4222
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "7",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 507,
+                                                                                                                                                    "top": 4148,
+                                                                                                                                                    "right": 546,
+                                                                                                                                                    "bottom": 4214
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 502,
+                                                                                                                                            "top": 4148,
+                                                                                                                                            "right": 609,
+                                                                                                                                            "bottom": 4222
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": ".",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 546,
+                                                                                                                                                    "top": 4148,
+                                                                                                                                                    "right": 565,
+                                                                                                                                                    "bottom": 4214
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 531,
+                                                                                                                                            "top": 4148,
+                                                                                                                                            "right": 638,
+                                                                                                                                            "bottom": 4222
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "7",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 565,
+                                                                                                                                                    "top": 4148,
+                                                                                                                                                    "right": 604,
+                                                                                                                                                    "bottom": 4214
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 573,
+                                                                                                                                            "top": 4148,
+                                                                                                                                            "right": 679,
+                                                                                                                                            "bottom": 4222
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "5",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 604,
+                                                                                                                                                    "top": 4148,
+                                                                                                                                                    "right": 648,
+                                                                                                                                                    "bottom": 4214
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 4249,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 4473
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 4276,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 4473
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 38,
+                                                                                                                            "top": 4278,
+                                                                                                                            "right": 1042,
+                                                                                                                            "bottom": 4471
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 38,
+                                                                                                                                    "top": 4314,
+                                                                                                                                    "right": 1042,
+                                                                                                                                    "bottom": 4435
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 38,
+                                                                                                                                            "top": 4314,
+                                                                                                                                            "right": 1042,
+                                                                                                                                            "bottom": 4361
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "leading_icon",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 74,
+                                                                                                                                                    "top": 4320,
+                                                                                                                                                    "right": 110,
+                                                                                                                                                    "bottom": 4356
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Total online time",
+                                                                                                                                                "id": "name",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 146,
+                                                                                                                                                    "top": 4314,
+                                                                                                                                                    "right": 446,
+                                                                                                                                                    "bottom": 4361
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "1 hr 46 min",
+                                                                                                                                                "id": "value",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 806,
+                                                                                                                                                    "top": 1946,
+                                                                                                                                                    "right": 1006,
+                                                                                                                                                    "bottom": 1993
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 38,
+                                                                                                                                            "top": 4388,
+                                                                                                                                            "right": 1042,
+                                                                                                                                            "bottom": 4435
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "leading_icon",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 74,
+                                                                                                                                                    "top": 2026,
+                                                                                                                                                    "right": 110,
+                                                                                                                                                    "bottom": 2062
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Offers accepted",
+                                                                                                                                                "id": "name",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 146,
+                                                                                                                                                    "top": 4388,
+                                                                                                                                                    "right": 438,
+                                                                                                                                                    "bottom": 4435
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "2 out of 2",
+                                                                                                                                                "id": "value",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 830,
+                                                                                                                                                    "top": 2020,
+                                                                                                                                                    "right": 1006,
+                                                                                                                                                    "bottom": 2067
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 4473,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 4536
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 4500,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 4500
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "root_container",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 4500,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 4500
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "earnings_container",
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 4500,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 4500
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "section_title_container",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 72,
+                                                                                                                                            "top": 4500,
+                                                                                                                                            "right": 240,
+                                                                                                                                            "bottom": 4536
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "This offer",
+                                                                                                                                                "id": "section_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 72,
+                                                                                                                                                    "top": 4500,
+                                                                                                                                                    "right": 240,
+                                                                                                                                                    "bottom": 4536
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "primary_icon",
+                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 240,
+                                                                                                                                            "top": 4500,
+                                                                                                                                            "right": 294,
+                                                                                                                                            "bottom": 4533
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "$17.72",
+                                                                                                                                        "id": "final_value",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 896,
+                                                                                                                                            "top": 4500,
+                                                                                                                                            "right": 1008,
+                                                                                                                                            "bottom": 4536
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "expandable_view",
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 4500,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 4619
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 4500,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 4619
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "prism_sheet_footer_divider",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4532,
+                                                            "right": 1080,
+                                                            "bottom": 4536
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "prism_sheet_footer_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4536,
+                                                            "right": 1080,
+                                                            "bottom": 4715
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "content",
+                                                                "class": "android.widget.LinearLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 2168,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.LinearLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2168,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 36,
+                                                                                    "top": 4572,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 4679
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.widget.Button",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 4572,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 4679
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Continue dashing",
+                                                                                                "id": "textView_prism_button_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 360,
+                                                                                                    "top": 4593,
+                                                                                                    "right": 720,
+                                                                                                    "bottom": 4659
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2347,
+                    "right": 1080,
+                    "bottom": 2400
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/delivery_summary_collapsed/2026-07-17_21-01-53-772__doordash__accessibility.window__delivery_summary_collapsed__4d9ab2.json
+++ b/app/src/test/resources/snapshots/delivery_summary_collapsed/2026-07-17_21-01-53-772__doordash__accessibility.window__delivery_summary_collapsed__4d9ab2.json
@@ -1,0 +1,807 @@
+{
+    "captureId": "da02c76a-67c9-4669-a25c-af0aba8d798a",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784340113750,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.delivery_summary_collapsed",
+    "classificationName": "delivery_summary_collapsed",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2365,
+                    "right": 1080,
+                    "bottom": 4712
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "action_bar_root",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 2501,
+                                    "right": 1080,
+                                    "bottom": 4712
+                                },
+                                "children": [
+                                    {
+                                        "id": "content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2501,
+                                            "right": 1080,
+                                            "bottom": 4712
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "layout_bottom_sheet",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 2501,
+                                                    "right": 1080,
+                                                    "bottom": 4712
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "overlay_view",
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "prism_sheet",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 3988,
+                                                            "right": 1080,
+                                                            "bottom": 4712
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "prism_sheet_collar_view",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 3988,
+                                                                    "right": 1080,
+                                                                    "bottom": 4024
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "handle_overlay",
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 3988,
+                                                                            "right": 1080,
+                                                                            "bottom": 4024
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "handle_overlay_image",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 4006,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4015
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "id": "prism_sheet_content_parent_container",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 1659,
+                                                                    "right": 1080,
+                                                                    "bottom": 2311
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "nested_scroll_view",
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 1659,
+                                                                            "right": 1080,
+                                                                            "bottom": 2311
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "prism_content_container",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 4024,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4533
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "bottomsheet_content_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 4024,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 4533
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "recycler",
+                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 4024,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 4533
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1659,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 1881
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 4057,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 4216
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "This dash so far",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 4052,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 4110
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 4131,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 4205
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 4125,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 4199
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 399,
+                                                                                                                                            "top": 1751,
+                                                                                                                                            "right": 505,
+                                                                                                                                            "bottom": 1825
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "$",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 428,
+                                                                                                                                                    "top": 4105,
+                                                                                                                                                    "right": 472,
+                                                                                                                                                    "bottom": 4171
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 443,
+                                                                                                                                            "top": 1724,
+                                                                                                                                            "right": 538,
+                                                                                                                                            "bottom": 1798
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "0",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 468,
+                                                                                                                                                    "top": 1699,
+                                                                                                                                                    "right": 487,
+                                                                                                                                                    "bottom": 1753
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "1",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 477,
+                                                                                                                                                    "top": 1720,
+                                                                                                                                                    "right": 489,
+                                                                                                                                                    "bottom": 1766
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 464,
+                                                                                                                                            "top": 1686,
+                                                                                                                                            "right": 570,
+                                                                                                                                            "bottom": 1760
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "6",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 497,
+                                                                                                                                                    "top": 1678,
+                                                                                                                                                    "right": 541,
+                                                                                                                                                    "bottom": 1693
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 504,
+                                                                                                                                            "top": 1675,
+                                                                                                                                            "right": 571,
+                                                                                                                                            "bottom": 1749
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": ".",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 549,
+                                                                                                                                                    "top": 1673,
+                                                                                                                                                    "right": 568,
+                                                                                                                                                    "bottom": 1739
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 541,
+                                                                                                                                            "top": 1671,
+                                                                                                                                            "right": 647,
+                                                                                                                                            "bottom": 1745
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "6",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 569,
+                                                                                                                                                    "top": 1666,
+                                                                                                                                                    "right": 613,
+                                                                                                                                                    "bottom": 1681
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 591,
+                                                                                                                                            "top": 1666,
+                                                                                                                                            "right": 697,
+                                                                                                                                            "bottom": 1740
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "0",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 618,
+                                                                                                                                                    "top": 1665,
+                                                                                                                                                    "right": 668,
+                                                                                                                                                    "bottom": 1697
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "3",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 622,
+                                                                                                                                                    "top": 1664,
+                                                                                                                                                    "right": 664,
+                                                                                                                                                    "bottom": 1719
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1764,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 1988
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 1791,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 1988
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 38,
+                                                                                                                            "top": 1792,
+                                                                                                                            "right": 1042,
+                                                                                                                            "bottom": 1985
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 38,
+                                                                                                                                    "top": 1828,
+                                                                                                                                    "right": 1042,
+                                                                                                                                    "bottom": 1949
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 38,
+                                                                                                                                            "top": 1828,
+                                                                                                                                            "right": 1042,
+                                                                                                                                            "bottom": 1875
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "leading_icon",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 74,
+                                                                                                                                                    "top": 1834,
+                                                                                                                                                    "right": 110,
+                                                                                                                                                    "bottom": 1870
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Total online time",
+                                                                                                                                                "id": "name",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 146,
+                                                                                                                                                    "top": 1828,
+                                                                                                                                                    "right": 446,
+                                                                                                                                                    "bottom": 1875
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": " 33 min",
+                                                                                                                                                "id": "value",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 872,
+                                                                                                                                                    "top": 1828,
+                                                                                                                                                    "right": 1006,
+                                                                                                                                                    "bottom": 1875
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 38,
+                                                                                                                                            "top": 1902,
+                                                                                                                                            "right": 1042,
+                                                                                                                                            "bottom": 1949
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "leading_icon",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 74,
+                                                                                                                                                    "top": 1908,
+                                                                                                                                                    "right": 110,
+                                                                                                                                                    "bottom": 1944
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Offers accepted",
+                                                                                                                                                "id": "name",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 146,
+                                                                                                                                                    "top": 1902,
+                                                                                                                                                    "right": 438,
+                                                                                                                                                    "bottom": 1949
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "1 out of 4",
+                                                                                                                                                "id": "value",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 836,
+                                                                                                                                                    "top": 1902,
+                                                                                                                                                    "right": 1006,
+                                                                                                                                                    "bottom": 1949
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1987,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2168
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 2014,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 2132
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "root_container",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 2014,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 2132
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "earnings_container",
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 2014,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 2132
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "section_title_container",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 72,
+                                                                                                                                            "top": 2050,
+                                                                                                                                            "right": 240,
+                                                                                                                                            "bottom": 2097
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "This offer",
+                                                                                                                                                "id": "section_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 72,
+                                                                                                                                                    "top": 2050,
+                                                                                                                                                    "right": 240,
+                                                                                                                                                    "bottom": 2097
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "primary_icon",
+                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 240,
+                                                                                                                                            "top": 2047,
+                                                                                                                                            "right": 294,
+                                                                                                                                            "bottom": 2101
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "$13.45",
+                                                                                                                                        "id": "final_value",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 887,
+                                                                                                                                            "top": 2050,
+                                                                                                                                            "right": 1008,
+                                                                                                                                            "bottom": 2097
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "expandable_view",
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 2133,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 2132
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 2133,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 2132
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "prism_sheet_footer_divider",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2164,
+                                                            "right": 1080,
+                                                            "bottom": 2168
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "prism_sheet_footer_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2168,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "content",
+                                                                "class": "android.widget.LinearLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 2168,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.LinearLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2168,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 36,
+                                                                                    "top": 2204,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 2311
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.widget.Button",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 2204,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Continue dashing",
+                                                                                                "id": "textView_prism_button_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 360,
+                                                                                                    "top": 2225,
+                                                                                                    "right": 720,
+                                                                                                    "bottom": 2291
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2347,
+                    "right": 1080,
+                    "bottom": 2400
+                }
+            }
+        ]
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,13 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — #801 / PR #817 — bubble session-earnings freshness on 0.230.0.** The collapsed receipt
+  no longer refreshes session `runningEarnings` (the 0.230.0 digit-wheel is unparseable); the figure now
+  rides the dash-control "This dash" label parse alone. After a delivery on 0.230.0, verify the bubble's
+  session-earnings figure still updates post-receipt; watch for a stale figure. Desk-side:
+  `sessionEarnings=null` on collapsed parses is EXPECTED on 0.230.0; the dash-control parse lines are the
+  live source.
+  - Confirmed: 0/2
 - **🆕 NEW — Capability consent surface: honest copy + revoke aborts automation to manual (#422 PR 3).**
   Settings → Data & Privacy → **Automation & Consent** now lists, per bundled ruleset source, every
   automation tap the rules enable (Accept, Decline, Confirm a decline, Open the pay breakdown) with a

--- a/matchers/rules/doordash/dropoff.json5
+++ b/matchers/rules/doordash/dropoff.json5
@@ -1175,6 +1175,18 @@
               }
             ]
           },
+          // #801: the "This dash so far" session total. Pre-0.230.0 this was a single
+          // settled TextView with a stable `earnings_ticker` id; DoorDash 0.230.0 dropped
+          // that id and now renders the total as an id-less ANIMATED digit-wheel ("$",
+          // "1","7",".","7","5" as separate nodes under an id=None container). Captures land
+          // mid-animation — the 07-17 corpus frames read "$0.00" and a doubled-digit
+          // "$016.603" for the same wheel — so the digits do NOT reliably reconstruct the
+          // value. NOT broadened onto that ticker (an unreliable read is worse than null);
+          // the id-anchored find below simply returns null on 0.230.0 (graceful — the field
+          // is already optional) while still parsing older-version replays. The dead
+          // `{sessionEarnings}` dedupe half was retired below in favour of `{totalPay}`,
+          // which 0.230.0 DOES render (the `final_value` id survives). See ParseOutputGoldenTest
+          // dedupeKey lint (the #427/#606 dead-template class).
           "sessionEarnings": {
             "find": {
               "hasIdSuffix": "earnings_ticker"
@@ -1218,7 +1230,7 @@
             "prefix": "Delivery - {totalPay}",
             "category": "delivery_summary"
           },
-          "dedupeKey": "delivery-ss-collapsed-{totalPay}-{sessionEarnings}",
+          "dedupeKey": "delivery-ss-collapsed-{totalPay}",
           "throttleMs": 60000
         }
       ]


### PR DESCRIPTION
Fixes #801.

## Problem

Two `delivery_summary_collapsed` captures from the 07-17 dash (DoorDash **appVersion 0.230.0**) parse `sessionEarnings = null`. The whole 07/18 pull is 0.230.0, and **none** of its collapsed frames carry the `earnings_ticker` id the rule anchored on. Folding a frame with the old dedupeKey `delivery-ss-collapsed-{totalPay}-{sessionEarnings}` would register a **new dead dedupe** (`collapsed:sessionEarnings`), the #427/#606 class the `ParseOutputGoldenTest` dedupeKey lint guards.

## Decision: genuinely dropped (retire the dead half), NOT broaden — node-tree evidence

Pre-0.230.0 the "This dash so far" session total was a single settled `TextView` with a stable `earnings_ticker` id. **0.230.0 dropped that id** and now renders the total as an **id-less animated digit-wheel** — each glyph is its own `TextView` (`"$" "1" "7" "." "7" "5"`) under an `id=None` container, with no anchor. It is an animated count-up, so captures land mid-animation and the digits do **not** reliably reconstruct the value:

| Frame | digit-wheel nodes | reconstructs to |
|---|---|---|
| `…692508` (07-17, $17.72 offer) | `$ 1 7 . 7 5` | "$17.75" (looks settled) |
| `…4d9ab2` (07-17, $13.45 offer) | `$ [0 1] 6 . [6] [0 3]` | garbage — doubled digits mid-roll |
| `…20a8cb` (07-17, $19.50 offer; identical-hash sibling also seen 07-08) | `$ 0 . 0 0` | "$0.00" — count-up not started |

So broadening the parse onto that wheel would produce **$0.00 / garbage**, worse than null. The rule's id-anchored `sessionEarnings` find is left in place (returns null on 0.230.0 — already optional; still parses older-version replays), and the **dead `{sessionEarnings}` half is retired from the dedupeKey → `delivery-ss-collapsed-{totalPay}`**. `totalPay` (the `final_value` id) **survives** in 0.230.0 (present on both new frames: 17.72 / 13.45), so it is the live differentiator.

## Why the dedupeKey lint ratchet is unchanged (not "fixed one, remove it")

`ParseOutputGoldenTest` scans dedupeKeys **post-resolution**, so a `{field}` token only reaches the lint on a frame where that field parsed **null** (the token survived interpolation). `collapsed:totalPay` stays dead there because **two legacy expand-only corpus frames** (`…173245_145/_150`) render no `final_value` — their `{totalPay}` survives. The new frames parse `totalPay` non-null, so their key fully resolves and never registers. Net: the `dead` set is **byte-identical to baseline** `{expanded:sessionEarnings, collapsed:totalPay}`. Retiring `{sessionEarnings}` from the dedupeKey is precisely what stops the **new** `collapsed:sessionEarnings` dead entry the new (sessionEarnings-null) frames would otherwise create. The test change is **documentation-only** — the ratchet `setOf(...)` is unchanged; only the KDoc **and** the matching inline comment were corrected (the old note claimed collapsed "never parses totalPay", which was already false — 11/13 frames parse it; it's null only on the 2 no-`final_value` frames — and the inline comment said "only never-non-null-anywhere is a violation", which contradicts the post-resolution scan; both now agree on "null on ≥1 frame").

**Deliberate deferral (filed as #819):** the mirror **expanded** rule's dedupeKey (`dropoff.json5:1107`) still carries its own dead `{sessionEarnings}` half. It's already pinned in `knownDeadDedupeTemplates`; left untouched here to keep this PR additions-only. Retiring it (and shrinking the ratchet) is tracked in **#819**.

## Corpus + golden

- Added the two 07-17 frames (`…692508`, `…4d9ab2`) via the Inbox workflow (sorted into `delivery_summary_collapsed/`, committed from the category folder, never from INBOX). The third 07-17 collapsed frame (`…20a8cb`) is **not** included: it is content-hash-identical to an uncommitted 07-08 pull sibling (neither is in the corpus — no collapsed `20a8cb` exists there), and it only captures the count-up's `$0.00` start; `4d9ab2`'s doubled-digit `$016.603` already carries the unreliability proof, so `20a8cb` adds no distinct coverage.
- **Golden diff is additions-only**: two new entries, each `totalPay` non-null / `sessionEarnings` null / `isExpanded` false / `expandButtonId` `expandable_view`. No existing entry changed. (The dedupeKey/effects are not part of the parse-output golden, so the template change itself produces no golden diff.)
- **Fixture id normalization (data-only) + the brittle-test fix:** raw 0.230.0 captures carry full-form ids (`com.doordash.driverapp:id/…`); the entire `delivery_summary_collapsed/` folder is legacy **suffix-form**, and `ActuationBindingResolutionTest` (#734) matched expandable ids by **exact equality** (`viewIdResourceName == "expandable_view"`), which only works on suffix-form. Two changes: (1) the two new fixtures' ids are stripped to suffix-form (behaviour-preserving — recognition/bind use `hasIdSuffix`), keeping the folder internally consistent; (2) the reviewer-sanctioned one-line test fix makes that assertion **suffix-aware** (`viewIdResourceName?.endsWith("expandable_view")`), so the next full-form capture added to this folder no longer mysteriously reds the suite. The 0.230.0 bind is in fact **correct**: the single `expandable_view` sits inside `earnings_container` after `final_value` (the pay section), with no stats-section expandable to confuse it.

## PII sweep attestation

Manually walked **every** text field (generic key walk — the model key is `text`; no `desc`/`contentDescription` present) on both fixtures. Content is exclusively: session-stats copy ("This dash so far" / "Total online time" / "Offers accepted"), the digit-wheel glyphs, the offer total ("$17.72" / "$13.45"), and "Continue dashing". **No** customer names (incl. `Firstname I.` / `For <Name>` shapes), addresses, gate codes, PINs, or dasher banking. No redaction required. (InboxProcessor's PII gate also passed.)

## Tests

- `./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` — green.
- `./gradlew testDebugUnitTest :domain:test` — green (full app + all module suites).
- Post-review re-run: `--tests "*AllMatchersSuite*" --tests "*ParseOutputGoldenTest*" --tests "*ActuationBindingResolutionTest*"` — green.

## Design-goal review

- **#8 Platform-agnostic core.** Recognition stays **data** — only rule JSON (`dropoff.json5`) + corpus changed; no Kotlin recognition/logic change, no platform literal. Vocabulary/fields unchanged. The two test-file edits are a KDoc/inline-comment correction and a one-line suffix-aware id match — no production logic.
- **#5 SSOT.** `totalPay` is the single live differentiator; the dead `{sessionEarnings}` half is removed rather than left to rot. No duplicated copy introduced.
- **#6 Security & privacy.** Recognition unaffected (require/reject/redact untouched — the frame still recognizes as `delivery_summary_collapsed`). Two new **capture fixtures**: manual generic-key PII sweep clean, no customer/dasher-sensitive content, no redaction needed; nothing new is parsed or stored.
- **#7 Logging.** No log sites touched.

## Adversarial review

Fable adversarial review returned **APPROVE-WITH-FIXES**; all fixes applied in-branch: field-test checklist item added (`docs/field-testing/README.md`), inline comment aligned with the corrected KDoc, `ActuationBindingResolutionTest` id match made suffix-aware, PR-body corrections (the `20a8cb` narrative + this deferral note), and the expanded-rule dead-half deferral filed as **#819**. Not merging in this PR.
