### PR TITLE
state: #810 B1 — JOB_ACCEPT_MISMATCH close-reconciliation tripwire

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/AcceptMismatchReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/AcceptMismatchReplayTest.kt
@@ -1,0 +1,132 @@
+package cloud.trotter.dashbuddy.replay
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.JobAcceptMismatchPayload
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
+import cloud.trotter.dashbuddy.test.util.SessionReplay
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #810 B1 — end-to-end Level-B replay of the **seq-114 invisible-unassign** shape, driving TWO
+ * accepted offers folded into ONE job (only the second delivered) through the REAL
+ * [cloud.trotter.dashbuddy.core.state.StateMachine] + [cloud.trotter.dashbuddy.core.state.EffectMap],
+ * and asserting exactly ONE `JOB_ACCEPT_MISMATCH` fires at the job close — while the delivered drop
+ * still folds normally.
+ *
+ * **Why a reconstruction (the #700 precedent).** The fielded seq-114 unassign committed through a
+ * support-chat path that rendered NO confirmation screen or click (Finding 1 in the #810 design), so
+ * there is no capturable dasher-side commit frame — a faithful full-device replay is impossible by
+ * construction. This test therefore reuses the real, already-PII-swept
+ * `single_delivery_2026_06_16` fixture as the DELIVERED order (order B) and adds explicitly-labelled
+ * SYNTHETIC injections for the invisibly-abandoned first order (order A) and for the one arrival frame
+ * the delivered order's own capture suppressed:
+ *  - order A's offer + accept (a mid-pickup add-on that folds into the job via the REAL
+ *    `consumeAcceptIntoJob`/`appendAddOn`, giving the job two `acceptedOffers` and a second dropoff
+ *    placeholder that is NEVER activated — the seq-114 corpse `121`). A is never unassigned (the
+ *    invisible-unassign class emits no `TASK_UNASSIGNED`);
+ *  - order B's dropoff ARRIVAL, carrying frame 06's OWN real parsed fields re-stamped as arrived — the
+ *    single_delivery capture completed B via a grace retire with no `DELIVERY_ARRIVED` frame on disk
+ *    (the arrival fell to UNKNOWN / was deduped, the same suppression #700 documents), so `arrivedAt`
+ *    needs this stand-in to make B a fully-delivered, accounted drop.
+ *
+ * The assertion is a hand-authored correct-behaviour invariant, never `replay == db`: given the machine
+ * is driven this way, the job closes with 2 accepts > 1 accounted drop → exactly one tripwire fires,
+ * carrying the true counts, and order B's `DELIVERY_COMPLETED` still lands. No new device fixture is
+ * committed (the only fixture bytes are the pre-existing swept single_delivery ones), so this test adds
+ * no raw customer PII — the injected orders carry only a synthetic hash / frame 06's already-hashed one.
+ */
+class AcceptMismatchReplayTest {
+
+    private val session = "snapshots/sessions/single_delivery_2026_06_16"
+
+    private fun dd(step: SessionReplay.ReplayStep) = step.stateAfter.regions.platforms[Platform.DoorDash]
+
+    /** A synthetic ADD-ON offer A (the invisibly-abandoned order) — explicitly labelled, no device
+     *  fixture; one order, dropoffCount 1, distinct hash so it appends into the delivered job. */
+    private fun offerA(atMs: Long): SessionReplay.RawInput = SessionReplay.RawInput(
+        Observation.Screen(
+            timestamp = atMs, captureId = null, ruleId = "doordash.screen.offer_popup",
+            metadata = ReplayMetadata.EMPTY, flow = Flow.OfferPresented, modeHint = Mode.Online,
+            parsed = ParsedFields.OfferFields(
+                parsedOffer = ParsedOffer(offerHash = "synthetic-abandoned-A", payAmount = 28.50, distanceMiles = 5.0),
+            ),
+            target = "offer_popup",
+        ),
+        atMs = atMs,
+    )
+
+    /** Order B's dropoff ARRIVAL — the frame the single_delivery capture suppressed. Carries frame 06's
+     *  OWN real parsed fields (store + customer hash) re-stamped as the arrived sub-flow so `arrivedAt`
+     *  is set and B counts as a fully-delivered, accounted drop (the #700 `mamaMargiesArrival` precedent). */
+    private fun dropoffArrival(atMs: Long, realFields: ParsedFields.TaskFields): SessionReplay.RawInput =
+        SessionReplay.RawInput(
+            Observation.Screen(
+                timestamp = atMs, captureId = null, ruleId = "doordash.screen.dropoff_photo",
+                metadata = ReplayMetadata.EMPTY, flow = Flow.TaskDropoffArrived, modeHint = Mode.Online,
+                parsed = realFields.copy(subFlow = TaskSubFlow.ARRIVED), target = "dropoff_photo",
+            ),
+            atMs = atMs,
+        )
+
+    private fun run(): List<SessionReplay.ReplayStep> {
+        val screens = SessionReplay.loadSession(session).map { SessionReplay.ScreenInput(it) }
+        val click = SessionReplay.loadClickFrame("$session/02_accept_offer_click.json")
+        // Order B's real parsed dropoff fields, from frame 06's own production recognition.
+        val f06 = screens.first { it.frame.file.startsWith("06_") }.frame
+        val bDropFields = SessionReplay.replayRecognition(listOf(f06)).first().parsed as ParsedFields.TaskFields
+        // Order A (abandoned) folds in mid-pickup, between 03 pickup_nav (…052151) and 04 arrival (…167944).
+        val aOffer = offerA(1_781_644_100_000L)
+        val aClick = SessionReplay.syntheticOfferClick("accept_offer", 1_781_644_100_500L)
+        // Order B's suppressed arrival, between 06 dropoff_pre_arrival (…692624) and 07 summary (…731531).
+        val bArrival = dropoffArrival(1_781_644_700_000L, bDropFields)
+        val timer = SessionReplay.graceCommit(screens.maxOf { it.atMs } + 200_000L)
+        return SessionReplay.reduceMixed(screens + click + aOffer + aClick + bArrival + timer)
+    }
+
+    @Test
+    fun `exactly one JOB_ACCEPT_MISMATCH fires at close - 2 accepts, 1 delivered, 1 leftover TBD`() {
+        val steps = run()
+        val mismatches = steps.flatMap { it.events }.filter { it.type == AppEventType.JOB_ACCEPT_MISMATCH }
+        assertEquals("exactly one tripwire fires at the job close", 1, mismatches.size)
+
+        val p = mismatches.single().payload as JobAcceptMismatchPayload
+        assertEquals("two offers were accepted into the closing job", 2, p.acceptedCount)
+        assertEquals("only the single delivered drop is accounted", 1, p.accountedCount)
+        assertTrue("both offer hashes ride the payload", p.acceptedOfferHashes.contains("synthetic-abandoned-A"))
+        assertEquals("the abandoned order left one never-activated TBD placeholder", 1, p.leftoverTbdPlaceholders)
+        assertEquals("nothing was explicitly unassigned (the INVISIBLE class)", 0, p.unassignedCount)
+        assertEquals("the delivered drop's customer hash is carried", 1, p.deliveredCustomerHashes.size)
+    }
+
+    @Test
+    fun `the delivered drop still folds - order B completes exactly once`() {
+        val steps = run()
+        val completed = steps.flatMap { it.events }.count { it.type == AppEventType.DELIVERY_COMPLETED }
+        assertEquals("order B still delivers normally — the tripwire never disturbs it", 1, completed)
+    }
+
+    @Test
+    fun `the tripwire fires on the job-close step, not mid-flow`() {
+        val steps = run()
+        // No mismatch is emitted while the job is still live (activeJob non-null with the same id).
+        steps.forEach { s ->
+            val fired = s.events.any { it.type == AppEventType.JOB_ACCEPT_MISMATCH }
+            if (fired) {
+                assertTrue(
+                    "the tripwire only fires on the step that closes the job (activeJob cleared/reminted)",
+                    dd(s)?.activeJob == null,
+                )
+            }
+        }
+    }
+}

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -208,6 +208,9 @@ class EffectMap @Inject constructor(
             addAll(diffTask(p, next, obs))
             addAll(diffPostTask(p, next, actedNextFlow, obs))
             addAll(diffNotification(obs))
+            // #810 B1: the job-close accept-reconciliation tripwire — diffs the activeJob close
+            // (any in-scope close routes through completeActiveJob; endSession is excluded inside).
+            addAll(diffJobClose(p, next, obs))
 
             // #438 B5/#240: the DELIVERY_COMPLETED mint (PostTask-exit + the #596 close-out
             // sweep) extracted to DeliveryCompletionEffects.kt as one unit — both blocks share the

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/JobCloseEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/JobCloseEffects.kt
@@ -1,0 +1,67 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.detectAcceptMismatch
+import timber.log.Timber
+
+/**
+ * #810 B1 — the job-close accept-reconciliation tripwire, emitted at the effect edge (P1/UDF: the
+ * stepper stays pure; this diffs prev/next durable state and emits, the `TASK_UNASSIGNED` precedent).
+ *
+ * The "mark" the effect diffs is the durable [PlatformRegion.activeJob] transition itself: a job
+ * closes when its `jobId` leaves the active slot — cleared to null (T1 retire / PostTask-exit /
+ * #736 abandon step-3) OR replaced by a fresh `jobId` (T2 close+mint). ALL of those in-scope close
+ * paths route through `PlatformRegionStepper.completeActiveJob`. [endSession] ALSO clears
+ * `activeJob`, but it uniquely nulls the session in the same step; the `next.session == null` guard
+ * keeps it out of scope (v1 — an offline-mid-job dash is its own class; #810 B1, noted in-code).
+ *
+ * Detection is the pure `:domain` [detectAcceptMismatch]; this only decides the close edge, then logs
+ * ONE `JOB_ACCEPT_MISMATCH` (keyed per `jobId`, so at-most-once — a job closes single-shot) + one
+ * edge-gated WARN. NO state mutation, NO re-attribution — a tripwire only.
+ *
+ * `next.recentTasks` is the delivered/unassigned source (a T1 retire completes the drop INTO
+ * `recentTasks` before `completeActiveJob`; a T2 close+mint commits it before the fresh mint), unioned
+ * inside the detector with the closing job's own `tasks` mirror (where a leftover TBD placeholder
+ * lives).
+ */
+internal fun EffectMap.diffJobClose(
+    prev: PlatformRegion,
+    next: PlatformRegion,
+    obs: Observation,
+): List<AppEffect> {
+    val closingJob = prev.activeJob ?: return emptyList()
+    // No close this step (same job survives, or an add-on `existing.copy` kept the jobId).
+    if (next.activeJob?.jobId == closingJob.jobId) return emptyList()
+    // endSession's simultaneous session-null is the out-of-scope marker (v1).
+    if (next.session == null) return emptyList()
+
+    val payload = detectAcceptMismatch(closingJob, next.recentTasks) ?: return emptyList()
+
+    val sessionId = next.session?.sessionId ?: prev.session?.sessionId
+    return buildList {
+        // WARN (P7): counts + jobId + hash PREFIXES only — no store/customer/raw text. Stable tag,
+        // matching the #691/#699 D6 join-miss precedent (the state module logs under "StateMachine").
+        Timber.tag("StateMachine").w(
+            "#810 job-close accept mismatch: job %s — %d accepts > %d accounted " +
+                "(%d leftover TBD, %d unassigned); offers=%s delivered=%s",
+            payload.jobId,
+            payload.acceptedCount,
+            payload.accountedCount,
+            payload.leftoverTbdPlaceholders,
+            payload.unassignedCount,
+            payload.acceptedOfferHashes.map { it.take(6) },
+            payload.deliveredCustomerHashes.map { it.take(6) },
+        )
+        add(
+            logEffect(
+                sessionId,
+                AppEventType.JOB_ACCEPT_MISMATCH,
+                obs.timestamp,
+                payload,
+                effectKeyOverride = "log:${AppEventType.JOB_ACCEPT_MISMATCH}:${payload.jobId}",
+            ),
+        )
+    }
+}

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/JobCloseEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/JobCloseEffects.kt
@@ -14,8 +14,9 @@ import timber.log.Timber
  * closes when its `jobId` leaves the active slot — cleared to null (T1 retire / PostTask-exit /
  * #736 abandon step-3) OR replaced by a fresh `jobId` (T2 close+mint). ALL of those in-scope close
  * paths route through `PlatformRegionStepper.completeActiveJob`. [endSession] ALSO clears
- * `activeJob`, but it uniquely nulls the session in the same step; the `next.session == null` guard
- * keeps it out of scope (v1 — an offline-mid-job dash is its own class; #810 B1, noted in-code).
+ * `activeJob`; it is kept out of scope (v1 — an offline-mid-job dash is its own class) by requiring the
+ * session to SURVIVE the step with the SAME id, not merely be present — one frame can commit a
+ * stale-grace end (session A) AND mint a fresh session B in the same step (see the guard).
  *
  * Detection is the pure `:domain` [detectAcceptMismatch]; this only decides the close edge, then logs
  * ONE `JOB_ACCEPT_MISMATCH` (keyed per `jobId`, so at-most-once — a job closes single-shot) + one
@@ -34,12 +35,18 @@ internal fun EffectMap.diffJobClose(
     val closingJob = prev.activeJob ?: return emptyList()
     // No close this step (same job survives, or an add-on `existing.copy` kept the jobId).
     if (next.activeJob?.jobId == closingJob.jobId) return emptyList()
-    // endSession's simultaneous session-null is the out-of-scope marker (v1).
-    if (next.session == null) return emptyList()
+    // endSession is out of scope (v1). Guard on session IDENTITY, not mere presence: a single frame
+    // can both commit a stale-grace `endSession` (session A → null, job → null) AND mint a FRESH
+    // session B in the mode arm (app killed mid-job while the offline grace pended; the next dash's
+    // first Online frame commits the stale end + starts the new dash in one step). That step shows
+    // `next.session != null` (session B) yet the job died with session A — a presence check would
+    // fire the tripwire for the out-of-scope offline-mid-job class, mis-attributed to the new session.
+    // The job only truly *closed within its own session* when that session survives the step.
+    if (next.session == null || next.session?.sessionId != prev.session?.sessionId) return emptyList()
 
     val payload = detectAcceptMismatch(closingJob, next.recentTasks) ?: return emptyList()
 
-    val sessionId = next.session?.sessionId ?: prev.session?.sessionId
+    val sessionId = next.session?.sessionId
     return buildList {
         // WARN (P7): counts + jobId + hash PREFIXES only — no store/customer/raw text. Stable tag,
         // matching the #691/#699 D6 join-miss precedent (the state module logs under "StateMachine").

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/JobCloseEffectsTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/JobCloseEffectsTest.kt
@@ -1,0 +1,101 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.JobAcceptMismatchPayload
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.AcceptedOfferEconomics
+import cloud.trotter.dashbuddy.domain.state.Job
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.Task
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #810 B1 — the [diffJobClose] effect-edge tripwire, in isolation. Focus: the endSession exclusion
+ * must key on session IDENTITY, not presence (the same-step end+mint shape, #818 adversarial Finding 1).
+ */
+class JobCloseEffectsTest {
+
+    private val effectMap = EffectMap()
+
+    private fun obs(): Observation = Observation.Screen(
+        timestamp = 5000L, captureId = null, ruleId = "test.rule", metadata = ReplayMetadata.EMPTY,
+        flow = null, modeHint = null, parsed = ParsedFields.None,
+    )
+
+    /** A job carrying a mismatch shape (2 accepts) so the tripwire WOULD fire if the edge admits it. */
+    private fun mismatchJob(id: String) = Job(
+        jobId = id,
+        offerStoreHint = emptyList(),
+        parentOfferHash = null,
+        acceptedOffers = listOf(
+            AcceptedOfferEconomics(offerHash = "hA", payAmount = 28.5, acceptedAt = 100L),
+            AcceptedOfferEconomics(offerHash = "hB", payAmount = 16.14, acceptedAt = 200L),
+        ),
+        tasks = listOf(Task(taskId = "d-tbd", jobId = id, phase = TaskPhase.DROPOFF, startedAt = 100L)),
+        startedAt = 100L,
+    )
+
+    private fun deliveredDrop(jobId: String) = Task(
+        taskId = "d1", jobId = jobId, phase = TaskPhase.DROPOFF,
+        customerNameHash = "c1", startedAt = 100L, arrivedAt = 200L, completedAt = 300L,
+    )
+
+    private fun mismatches(effects: List<AppEffect>): List<JobAcceptMismatchPayload> =
+        effects.filterIsInstance<AppEffect.LogEvent>()
+            .filter { it.event.type == AppEventType.JOB_ACCEPT_MISMATCH }
+            .map { it.event.payload as JobAcceptMismatchPayload }
+
+    @Test
+    fun `a real close within the same session fires the tripwire`() {
+        val session = Session("dash-A", startedAt = 50L)
+        val job = mismatchJob("J1")
+        val prev = PlatformRegion(Platform.DoorDash, session = session, activeJob = job)
+        val next = PlatformRegion(
+            Platform.DoorDash, session = session, activeJob = null,
+            recentTasks = listOf(deliveredDrop("J1")),
+        )
+        val m = mismatches(effectMap.diffJobClose(prev, next, obs()))
+        assertEquals("the in-session close fires exactly one tripwire", 1, m.size)
+        assertEquals(2, m.single().acceptedCount)
+        assertEquals(1, m.single().accountedCount)
+    }
+
+    @Test
+    fun `a same-step endSession-plus-mint does NOT fire (session identity, not presence)`() {
+        // The stale-grace endSession commits (session A → null, job → null) and the SAME Online frame
+        // mints a FRESH session B — so next has NO job but a DIFFERENT (present, non-null) session. A
+        // presence-only guard would fire the tripwire here for the out-of-scope offline-mid-job class,
+        // mis-attributed to session B. The identity guard (next.session.id != prev.session.id) blocks it.
+        val sessionA = Session("dash-A", startedAt = 50L)
+        val sessionB = Session("dash-B", startedAt = 6000L)
+        val prev = PlatformRegion(Platform.DoorDash, session = sessionA, activeJob = mismatchJob("J1"))
+        val next = PlatformRegion(
+            Platform.DoorDash, session = sessionB, activeJob = null,
+            recentTasks = listOf(deliveredDrop("J1")),
+        )
+        assertEquals(
+            "endSession+mint in one step is out of scope — the fresh session must not admit the tripwire",
+            0, mismatches(effectMap.diffJobClose(prev, next, obs())).size,
+        )
+    }
+
+    @Test
+    fun `a plain endSession (session cleared) does NOT fire`() {
+        val sessionA = Session("dash-A", startedAt = 50L)
+        val prev = PlatformRegion(Platform.DoorDash, session = sessionA, activeJob = mismatchJob("J1"))
+        val next = PlatformRegion(
+            Platform.DoorDash, session = null, activeJob = null,
+            recentTasks = listOf(deliveredDrop("J1")),
+        )
+        assertEquals(
+            "a session-clearing endSession is out of scope (v1)",
+            0, mismatches(effectMap.diffJobClose(prev, next, obs())).size,
+        )
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodec.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodec.kt
@@ -13,6 +13,7 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.SessionPausedPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.TaskUnassignedPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.JobAcceptMismatchPayload
 import kotlinx.serialization.json.Json
 
 /**
@@ -44,6 +45,7 @@ object AppEventCodec {
         is DeliveryAdjustmentPayload -> json.encodeToString(payload)
         is DeliverySessionAssignPayload -> json.encodeToString(payload)
         is TaskUnassignedPayload -> json.encodeToString(payload)
+        is JobAcceptMismatchPayload -> json.encodeToString(payload)
     }
 
     /**
@@ -97,6 +99,9 @@ object AppEventCodec {
 
             AppEventType.TASK_UNASSIGNED ->
                 json.decodeFromString<TaskUnassignedPayload>(payloadJson)
+
+            AppEventType.JOB_ACCEPT_MISMATCH ->
+                json.decodeFromString<JobAcceptMismatchPayload>(payloadJson)
 
             AppEventType.ZONE_SWITCH,
             AppEventType.NOTIFICATION_RECEIVED,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventType.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventType.kt
@@ -29,6 +29,14 @@ enum class AppEventType {
     TASK_UNASSIGNED, // The dasher unassigned the order mid-flow (via help). Teardown, NOT a completion:
                      // no pay/miles ever attributes, and the close-out sweep can never confirm it.
 
+    // --- Job-close reconciliation tripwire (#810 B1) ---
+    JOB_ACCEPT_MISMATCH, // A job closed with MORE accepted offers than accounted physical orders (delivered
+                         // drops + unassign-marked orders) — the invisible-unassign class (seq-114): an offer
+                         // died with no capturable commit surface, so no TASK_UNASSIGNED ever fired. A pure
+                         // tripwire: read-model-inert (the projector's liveness `else` arm), NO state mutation,
+                         // NO re-attribution — it only makes the silent seam observable. Payload = hashes +
+                         // counts only (PII-safe, P7).
+
     // --- User corrections (#650) ---
     MANUAL_DELIVERY, // A driver-entered missed delivery (durable correction event, never destructive)
     PAY_ADJUSTMENT,  // A driver re-price of an already-recorded delivery (the original event stays)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
@@ -194,6 +194,41 @@ data class TaskUnassignedPayload(
 ) : AppEventPayload
 
 /**
+ * Payload for `JOB_ACCEPT_MISMATCH` (#810 B1) — emitted once when a job closes carrying MORE accepted
+ * offers than accounted physical orders. This is the seq-114 invisible-unassign signal: an accepted
+ * offer died without a capturable dasher-side commit surface (a support-chat unassign renders no
+ * confirmation screen/click), so no `TASK_UNASSIGNED` ever fired and the seam was previously silent.
+ *
+ * It is a **tripwire, not a guess**: the machine does NOT mutate state, re-attribute pay, or decide
+ * which offer died (that attribution is structurally ambiguous — deferred to #810 B2). The payload
+ * carries only the shape of the mismatch so the desk playbook / a future review affordance can see it.
+ *
+ * **PII-safe by construction (P7):** `sha256` hashes and counts only — no store names, no raw text.
+ * `acceptedCount`/`accountedCount` are the raw mismatch numbers (the WARN reads them); the hash lists
+ * are the offer↔job and delivered-customer links, mirroring the other phase payloads.
+ *
+ * **Read-model-inert:** the projector routes it through the liveness `else` arm (the `TASK_UNASSIGNED`
+ * precedent) — it mints no record and needs no `PROJECTOR_VERSION` bump (a new type can't exist in
+ * already-folded history).
+ */
+@Serializable
+data class JobAcceptMismatchPayload(
+    val jobId: String,
+    /** `job.acceptedOffers.size` — the accepted-offer count at close (the mismatch numerator). */
+    val acceptedCount: Int,
+    /** Distinct delivered dropoffs + distinct unassign-marked orders (the mismatch denominator). */
+    val accountedCount: Int,
+    /** Every offer hash that contributed to the closing job (the add-on chain). */
+    val acceptedOfferHashes: List<String> = emptyList(),
+    /** Customer hashes of the drops that DID deliver — the accounted, hashed customer set. */
+    val deliveredCustomerHashes: List<String> = emptyList(),
+    /** Never-activated TBD dropoff placeholders left outstanding at close (customer-less, undelivered). */
+    val leftoverTbdPlaceholders: Int = 0,
+    /** Orders the dasher explicitly unassigned via help (#736) — accounted, not part of the signal. */
+    val unassignedCount: Int = 0,
+) : AppEventPayload
+
+/**
  * Payload for `MANUAL_DELIVERY` (#650) — a driver-entered missed delivery: a real drop the capture
  * pipeline never saw (an unrecognized screen, a crash, an offer taken outside the app). It is an
  * **event, never a destructive edit**: the projector folds it into a `delivery_record` (payBasis

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/JobAcceptReconciliation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/JobAcceptReconciliation.kt
@@ -1,0 +1,82 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import cloud.trotter.dashbuddy.domain.model.event.payload.JobAcceptMismatchPayload
+
+/**
+ * #810 B1 — the job-close accept-reconciliation tripwire (pure, `obs.timestamp`-free detection).
+ *
+ * When a job closes carrying MORE accepted offers than accounted physical orders, an accepted offer
+ * silently vanished. The fielded seq-114 shape: two accepts, one delivered drop, one never-activated
+ * TBD dropoff placeholder — and ZERO signal, because the unassign committed through a support-chat
+ * path that rendered no confirmation screen or click (so no `TASK_UNASSIGNED` ever fired, contrast the
+ * #736 help-flow unassign that walks the full confirmation path). This detector makes that seam
+ * observable; the emission side ([cloud.trotter.dashbuddy.core.state] `diffJobClose`) fires ONE
+ * `JOB_ACCEPT_MISMATCH` event + an edge-gated WARN off its result.
+ *
+ * **A tripwire, not a guess:** it computes the shape of the mismatch and returns it; it never mutates
+ * state, re-attributes pay, or decides which offer died (that attribution is structurally ambiguous —
+ * deferred to #810 B2). It is `Platform`-agnostic (operates only on [Job]/[Task] shape) and pure, so
+ * it is replay-deterministic.
+ *
+ * **Accounting** (design point 1):
+ * - `nAccepts` = [Job.acceptedOffers]`.size`. Guarded to `>= 2`: a single-accept job that closes
+ *   drop-less is the existing early-offline / coarse-platform class (an Uber `task:active` job that
+ *   never rendered a drop), NOT this invisible-unassign signal — so it never trips the tripwire.
+ * - `accounted` = distinct delivered dropoffs (`completedAt != null && arrivedAt != null &&
+ *   unassignedAt == null`, deduped by `taskId`) + distinct unassign-marked orders
+ *   (`unassignedAt != null`, deduped by customer identity so a pickup+dropoff leg of the SAME
+ *   abandoned order counts once). A properly-#736'd unassign is therefore accounted and does NOT
+ *   trip this.
+ * - Tasks are the union of `recentTasks` (where delivered + unassigned tasks live) and [Job.tasks]
+ *   (the non-unassigned lineage mirror — where a leftover TBD placeholder lives), filtered to this job
+ *   and deduped by `taskId`. `recentTasks` is listed FIRST so its FRESH copy of a just-finished drop
+ *   wins the dedup over the `Job.tasks` mirror's STALE copy (the mirror re-runs after `stepCore`, so
+ *   at a close its copy of the just-finished drop still shows `completedAt` null — the same staleness
+ *   `isJobPhysicallyComplete` guards against by deriving completion truth from `recentTasks` only).
+ *
+ * Returns a fully-built [JobAcceptMismatchPayload] (the payload IS the detection result — one SSOT,
+ * no parallel data class) when `nAccepts > accounted`, else null.
+ */
+fun detectAcceptMismatch(job: Job, recentTasks: List<Task>): JobAcceptMismatchPayload? {
+    val nAccepts = job.acceptedOffers.size
+    // A single-accept drop-less close is the early-offline / coarse-platform class, not this signal.
+    if (nAccepts < 2) return null
+
+    // recentTasks FIRST so a finished drop's fresh copy wins the dedup over the stale Job.tasks mirror.
+    val jobTasks = (recentTasks + job.tasks)
+        .filter { it.jobId == job.jobId }
+        .distinctBy { it.taskId }
+
+    val deliveredDrops = jobTasks.filter {
+        it.phase == TaskPhase.DROPOFF &&
+            it.completedAt != null &&
+            it.arrivedAt != null &&
+            it.unassignedAt == null
+    }
+    // Dedupe unassigned legs by customer identity (a pickup + a dropoff of the same abandoned order
+    // must not double-count); fall back to taskId when the abandoned task carries no customer hash.
+    val unassignedOrders = jobTasks
+        .filter { it.unassignedAt != null }
+        .distinctBy { it.customerNameHash ?: it.taskId }
+
+    val accounted = deliveredDrops.size + unassignedOrders.size
+    if (nAccepts <= accounted) return null
+
+    // Never-activated TBD dropoff placeholders left outstanding at close — the seq-114 corpse (121).
+    val leftoverTbd = jobTasks.count {
+        it.phase == TaskPhase.DROPOFF &&
+            it.customerNameHash == null &&
+            it.completedAt == null &&
+            it.unassignedAt == null
+    }
+
+    return JobAcceptMismatchPayload(
+        jobId = job.jobId,
+        acceptedCount = nAccepts,
+        accountedCount = accounted,
+        acceptedOfferHashes = job.acceptedOffers.mapNotNull { it.offerHash },
+        deliveredCustomerHashes = deliveredDrops.mapNotNull { it.customerNameHash },
+        leftoverTbdPlaceholders = leftoverTbd,
+        unassignedCount = unassignedOrders.size,
+    )
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/JobAcceptReconciliation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/JobAcceptReconciliation.kt
@@ -36,6 +36,15 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.JobAcceptMismatchPaylo
  *
  * Returns a fully-built [JobAcceptMismatchPayload] (the payload IS the detection result — one SSOT,
  * no parallel data class) when `nAccepts > accounted`, else null.
+ *
+ * **Known false-positive residual (documented, not gated).** The PostTask-exit and #736 abandon-step-3
+ * closes do not enforce an arrival gate, yet a delivered drop is counted here only with `arrivedAt !=
+ * null`. So a genuine 2-accept 2-drop stack whose FIRST drop's ARRIVAL frame was suppressed on-device
+ * (the #700 capture-dedup class — the same suppression this feature's own replay fixture had to
+ * synthesize) closes via the receipt edge with that drop un-accounted → the tripwire trips. It is
+ * semi-legitimate (that same drop also minted no `DELIVERY_COMPLETED`, so it really is under-recorded)
+ * and fails toward ONE spurious review callout, never a mutation. The desk playbook should treat a lone
+ * mismatch WARN on an otherwise-reconciling stack as this residual, not a new bug.
  */
 fun detectAcceptMismatch(job: Job, recentTasks: List<Task>): JobAcceptMismatchPayload? {
     val nAccepts = job.acceptedOffers.size

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -25,6 +25,7 @@ import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.model.event.payload.TaskUnassignedPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.JobAcceptMismatchPayload
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -176,6 +177,15 @@ class RecordFoldsTest {
         odometer = odo,
     )
 
+    private fun jobAcceptMismatch(sid: String, at: Long, jobId: String) = ev(
+        AppEventType.JOB_ACCEPT_MISMATCH, sid, at,
+        JobAcceptMismatchPayload(
+            jobId = jobId, acceptedCount = 2, accountedCount = 1,
+            acceptedOfferHashes = listOf("hA", "hB"), deliveredCustomerHashes = listOf("cust1"),
+            leftoverTbdPlaceholders = 1, unassignedCount = 0,
+        ),
+    )
+
     // Thread a session's events, returning the outcomes in order and the final context.
     private fun foldSession(events: List<SequencedAppEvent>, currentCpm: Double? = null): Pair<List<FoldOutcome>, SessionFoldContext?> {
         var ctx: SessionFoldContext? = null
@@ -185,6 +195,37 @@ class RecordFoldsTest {
             o
         }
         return outcomes to ctx
+    }
+
+    @Test
+    fun `JOB_ACCEPT_MISMATCH is read-model-inert - no record, liveness still advances (#810 B1)`() {
+        val s = "S1"
+        val (outcomes, ctx) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                delivery(s, 3_000, "J1", "T1", totalPay = 10.0, parsedPay = parsedPay(base = 7.0, tip = 3.0), odo = 105.0),
+                // The tripwire event lands after the delivery — it must mint NOTHING.
+                jobAcceptMismatch(s, 3_500, "J1"),
+                dashStop(s, 4_000, odo = 110.0, earnings = 10.0),
+            ),
+        )
+
+        // The delivered drop still folds normally (the tripwire never disturbs it).
+        assertNotNull("the real delivery still folds to a record", outcomes[1].delivery)
+
+        // The mismatch fold mints no record of any kind (the liveness `else` arm, TASK_UNASSIGNED precedent).
+        val mismatch = outcomes[2]
+        assertNull("no delivery record", mismatch.delivery)
+        assertNull("no offer record", mismatch.offer)
+        assertNull("no pickup record", mismatch.pickup)
+        assertNull("no store resolution", mismatch.resolution)
+        assertNull("no pay adjustment", mismatch.payAdjustment)
+        assertNull("no delivery adjustment", mismatch.deliveryAdjustment)
+        assertNull("no session assign", mismatch.sessionAssign)
+        assertNull("not a skip — it advances liveness like any session-attributed event", mismatch.skip)
+        // Liveness advanced to the event's time (the `else` arm's `ctx.advance`).
+        assertNotNull("context carries through", mismatch.context)
+        assertEquals("liveness advanced to the mismatch event time", 3_500L, mismatch.context!!.lastEventAt)
     }
 
     @Test

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodecTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodecTest.kt
@@ -4,7 +4,10 @@ import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.JobAcceptMismatchPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.TaskUnassignedPayload
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferReceivedPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionEndSource
@@ -86,6 +89,16 @@ class AppEventCodecTest {
                 sessionId = "s1", endedAt = 8_000L,
                 source = SessionEndSource.SUMMARY_SCREEN, totalEarnings = 41.25,
                 sessionDurationMillis = 3_600_000L, offersAccepted = 7, offersTotal = 9,
+            ),
+            AppEventType.TASK_UNASSIGNED to TaskUnassignedPayload(
+                jobId = "j1", taskId = "t1", phase = TaskPhase.PICKUP, storeName = "Wendy's",
+                arrivedAt = 4_000L, startedAt = 3_000L, unassignedAt = 5_000L,
+                jobOfferHashes = listOf("h1"),
+            ),
+            AppEventType.JOB_ACCEPT_MISMATCH to JobAcceptMismatchPayload(
+                jobId = "j1", acceptedCount = 2, accountedCount = 1,
+                acceptedOfferHashes = listOf("hA", "hB"), deliveredCustomerHashes = listOf("c1"),
+                leftoverTbdPlaceholders = 1, unassignedCount = 0,
             ),
         )
 

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/JobAcceptReconciliationTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/JobAcceptReconciliationTest.kt
@@ -1,0 +1,183 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #810 B1 — the pure job-close accept-reconciliation tripwire ([detectAcceptMismatch]).
+ *
+ * The true/false shapes below are the design's acceptance cases: the seq-114 invisible-unassign shape
+ * FIRES; a genuine finished stack and a properly-#736'd unassign stay SILENT.
+ */
+class JobAcceptReconciliationTest {
+
+    private fun offer(hash: String) = AcceptedOfferEconomics(offerHash = hash, payAmount = 10.0, acceptedAt = 50L)
+
+    private fun job(offers: List<String>, tasks: List<Task>) = Job(
+        jobId = "J",
+        offerStoreHint = emptyList(),
+        parentOfferHash = null,
+        acceptedOffers = offers.map { offer(it) },
+        tasks = tasks,
+        startedAt = 50L,
+    )
+
+    /** A delivered dropoff: arrived + completed, not unassigned. */
+    private fun deliveredDrop(id: String, customer: String) = Task(
+        taskId = id, jobId = "J", phase = TaskPhase.DROPOFF,
+        customerNameHash = customer, startedAt = 100L, arrivedAt = 200L, completedAt = 300L,
+    )
+
+    /** A never-activated TBD dropoff placeholder: customer-less, undelivered. */
+    private fun tbdPlaceholder(id: String) = Task(
+        taskId = id, jobId = "J", phase = TaskPhase.DROPOFF, startedAt = 100L,
+    )
+
+    /** An unassign-marked (abandoned) task. */
+    private fun unassignedTask(id: String, phase: TaskPhase, customer: String?) = Task(
+        taskId = id, jobId = "J", phase = phase, customerNameHash = customer,
+        startedAt = 100L, unassignedAt = 250L,
+    )
+
+    // ---------------------------------------------------------------------------------------------
+    // FIRES
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    fun `the seq-114 shape fires - 2 accepts, 1 delivered, 1 leftover TBD`() {
+        // Job.tasks holds the leftover TBD placeholder (never activated → stays in the lineage mirror);
+        // recentTasks holds the one delivered drop.
+        val job = job(listOf("offerA", "offerB"), tasks = listOf(tbdPlaceholder("d-tbd")))
+        val recent = listOf(deliveredDrop("d-delivered", "cust1"))
+
+        val m = detectAcceptMismatch(job, recent)
+        assertNotNull("2 accepts > 1 accounted → tripwire fires", m)
+        assertEquals("J", m!!.jobId)
+        assertEquals(2, m.acceptedCount)
+        assertEquals("only the single delivered drop is accounted", 1, m.accountedCount)
+        assertEquals(listOf("offerA", "offerB"), m.acceptedOfferHashes)
+        assertEquals(listOf("cust1"), m.deliveredCustomerHashes)
+        assertEquals(1, m.leftoverTbdPlaceholders)
+        assertEquals(0, m.unassignedCount)
+    }
+
+    @Test
+    fun `three accepts with only two accounted still fires`() {
+        val job = job(listOf("a", "b", "c"), tasks = listOf(tbdPlaceholder("d-tbd")))
+        val recent = listOf(deliveredDrop("d1", "c1"), deliveredDrop("d2", "c2"))
+        val m = detectAcceptMismatch(job, recent)
+        assertNotNull(m)
+        assertEquals(3, m!!.acceptedCount)
+        assertEquals(2, m.accountedCount)
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // SILENT
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    fun `a genuine finished 2-drop stack is silent`() {
+        // 2 accepts, both drops delivered (a real batch/add-on that completed) → accounted == accepts.
+        val job = job(listOf("a", "b"), tasks = emptyList())
+        val recent = listOf(deliveredDrop("d1", "c1"), deliveredDrop("d2", "c2"))
+        assertNull("2 accounted == 2 accepts → no signal", detectAcceptMismatch(job, recent))
+    }
+
+    @Test
+    fun `a single-accept drop-less close is silent (the early-offline class, nAccepts less-than 2)`() {
+        // 1 accept, 0 delivered, a leftover TBD — the coarse/early-offline class, NOT the signal.
+        val job = job(listOf("a"), tasks = listOf(tbdPlaceholder("d-tbd")))
+        assertNull("single accept never trips the tripwire", detectAcceptMismatch(job, emptyList()))
+    }
+
+    @Test
+    fun `a same-customer 1-offer-2-order job with a leftover TBD is silent (nAccepts less-than 2)`() {
+        // One offer covering two orders (a same-customer multi-order), one delivered, one leftover.
+        // nAccepts == 1 → below the guard, never fires (this is the #749 class, handled elsewhere).
+        val job = job(listOf("a"), tasks = listOf(tbdPlaceholder("d-tbd")))
+        val recent = listOf(deliveredDrop("d1", "c1"))
+        assertNull(detectAcceptMismatch(job, recent))
+    }
+
+    @Test
+    fun `a properly-736'd unassign counts as accounted and stays silent`() {
+        // 2 accepts: one delivered, one explicitly unassigned via help (#736). accounted = 1 + 1 = 2.
+        val job = job(listOf("a", "b"), tasks = emptyList())
+        val recent = listOf(
+            deliveredDrop("d1", "c1"),
+            unassignedTask("d2", TaskPhase.DROPOFF, "c2"),
+        )
+        val m = detectAcceptMismatch(job, recent)
+        assertNull("the unassign is accounted → 2 == 2, no signal", m)
+    }
+
+    @Test
+    fun `an unassigned order's pickup and dropoff legs count as one accounted order`() {
+        // 2 accepts, 1 delivered, 1 abandoned order whose pickup AND dropoff legs are both marked with
+        // the SAME customer hash — must dedupe to one accounted order (else accounted would over-count).
+        val job = job(listOf("a", "b"), tasks = emptyList())
+        val recent = listOf(
+            deliveredDrop("d1", "c1"),
+            unassignedTask("p2", TaskPhase.PICKUP, "c2"),
+            unassignedTask("d2", TaskPhase.DROPOFF, "c2"),
+        )
+        val m = detectAcceptMismatch(job, recent)
+        // accounted = 1 delivered + 1 distinct unassigned customer = 2 == 2 accepts → silent.
+        assertNull(m)
+    }
+
+    @Test
+    fun `a delivered-but-never-arrived drop does not count as accounted`() {
+        // completedAt set but arrivedAt null → not a fully delivered drop per the spec; 2 accepts, 0
+        // accounted → fires (the drop is NOT counted).
+        val job = job(listOf("a", "b"), tasks = emptyList())
+        val notArrived = Task(
+            taskId = "d1", jobId = "J", phase = TaskPhase.DROPOFF,
+            customerNameHash = "c1", startedAt = 100L, arrivedAt = null, completedAt = 300L,
+        )
+        val m = detectAcceptMismatch(job, listOf(notArrived))
+        assertNotNull("an unarrived completion is not accounted", m)
+        assertEquals(0, m!!.accountedCount)
+    }
+
+    @Test
+    fun `tasks from a different job are ignored`() {
+        val job = job(listOf("a", "b"), tasks = emptyList())
+        val foreign = deliveredDrop("d1", "c1").copy(jobId = "OTHER")
+        val ownDelivered = deliveredDrop("d2", "c2")
+        // Only the own-job delivered drop counts → 2 accepts, 1 accounted → fires.
+        val m = detectAcceptMismatch(job, listOf(foreign, ownDelivered))
+        assertNotNull(m)
+        assertEquals(1, m!!.accountedCount)
+        assertEquals(listOf("c2"), m.deliveredCustomerHashes)
+    }
+
+    @Test
+    fun `union dedupes a task present in both job_tasks and recentTasks`() {
+        val delivered = deliveredDrop("d1", "c1")
+        // Same delivered task appears in BOTH the job mirror and recentTasks — must count once.
+        val job = job(listOf("a", "b"), tasks = listOf(delivered, tbdPlaceholder("d-tbd")))
+        val m = detectAcceptMismatch(job, listOf(delivered))
+        assertNotNull(m)
+        assertEquals("the delivered drop is counted once, not twice", 1, m!!.accountedCount)
+        assertEquals(1, m.leftoverTbdPlaceholders)
+    }
+
+    @Test
+    fun `the fresh recentTasks copy wins over a stale job_tasks mirror copy`() {
+        // The Job.tasks mirror re-runs after stepCore, so at a close its copy of the just-finished drop
+        // is STALE (completedAt/arrivedAt null); recentTasks holds the fresh delivered copy. The stale
+        // mirror copy must NOT mask the finished one (else accountedCount would under-count → the drop
+        // would look un-delivered). Same taskId in both pools.
+        val staleMirrorCopy = Task(taskId = "d1", jobId = "J", phase = TaskPhase.DROPOFF, startedAt = 100L)
+        val freshDelivered = deliveredDrop("d1", "c1")
+        val job = job(listOf("a", "b"), tasks = listOf(staleMirrorCopy, tbdPlaceholder("d-tbd")))
+        val m = detectAcceptMismatch(job, listOf(freshDelivered))
+        assertNotNull(m)
+        assertEquals("the finished recentTasks copy is what counts", 1, m!!.accountedCount)
+        assertEquals(listOf("c1"), m.deliveredCustomerHashes)
+        assertEquals(1, m.leftoverTbdPlaceholders)
+    }
+}


### PR DESCRIPTION
## #810 B1 — `JOB_ACCEPT_MISMATCH` close-reconciliation tripwire

Builds **B1 only** of the #810 design pass (Fable, 2026-07-20). When a job closes carrying MORE
accepted offers than accounted physical orders, the machine now emits ONE `JOB_ACCEPT_MISMATCH`
event + one edge-gated WARN instead of staying silent — the seq-114 invisible-unassign class (2
accepts, 1 delivered drop, 1 never-activated TBD dropoff placeholder, and previously ZERO signal
anywhere because the unassign committed through a support-chat path that rendered no confirmation
screen or click, so no `TASK_UNASSIGNED` ever fired).

**A tripwire only — NO state mutation, NO re-attribution, NO guess about which offer died** (that
attribution is structurally ambiguous; deferred to B2). It only makes the silent seam observable.

### Out of scope (explicitly not built)
- **B2** — orphan `offer_records` resolution / driver-attested correction affordance (dev decision).
- **B3** — the "Select an issue" recognition variant (rides the #796/#806 recognition batch).
- **B4** — timeline owed-set reconciliation (new capture-first issue).
- `endSession`'s direct job-drop bypasses `completeActiveJob` and is deliberately **out of scope v1**
  (an offline-mid-job dash is its own class) — excluded in-code via the `next.session == null` guard.

### Mechanism
1. **Pure detection** (`:domain` `JobAcceptReconciliation.detectAcceptMismatch`): at close,
   `nAccepts = job.acceptedOffers.size` (guarded `>= 2`); `accounted` = distinct delivered dropoffs
   (`completedAt != null && arrivedAt != null && unassignedAt == null`, deduped by `taskId`) +
   distinct unassign-marked orders (`unassignedAt != null`, deduped by customer identity). Tasks are
   the union of `recentTasks` (first — so a finished drop's fresh copy wins the dedup over the stale
   `Job.tasks` mirror copy, the same staleness `isJobPhysicallyComplete` guards against) and
   `job.tasks`, filtered to the job. Fires when `nAccepts > accounted`. Returns the payload directly
   (payload IS the detection result — one SSOT, no parallel data class).
2. **Emission at the effect edge** (`:core:state` `JobCloseEffects.diffJobClose`, the `TASK_UNASSIGNED`
   precedent — stepper marks durable state, effect diffs it): the "mark" is the `activeJob` transition
   itself — a close is `prev.activeJob.jobId` leaving the active slot (cleared to null on T1
   retire / PostTask-exit / #736 abandon step-3, OR reminted to a fresh jobId on T2 close+mint — ALL
   route through `completeActiveJob`). `endSession` also clears `activeJob` but uniquely nulls the
   session, so the `next.session == null` guard excludes it. Per-`jobId` `effectKeyOverride` ⇒
   at-most-once (a job closes single-shot). One edge-gated `Timber.tag("StateMachine").w` — counts +
   jobId + hash *prefixes* (`take(6)`) only.
3. **Read-model-inert**: routes through the projector's liveness `else` arm (mints no record, advances
   liveness like any session event). No `PROJECTOR_VERSION` bump — a new type can't exist in folded
   history. No schema/Room change (payload rides the existing `app_events` TEXT payload). Pin test in
   `RecordFoldsTest`.

### Tests
- `JobAcceptReconciliationTest` (pure, 11 cases): the seq-114 shape fires; a finished 2-drop stack is
  silent; a single-accept drop-less close is silent (`nAccepts < 2`); a properly-#736'd unassign is
  accounted (silent); a pickup+dropoff of the same abandoned order dedupe to one; the fresh
  `recentTasks` copy wins over the stale `job.tasks` mirror; foreign-job tasks ignored.
- `RecordFoldsTest`: `JOB_ACCEPT_MISMATCH` mints no record of any kind, liveness still advances, the
  real delivery beside it still folds.
- **Replay (crown proof)** `AcceptMismatchReplayTest`: reduces the seq-114 shape through the REAL
  `StateMachine` + `EffectMap` and asserts exactly one tripwire fires at the job close with the
  expected counts, the delivered drop still `DELIVERY_COMPLETED`s, and the tripwire fires only on the
  close step.

### Fixture provenance / PII-sweep attestation
The replay reuses the pre-existing, already-PII-swept `single_delivery_2026_06_16` fixture as the
DELIVERED order, plus explicitly-labelled SYNTHETIC injections (the #700 precedent) for (a) the
invisibly-abandoned order's offer+accept — a synthetic offer hash, no customer data — and (b) the
delivered order's suppressed dropoff ARRIVAL, carrying frame 06's OWN already-hashed parsed fields.
**No new device capture fixture is committed** (the fielded seq-114 unassign has no capturable
commit surface — Finding 1 — so a faithful full-device replay is impossible by construction). The
only fixture bytes on disk are the unchanged swept single_delivery ones; the injected orders carry a
synthetic hash / frame 06's already-`sha256`'d customer hash. No raw customer name or address is
introduced. (The 2026-07-20 pull's 14:20:59 UNKNOWN frame with a raw `For <name>` line is NOT used.)

### Design-goal review
- **P1 (UDF):** detection is a pure `:domain` function (no Android, no wall clock — operates on
  `Job`/`Task` shape only); emission is at the `EffectMap` edge diffing prev/next durable state. The
  reducer/stepper is untouched — no logging/IO added there.
- **P5 (SSOT):** the payload IS the detection result (no parallel data class); the union orders
  `recentTasks` first to mirror `isJobPhysicallyComplete`'s completion-truth-from-recentTasks rule
  rather than re-deriving it inconsistently.
- **P6 (privacy):** payload + WARN are hashes + counts only — no store/customer/raw text (P7).
- **P7 (logging):** one WARN (a defended invariant fired), stable `StateMachine` tag (not bare — the
  TimberTagGuard ratchet stays green), hash prefixes `take(6)`, INFO-class milestone payload PII-safe
  by construction.
- **P8 (platform-agnostic):** no platform literals; new vocabulary (`JOB_ACCEPT_MISMATCH`) is an
  enumerated `AppEventType` with its typed payload through the codec — not a magic string + `when`.
  Detection keys on `Job`/`Task` structure only. No rule JSON.

### Adversarial review
_Pending — to be run at fable tier before merge (`/code-review`)._
