### PR TITLE
privacy(rules): #809 — pickup_select_issue redact + issue-list variant recognition

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -136,6 +136,40 @@ class CaptureRedactionCorpusTest {
         )
     }
 
+    @Test
+    fun `every For-family redact masks the fused customer header, keeps the For marker (#809)`() {
+        // #809: the four pickup "For <customer> • <store>" surfaces each ship a
+        // `redact` with keepPrefix ["For "] + normalize customerName. Nothing else
+        // pinned them — the #598 sha256 compile gate needs a sha256 parse (these are
+        // recognize-only), and CustomerTextMarkers has no bare "For " marker — so a
+        // deleted redact block on any of them went unnoticed (mutation-verified: the
+        // full suite stayed green). This is the teeth: an injected fused header node
+        // must mask to "For [redacted:<4hex>]" with no name residue. This is a PIN for
+        // these four explicit ids, NOT a discovery gate — a FIFTH "For "-surface rule
+        // added without redact won't appear in this list; that gap is caught at
+        // author/review time, not here.
+        val forFamily = listOf(
+            "doordash.screen.pickup_select_issue",
+            "doordash.screen.pickup_resolution_options",
+            "doordash.screen.pickup_unassigned_confirmation",
+            "doordash.screen.pickup_unassign_survey",
+        )
+        val maskShape = Regex("""^For \[redacted:[0-9a-f]{4}\]$""")
+        for (id in forFamily) {
+            val rule = TestRulesetFactory.screenRuleset.ruleById(id)!!
+            assertFalse("$id must carry a non-empty redact block (#809)", rule.redact.isEmpty())
+            val masked = rule.redact
+                .apply(UiNode(text = "For Jane Q Doe • STORENAME").restoreParents())
+                .text!!
+            assertFalse("$id: customer first name must not persist", masked.contains("Jane"))
+            assertFalse("$id: customer last name must not persist", masked.contains("Doe"))
+            assertTrue(
+                "$id: fused header must mask to 'For [redacted:<4hex>]' (store tail dropped); got '$masked'",
+                maskShape.matches(masked),
+            )
+        }
+    }
+
     // =========================================================================
     // #501 — the id-less first-name + last-initial customer-name shape. The
     // adversarial-review pledge finding: the runtime redact fail-OPEN on common

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -4185,6 +4185,12 @@
         "shape": null,
         "fields": {}
     },
+    "pickup_select_issue/2026-07-19_14-20-59-652__doordash__accessibility.window__pickup_select_issue__496268.json": {
+        "ruleId": "doordash.screen.pickup_select_issue",
+        "intent": "pickup_select_issue",
+        "shape": null,
+        "fields": {}
+    },
     "pickup_shopping/20260128_170657_958_PICKUP_DETAILS_POST_ARRIVAL_SHOP.json": {
         "ruleId": "doordash.screen.pickup_shopping",
         "intent": "pickup_shopping",

--- a/app/src/test/resources/snapshots/pickup_select_issue/2026-07-19_14-20-59-652__doordash__accessibility.window__pickup_select_issue__496268.json
+++ b/app/src/test/resources/snapshots/pickup_select_issue/2026-07-19_14-20-59-652__doordash__accessibility.window__pickup_select_issue__496268.json
@@ -1,0 +1,670 @@
+{
+    "captureId": "b62ff885-60bf-4217-8216-1d347b68cf93",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784488859647,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2311
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2311
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2311
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2311
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1042,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1042,
+                                                                                                    "bottom": 2311
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 236,
+                                                                                                            "right": 1006,
+                                                                                                            "bottom": 847
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "Select an issue",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 272,
+                                                                                                                    "right": 1006,
+                                                                                                                    "bottom": 329
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 365,
+                                                                                                                    "right": 1006,
+                                                                                                                    "bottom": 847
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 365,
+                                                                                                                            "right": 1006,
+                                                                                                                            "bottom": 486
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 365,
+                                                                                                                                    "right": 1006,
+                                                                                                                                    "bottom": 484
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 365,
+                                                                                                                                            "right": 970,
+                                                                                                                                            "bottom": 484
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Order has long wait time",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 401,
+                                                                                                                                                    "right": 970,
+                                                                                                                                                    "bottom": 448
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 970,
+                                                                                                                                            "top": 407,
+                                                                                                                                            "right": 1006,
+                                                                                                                                            "bottom": 443
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "desc": "",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 970,
+                                                                                                                                                    "top": 407,
+                                                                                                                                                    "right": 1006,
+                                                                                                                                                    "bottom": 443
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 432,
+                                                                                                                                    "right": 1006,
+                                                                                                                                    "bottom": 486
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 486,
+                                                                                                                            "right": 1006,
+                                                                                                                            "bottom": 607
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 486,
+                                                                                                                                    "right": 1006,
+                                                                                                                                    "bottom": 605
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 486,
+                                                                                                                                            "right": 970,
+                                                                                                                                            "bottom": 605
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Red Card issues",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 522,
+                                                                                                                                                    "right": 970,
+                                                                                                                                                    "bottom": 569
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 970,
+                                                                                                                                            "top": 528,
+                                                                                                                                            "right": 1006,
+                                                                                                                                            "bottom": 564
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "desc": "",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 970,
+                                                                                                                                                    "top": 528,
+                                                                                                                                                    "right": 1006,
+                                                                                                                                                    "bottom": 564
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 553,
+                                                                                                                                    "right": 1006,
+                                                                                                                                    "bottom": 607
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 607,
+                                                                                                                            "right": 1006,
+                                                                                                                            "bottom": 728
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 607,
+                                                                                                                                    "right": 1006,
+                                                                                                                                    "bottom": 726
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 607,
+                                                                                                                                            "right": 970,
+                                                                                                                                            "bottom": 726
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "I was in a vehicle crash",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 643,
+                                                                                                                                                    "right": 970,
+                                                                                                                                                    "bottom": 690
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 970,
+                                                                                                                                            "top": 649,
+                                                                                                                                            "right": 1006,
+                                                                                                                                            "bottom": 685
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "desc": "",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 970,
+                                                                                                                                                    "top": 649,
+                                                                                                                                                    "right": 1006,
+                                                                                                                                                    "bottom": 685
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 674,
+                                                                                                                                    "right": 1006,
+                                                                                                                                    "bottom": 728
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 728,
+                                                                                                                            "right": 1006,
+                                                                                                                            "bottom": 847
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 728,
+                                                                                                                                    "right": 1006,
+                                                                                                                                    "bottom": 847
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 728,
+                                                                                                                                            "right": 970,
+                                                                                                                                            "bottom": 847
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "It's something else",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 764,
+                                                                                                                                                    "right": 970,
+                                                                                                                                                    "bottom": 811
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 970,
+                                                                                                                                            "top": 770,
+                                                                                                                                            "right": 1006,
+                                                                                                                                            "bottom": 806
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "desc": "",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 970,
+                                                                                                                                                    "top": 770,
+                                                                                                                                                    "right": 1006,
+                                                                                                                                                    "bottom": 806
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1042,
+                                                                                                            "bottom": 236
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 1024,
+                                                                                                                    "bottom": 225
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 78,
+                                                                                                                            "bottom": 234
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 154,
+                                                                                                                                    "right": 51,
+                                                                                                                                    "bottom": 207
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 69,
+                                                                                                                            "top": 137,
+                                                                                                                            "right": 953,
+                                                                                                                            "bottom": 225
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "I have an issue",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 364,
+                                                                                                                                    "top": 137,
+                                                                                                                                    "right": 659,
+                                                                                                                                    "bottom": 189
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "For Sample C. • H-E-B",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 338,
+                                                                                                                                    "top": 189,
+                                                                                                                                    "right": 684,
+                                                                                                                                    "bottom": 225
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 182,
+                                                                                                                    "right": 1042,
+                                                                                                                    "bottom": 288
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 1042,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 1062,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2311
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 1069,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 236
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 1069,
+                                                                                                                    "top": 182,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 288
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 1062,
+                                                                                                            "top": 1769,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2311
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/matchers/rules/doordash/pickup.json5
+++ b/matchers/rules/doordash/pickup.json5
@@ -575,22 +575,63 @@
       }
     },
     {
+      "comment": "The pickup 'Select an issue' list. #809: carries the SAME 'For <customer> • <store>' redact as its sibling resolution surfaces (pickup_resolution_options / pickup_unassign_survey). Recognize-only (no parse), so redact-without-parse is legal (the survey precedent); the fused header node's post-'For ' remainder — customer name AND the ' • <store>' tail — is masked to '[redacted:<4hex>]', so the store tail does NOT survive. That is fine here: no anchor or parse rides the header line (the anchors are the separate 'Select an issue' + option nodes), and no other rule reads this surface's store from that node. B3 (#810 design): a SECOND branch recognizes the option-set variant that lacks 'Order already picked up'.",
       "id": "doordash.screen.pickup_select_issue",
       "priority": 102,
-      "require": {
-        "all": [
-          {
-            "exists": {
-              "hasTextContaining": "Select an issue"
-            }
+      "redact": [
+        {
+          "find": {
+            "hasTextStartsWith": "For "
           },
-          {
-            "exists": {
-              "hasTextContaining": "Order already picked up"
-            }
+          "keepPrefix": [
+            "For "
+          ],
+          "normalize": "customerName"
+        }
+      ],
+      "branches": [
+        {
+          "comment": "Original 'Select an issue' list reached via the already-picked-up path.",
+          "require": {
+            "all": [
+              {
+                "exists": {
+                  "hasTextContaining": "Select an issue"
+                }
+              },
+              {
+                "exists": {
+                  "hasTextContaining": "Order already picked up"
+                }
+              }
+            ]
           }
-        ]
-      }
+        },
+        {
+          "comment": "#809 B3 — the 'Select an issue' variant option-set (Red Card issues / vehicle crash / 'It's something else' / 'I have an issue') that lacks the 'Order already picked up' option; session-114 (2026-07-19 14:20:59) fell to UNKNOWN. Same surface, same intent, recognize-only. The reject of 'Resolution options' is load-bearing: the deeper combined resolution panel (pickup_resolution_options, priority 103) scrolls this SAME issue list above its own 'Resolution options' content, so it also carries 'Select an issue' + 'It's something else' — and because 102 evaluates before 103, without this belt a resolution frame would misclassify as select_issue. Anchor discipline (#738): 'Select an issue' + 'It's something else' + reject 'Resolution options' is corpus-unique (verified: no non-resolution frame carries both anchors).",
+          "reject": [
+            {
+              "exists": {
+                "hasTextContaining": "Resolution options"
+              }
+            }
+          ],
+          "require": {
+            "all": [
+              {
+                "exists": {
+                  "hasTextContaining": "Select an issue"
+                }
+              },
+              {
+                "exists": {
+                  "hasTextContaining": "It's something else"
+                }
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "comment": "Deeper than pickup_select_issue — the resolution panel reached after picking an issue. Keyed on its own distinctive strings so it never overlaps the issue list.",


### PR DESCRIPTION
Closes #809. Bundles B3 of the #810 design (same file, same `For ` redact family).

## Part A — #809 proper: redact on `pickup_select_issue`

`doordash.screen.pickup_select_issue` (matchers/rules/doordash/pickup.json5, priority 102) shipped **no `redact`** for the fused `"For <FirstName> <I>. • <store>"` header node, so the raw customer name reached every on-device capture of that surface. Added the exact block its sibling resolution surfaces already carry (`pickup_resolution_options` / `pickup_unassigned_confirmation` / `pickup_unassign_survey`, the #736 precedent):

```json5
"redact": [ { "find": { "hasTextStartsWith": "For " }, "keepPrefix": [ "For " ], "normalize": "customerName" } ]
```

The rule is recognize-only (no `parse`), so redact-without-parse is legal (the `pickup_unassign_survey` precedent) and the golden is unchanged for parse (`fields: {}`).

### Masker fused-node finding (the #809 question)

Read `CompiledRedact.mask` (`core/pipeline/.../rules/CompiledRules.kt`). For a node whose whole text is `"For Samiraben P. • H-E-B"`:
- `keepPrefix` matches `"For "`; `stripped = "Samiraben P. • H-E-B"` (trimmed).
- `normalize: customerName` → `customerNameKey(stripped)` → tokens `[samiraben, p, heb]` → key `"samiraben p"` (first token + second-token initial; the `•`/`.`/`-` are stripped as non-alphanumeric). So the hash suffix is derived from name-only, ignoring the store tail — stable across name renderings, exactly the #623/#733 invariant.
- Output = `prefix + "[redacted:<4hex>]"` = **`"For [redacted:<4hex>]"`**.

**So the entire post-`For ` remainder — the customer name AND the ` • <store>` tail — is masked into the single `[redacted:<4hex>]` token; the store name does NOT survive.** This is acceptable and documented in the rule comment: no anchor or parse rides the header line (the recognition anchors are the separate `"Select an issue"` + option nodes), and no rule reads this surface's store from that node.

**Empirical receipt** — real captures of the sibling `For ` redact already in the corpus (`pickup_resolution_options/*.json`) render exactly `"text": "For [redacted:5d02]"` / `"For [redacted:e386]"` / `"For [redacted:eacf]"` — no store tail, confirming the masker behavior on-device.

The two pre-existing `pickup_select_issue` fixtures still recognize (folder-name intent guard green) and their parse output is byte-unchanged in the golden (redact does not alter parse).

## Part B — bundled B3: recognize the "Select an issue" VARIANT

Session-114 evidence (2026-07-19 14:20:59) captured a variant issue-list screen — anchors `"Select an issue"` + `"Order has long wait time"` / `"Red Card issues"` / `"I was in a vehicle crash"` / `"It's something else"` / `"I have an issue"`, plus the fused `"For <name> • <store>"` line — that **lacked** `"Order already picked up"` and therefore fell to UNKNOWN under the existing single-require rule.

Added as a **second branch** of `pickup_select_issue` (recognize-only, no `state`; classifies AS the existing intent — same semantic surface, the pickup issue-selection list, just a different option set). The rule-level `redact` covers both branches.

**Intent-folder decision:** `pickup_select_issue` (existing intent). Per the spec's "prefer classifying to the EXISTING intent unless the surfaces genuinely differ semantically" — both branches are the same issue-selection list; only the option rows differ. Cleaner than a new intent id, and the shared rule-level redact protects both.

### Anchor-uniqueness receipts (#738 discipline)

Two conjunctive anchors: `"Select an issue"` + `"It's something else"`, plus a **reject** of `"Resolution options"`.

- The variant anchors are **not** unique on their own — `"Select an issue"` / `"It's something else"` / `"Red Card issues"` / `"I was in a vehicle crash"` all also appear in `pickup_resolution_options` fixtures. That panel scrolls the SAME issue list above its own `"Resolution options"` content. Because 102 evaluates before 103, without a belt this rule would **steal** every resolution frame → the reject of `"Resolution options"` is load-bearing.
- After the reject, corpus-wide there is **no** frame carrying both `"Select an issue"` + `"It's something else"` that lacks `"Resolution options"` (verified by grep over the whole snapshot corpus; the one `sessions/.../04_pickup_resolution_early.json` that has the anchors also has `"Resolution options"` → excluded).
- Branch 1 (existing) requires `"Order already picked up"`, which no `pickup_resolution_options` fixture carries → the two branches don't need cross-rejects, and branch 1 is unaffected.

### Fixture / PII attestation

Source: `~/dashbuddy/logs/2026/07/20/captures/doordash/.../UNKNOWN/2026-07-19_14-20-59-652__doordash__accessibility.window__UNKNOWN__496268.json`, which carried a **raw** customer name (`"For Samiraben P. • H-E-B"`).

- Manually anonymized **before** it entered the repo: `"Samiraben P."` → `"Sample C."` (the #736 "Kelly S." precedent — structure preserved, matches the existing `"Sample C."`/`"Sample R."` fixtures), then a generic `Samiraben` → `Sample` sweep (0 residual). `H-E-B` is a store name (kept per Pledge — customers hashed, stores kept).
- Full generic sweep of every `text`/`desc`/`hint`/`contentDescription` value: the only non-generic string was the anonymized `For ` node; all `desc` fields empty; the only 5+ digit sequences are the capture `timestamp` and the device build fingerprint (no phone/address/PII).
- Ran through the Inbox workflow: `InboxProcessorTest` sorted it into `pickup_select_issue/` (recognized as the variant), no PII failure. Committed from the sorted category folder, renamed to the intent convention (`…__pickup_select_issue__496268.json`).

### Golden diff shape

Additions-only — one new entry, recognize-only (no parse), no existing entry changed:

```
+ "pickup_select_issue/2026-07-19_14-20-59-652__…__pickup_select_issue__496268.json": {
+     "ruleId": "doordash.screen.pickup_select_issue",
+     "intent": "pickup_select_issue",
+     "shape": null,
+     "fields": {}
+ }
```

## Tests

`InboxProcessorTest` ✅ (sorted, no PII) · `AllMatchersSuite` ✅ (golden guard + ruleset + classifier + regenerated parse golden) · full `testDebugUnitTest :domain:test` ✅ (718 recognition + all module tests green). Zero Kotlin changes — rules are data.

### Design-goal review

- **P6 (security & privacy first).** This is a pure privacy hardening: the `For ` redact closes a raw-customer-name-to-disk leak on `pickup_select_issue`, matching the established sibling-surface control; masks to `[redacted:<4hex>]` (edge-hashed, per-customer-distinct, fail-closed to `[redacted]`). Recognition-side: the new variant branch is recognize-only (no `state`, no effect) and cannot perturb the state machine; it only pulls a customer-bearing surface out of UNKNOWN and under the rule's redact. No block-side downgrade, no new raw-PII storage. Fixture manually anonymized before entering the repo (attestation above).
- **P8 (platform-agnostic core).** Data-only change (rule JSON + corpus). No Kotlin, no platform literals, no new rule↔state vocabulary; `customerName` normalize + `For ` marker are existing cross-platform redact data. Adding this surface needed zero `:core:*`/`:domain` edits.
- **P5 (SSOT).** Reuses the one `CompiledRedact.mask` / `customerNameKey` path and the existing `For ` marker; no new masker, no duplicated constant.

### Adversarial review

Pending — to be run by the caller (fable `/code-review` + `/security-review`) per the merge policy. Not merged.
