### PR TITLE
privacy: #803 — id-less instructions-body redaction (pin keyword + rule redact + scanner shape)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -187,9 +187,14 @@ class CaptureRedactionCorpusTest {
             ruleRedactRegexes("doordash.screen.dropoff_multi_order_confirm")
                 .contains(SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN),
         )
-        // FIX 3 defense-in-depth: the two earlier-priority rules that could win a
-        // modal-over-handoff combined frame carry the SAME pattern.
-        for (id in listOf("doordash.screen.dropoff_navigation", "doordash.screen.dropoff_handoff")) {
+        // FIX 3 defense-in-depth + #803: the earlier-priority rules that could win a
+        // modal-over-handoff combined frame, AND the pin_entry surface whose id-less
+        // body carries the same name shape, all carry the SAME canonical pattern.
+        for (id in listOf(
+            "doordash.screen.dropoff_navigation",
+            "doordash.screen.dropoff_handoff",
+            "doordash.screen.dropoff_pin_entry",
+        )) {
             assertTrue(
                 "$id must carry the canonical name-shape regex (FIX 3 defense-in-depth)",
                 ruleRedactRegexes(id).contains(SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN),
@@ -291,6 +296,34 @@ class CaptureRedactionCorpusTest {
         assertFalse("embedded customer name must not persist", masked.contains("John Smith"))
         assertFalse("step_description instruction must not persist", masked.contains("Ask John"))
         assertTrue("require anchor (step_title) kept", masked.contains("Collect PIN from customer"))
+    }
+
+    @Test
+    fun `dropoff_pin_entry redact masks pin colon-fused variants and a bare gate code (#803 F1-F3)`() {
+        // Each body is the id-less instructions node; the token variant must mask the
+        // WHOLE body (embedded name "Casey Doe" included). Covers the colon / fused /
+        // bare-gate shapes the first-cut regex missed.
+        val bodies = listOf(
+            "Casey Doe PIN: 4821 at the back",
+            "Casey Doe pin:4821",
+            "Casey Doe Pin4821",
+            "Casey Doe gate 4821 then knock", // bare gate, no "code" token
+            "Casey Doe Gate: 4821",
+        )
+        val rule = TestRulesetFactory.screenRuleset.ruleById("doordash.screen.dropoff_pin_entry")!!
+        for (body in bodies) {
+            val tree = UiNode(
+                viewIdResourceName = "com.dd:id/drop_off_workflow_host_fragment",
+                children = listOf(
+                    UiNode(text = "Hand it to customer"),
+                    UiNode(text = body),
+                    UiNode(viewIdResourceName = "com.dd:id/step_title", text = "Collect PIN from customer"),
+                ),
+            ).restoreParents()
+            val masked = serialize(rule.redact.apply(tree))
+            assertFalse("'$body' -> code must not persist: $masked", masked.contains("4821"))
+            assertFalse("'$body' -> embedded name must not persist: $masked", masked.contains("Casey Doe"))
+        }
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -256,6 +256,66 @@ class CaptureRedactionCorpusTest {
         node.children.forEach { walkText(it, visit) }
     }
 
+    // =========================================================================
+    // #803 — the id-less delivery-instructions-body blind class. The rule redact
+    // is the PRIMARY (runtime-edge) control: it masks the WHOLE offending node, so
+    // a gate-code / PIN fragment takes the embedded customer name with it. These
+    // build a synthetic live (un-redacted) capture, confirm recognition still lands
+    // on the surface, then assert its redact masks the body while the require
+    // anchors survive — redaction is capture-only, never touching parse (both rules
+    // are parse-less; the goldens are byte-identical).
+    // =========================================================================
+
+    @Test
+    fun `dropoff_pin_entry redact masks the id-less instructions body PIN, gate code, and embedded name (#803)`() {
+        val tree = UiNode(
+            viewIdResourceName = "com.dd:id/drop_off_workflow_host_fragment",
+            children = listOf(
+                UiNode(text = "Hand it to customer"),
+                // The id-less free-text instructions body — the blind class: no viewId,
+                // an embedded full name, plus the gate code + PIN that reached disk raw.
+                UiNode(text = "John Smith gate code 8834 pin 4821"),
+                UiNode(viewIdResourceName = "com.dd:id/step_title", text = "Collect PIN from customer"),
+                UiNode(viewIdResourceName = "com.dd:id/step_description", text = "Ask John for the entry code"),
+            ),
+        ).restoreParents()
+
+        val match = TestRulesetFactory.screenRuleset.matchFirst(tree)
+        assertEquals("doordash.screen.dropoff_pin_entry", match?.ruleId)
+        val rule = TestRulesetFactory.screenRuleset.ruleById(match!!.ruleId)!!
+        assertFalse("pin_entry must now carry a redact block", rule.redact.isEmpty())
+
+        val masked = serialize(rule.redact.apply(tree))
+        assertFalse("PIN must not persist", masked.contains("4821"))
+        assertFalse("gate code must not persist", masked.contains("8834"))
+        assertFalse("embedded customer name must not persist", masked.contains("John Smith"))
+        assertFalse("step_description instruction must not persist", masked.contains("Ask John"))
+        assertTrue("require anchor (step_title) kept", masked.contains("Collect PIN from customer"))
+    }
+
+    @Test
+    fun `dropoff_handoff redact masks the id-less instructions body gate code and PIN (#803)`() {
+        val tree = UiNode(
+            viewIdResourceName = "com.dd:id/drop_off_workflow_host_fragment",
+            children = listOf(
+                UiNode(text = "hand it to customer"),
+                UiNode(text = "Meet me at the back. gate code 5567 pin 9032"),
+                UiNode(viewIdResourceName = "com.dd:id/step_description", text = "Text Jane on arrival"),
+                UiNode(text = "Complete Delivery"), // arrival CTA discriminator
+            ),
+        ).restoreParents()
+
+        val match = TestRulesetFactory.screenRuleset.matchFirst(tree)
+        assertEquals("doordash.screen.dropoff_handoff", match?.ruleId)
+        val rule = TestRulesetFactory.screenRuleset.ruleById(match!!.ruleId)!!
+
+        val masked = serialize(rule.redact.apply(tree))
+        assertFalse("gate code must not persist", masked.contains("5567"))
+        assertFalse("PIN must not persist", masked.contains("9032"))
+        assertFalse("step_description instruction must not persist", masked.contains("Text Jane"))
+        assertTrue("arrival CTA anchor kept", masked.contains("Complete Delivery"))
+    }
+
     @Test
     fun `every screen rule that hashes PII declares a redact block`() {
         var checked = 0

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/InstructionsBodyPiiScrubTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/InstructionsBodyPiiScrubTest.kt
@@ -1,0 +1,81 @@
+package cloud.trotter.dashbuddy.test.util
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #803 — the id-less delivery-instructions-body blind class. A residence-entry
+ * PIN ("pin 4821") embedded in a free-text instructions body reached a corpus
+ * candidate past every layer. These pin down the two test-side controls this
+ * issue adds: [SnapshotRedactor]'s `pin` keyword mask (scrubs a NEW inbound
+ * fixture) and [SnapshotSecurityScanner]'s `pin` shape (fails the corpus gate on
+ * recurrence).
+ */
+class InstructionsBodyPiiScrubTest {
+
+    // --- SnapshotRedactor: the `pin <digits>` mask (digit-adjacent) -----------
+
+    /** Route a raw text value through the redactor exactly as an id-less fixture node would. */
+    private fun scrubText(raw: String): String =
+        SnapshotRedactor.redact("""{"text":"${raw.replace("\"", "\\\"")}"}""")
+
+    @Test
+    fun `pin followed by digits is masked, keeping the lead-in`() {
+        for (raw in listOf("pin 4821", "PIN: 4821", "PIN #4821", "Your pin 4821 opens the gate")) {
+            val out = scrubText(raw)
+            assertFalse("digits must not survive in '$raw' -> $out", out.contains("4821"))
+            assertTrue("pin lead-in kept in '$raw' -> $out", out.contains(SnapshotRedactor.MASK))
+        }
+    }
+
+    @Test
+    fun `pin without adjacent digits is left untouched (no false positive)`() {
+        // "PIN pad" / "pin it" / a word merely containing 'pin' must NOT be masked.
+        for (raw in listOf("PIN pad", "pin it to the board", "Enter PIN code", "shopping list", "opinion")) {
+            val out = scrubText(raw)
+            assertFalse("'$raw' must not be masked -> $out", out.contains(SnapshotRedactor.MASK))
+        }
+    }
+
+    // --- SnapshotSecurityScanner: the corpus-gate `pin <digits>` shape --------
+
+    @Test
+    fun `scanner flags a pin-code fragment as toxic`() {
+        val tree = UiNode(
+            children = listOf(
+                UiNode(text = "Hand it to customer"),
+                UiNode(text = "Leave at door. pin 1234 to enter"), // the id-less instructions body
+            ),
+        ).restoreParents()
+        val result = SnapshotSecurityScanner.scan(tree)
+        assertTrue("a 'pin 1234' fragment must make the fixture toxic", result.isToxic)
+        assertTrue(
+            "trigger names the pin shape",
+            result.triggers.any { it.second == "pin-code-shape" },
+        )
+    }
+
+    @Test
+    fun `scanner does not flag pin-adjacent non-PII text`() {
+        val tree = UiNode(
+            children = listOf(
+                UiNode(text = "Enter PIN code"),
+                UiNode(text = "PIN code not provided"),
+                UiNode(text = "Collect PIN from customer"),
+            ),
+        ).restoreParents()
+        val result = SnapshotSecurityScanner.scan(tree)
+        assertFalse("pin UI copy without adjacent digits must stay clean", result.isToxic)
+    }
+
+    @Test
+    fun `scanner requires at least three digits`() {
+        // Two digits after "pin" (unlikely to be a real code) stays clean; the
+        // gate targets the 3+ digit residence-PIN shape.
+        val tree = UiNode(text = "pin 42 stars").restoreParents()
+        assertEquals(false, SnapshotSecurityScanner.scan(tree).isToxic)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/InstructionsBodyPiiScrubTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/InstructionsBodyPiiScrubTest.kt
@@ -24,7 +24,11 @@ class InstructionsBodyPiiScrubTest {
 
     @Test
     fun `pin followed by digits is masked, keeping the lead-in`() {
-        for (raw in listOf("pin 4821", "PIN: 4821", "PIN #4821", "Your pin 4821 opens the gate")) {
+        // Space, colon (spaced + fused), hash, fully fused (no separator), and mid-body.
+        for (raw in listOf(
+            "pin 4821", "PIN: 4821", "pin:4821", "PIN #4821", "Pin4821",
+            "Your pin 4821 opens the gate",
+        )) {
             val out = scrubText(raw)
             assertFalse("digits must not survive in '$raw' -> $out", out.contains("4821"))
             assertTrue("pin lead-in kept in '$raw' -> $out", out.contains(SnapshotRedactor.MASK))
@@ -56,6 +60,14 @@ class InstructionsBodyPiiScrubTest {
             "trigger names the pin shape",
             result.triggers.any { it.second == "pin-code-shape" },
         )
+    }
+
+    @Test
+    fun `scanner flags pin colon and fused variants and a bare gate code`() {
+        for (body in listOf("PIN: 1234", "Pin1234", "gate 4821", "Gate: 4821")) {
+            val tree = UiNode(text = body).restoreParents()
+            assertTrue("'$body' must be flagged", SnapshotSecurityScanner.scan(tree).isToxic)
+        }
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
@@ -113,6 +113,16 @@ object SnapshotRedactor {
         "^\\s{0,8}[\\p{L}][\\p{L}'-]{0,20}( [\\p{L}][\\p{L}'-]{0,20}){0,3} [A-Z]\\.?\\s{0,8}$"
     private val FIRST_LAST_INITIAL = Regex(FIRST_LAST_INITIAL_PATTERN, RegexOption.IGNORE_CASE)
     private val APT = Regex("""(?i)\b(apt|suite|ste|unit|bldg|building|gate code|gate)\b[:#\s]*[A-Za-z0-9\-]+""")
+    /**
+     * A residence-entry PIN, e.g. "pin 4821" / "PIN: 4821" / "PIN #4821" (#803). Kept
+     * SEPARATE from [APT]'s alternation (never folded in) because "pin" needs a
+     * **digit-adjacency** guard the APT shape lacks — `[:#\s]*[A-Za-z0-9-]+` would
+     * mask "PIN pad" / "pin it". Word-bounded (`\bpin\b`, so "shopping"/"opinion"
+     * don't match) and requires ≥3 trailing digits, so only an actual code is masked;
+     * the "pin" lead-in is kept, the digits become [MASK]. The paired
+     * [SnapshotSecurityScanner] shape is the corpus gate that catches recurrence.
+     */
+    private val PIN = Regex("""(?i)\b(pin)\b[\s:#]*#?\s*\d{3,}""")
     /** A quoted free-text customer note, e.g. "Corner House, please leave at door." — customer-entered, mask whole. */
     private val QUOTED_NOTE = Regex(""""[^"]{6,}"""")
 
@@ -195,6 +205,7 @@ object SnapshotRedactor {
         t = CARD.replace(t, "[card]")
         t = QUOTED_NOTE.replace(t, "\"[note]\"")
         t = APT.replace(t) { it.value.substringBefore(it.groupValues[1]) + it.groupValues[1] + " " + MASK }
+        t = PIN.replace(t) { it.groupValues[1] + " " + MASK }
         t = FULL_ADDRESS.replace(t, "[address]")
         t = STREET.replace(t, "[address]")
         t = CITY_STATE_ZIP.replace(t, "[address]")

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
@@ -114,15 +114,18 @@ object SnapshotRedactor {
     private val FIRST_LAST_INITIAL = Regex(FIRST_LAST_INITIAL_PATTERN, RegexOption.IGNORE_CASE)
     private val APT = Regex("""(?i)\b(apt|suite|ste|unit|bldg|building|gate code|gate)\b[:#\s]*[A-Za-z0-9\-]+""")
     /**
-     * A residence-entry PIN, e.g. "pin 4821" / "PIN: 4821" / "PIN #4821" (#803). Kept
-     * SEPARATE from [APT]'s alternation (never folded in) because "pin" needs a
-     * **digit-adjacency** guard the APT shape lacks — `[:#\s]*[A-Za-z0-9-]+` would
-     * mask "PIN pad" / "pin it". Word-bounded (`\bpin\b`, so "shopping"/"opinion"
-     * don't match) and requires ≥3 trailing digits, so only an actual code is masked;
-     * the "pin" lead-in is kept, the digits become [MASK]. The paired
-     * [SnapshotSecurityScanner] shape is the corpus gate that catches recurrence.
+     * A residence-entry PIN, e.g. "pin 4821" / "PIN: 4821" / "pin:4821" / "Pin4821"
+     * (#803). Kept SEPARATE from [APT]'s alternation (never folded in) because "pin"
+     * needs a **digit-adjacency** guard the APT shape lacks — `[:#\s]*[A-Za-z0-9-]+`
+     * would mask "PIN pad" / "pin it". Word-bounded lead-in (`\bpin`, so
+     * "shopping"/"opinion" don't match), a `[\s:#]` separator class (covers the colon
+     * variants), and **no trailing `\b`** so the fused "Pin4821" shape is caught too —
+     * "pinch"/"opinion" stay clean because the char after "pin" is constrained to
+     * `[\s:#]` or a digit. Requires ≥3 trailing digits; the "pin" lead-in is kept, the
+     * digits become [MASK]. Byte-aligned with the rule-side `\bpin[\s:#]*\d{3}` and the
+     * [SnapshotSecurityScanner] shape (three-layer parity, #362 class).
      */
-    private val PIN = Regex("""(?i)\b(pin)\b[\s:#]*#?\s*\d{3,}""")
+    private val PIN = Regex("""(?i)\b(pin)[\s:#]*\d{3,}""")
     /** A quoted free-text customer note, e.g. "Corner House, please leave at door." — customer-entered, mask whole. */
     private val QUOTED_NOTE = Regex(""""[^"]{6,}"""")
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScanner.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScanner.kt
@@ -23,7 +23,11 @@ object SnapshotSecurityScanner {
      *   instructions body. This is the exact fragment that reached a corpus
      *   candidate id-less (no viewId → no rule/test id-scrub) and survived every
      *   layer; making it a corpus-gate failure stops recurrence in ANY future
-     *   fixture. Digit-adjacency (≥3 digits) keeps "PIN pad"/"pin it" clean.
+     *   fixture. A `[\s:#]` separator class + no trailing `\b` (byte-aligned with the
+     *   rule redact + [SnapshotRedactor.PIN]) catches "PIN: 4821"/"Pin4821";
+     *   digit-adjacency (≥3 digits) keeps "PIN pad"/"pin it"/"opinion" clean.
+     * - `gate \d{3,}` — a bare residence gate code ("gate 4821", no "code" token) in
+     *   the same free-text body (#803 F1/F3). Same separator class + digit-adjacency.
      *
      * Deliberately NOT added: an embedded full-name bigram (`[A-Z][a-z]+ [A-Z][a-z]+`).
      * The scanner runs over the whole committed corpus, which legitimately carries
@@ -34,7 +38,8 @@ object SnapshotSecurityScanner {
      * `CaptureRedactionCorpusTest` (FIX 4), so it needs no scanner duplicate.
      */
     private val SENSITIVE_SHAPES: List<Pair<Regex, String>> = listOf(
-        Regex("""(?i)\bpin\b[\s:#]*#?\s*\d{3,}""") to "pin-code-shape",
+        Regex("""(?i)\bpin[\s:#]*\d{3,}""") to "pin-code-shape",
+        Regex("""(?i)\bgate[\s:#]*\d{3,}""") to "gate-code-shape",
     )
 
     data class ScanResult(

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScanner.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScanner.kt
@@ -15,6 +15,28 @@ object SnapshotSecurityScanner {
 
     private val SENSITIVE_KEYWORDS = SensitiveTextMarkers.KEYWORDS
 
+    /**
+     * Regex SHAPES that mark PII a bare keyword can't (the #803 blind class). Each
+     * pairs a pattern with a synthetic "keyword" label for the trigger report.
+     *
+     * - `pin \d{3,}` — a residence-entry PIN embedded in a free-text delivery-
+     *   instructions body. This is the exact fragment that reached a corpus
+     *   candidate id-less (no viewId → no rule/test id-scrub) and survived every
+     *   layer; making it a corpus-gate failure stops recurrence in ANY future
+     *   fixture. Digit-adjacency (≥3 digits) keeps "PIN pad"/"pin it" clean.
+     *
+     * Deliberately NOT added: an embedded full-name bigram (`[A-Z][a-z]+ [A-Z][a-z]+`).
+     * The scanner runs over the whole committed corpus, which legitimately carries
+     * merchant/street/UI two-word capitalized phrases ("Maple Street", "Farmers
+     * Market", "Complete Delivery"); a bigram scan would false-positive heavily on
+     * driver-owned, non-PII text. The whole-value first-name+last-initial name shape
+     * is already owned by [SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN] and pinned by
+     * `CaptureRedactionCorpusTest` (FIX 4), so it needs no scanner duplicate.
+     */
+    private val SENSITIVE_SHAPES: List<Pair<Regex, String>> = listOf(
+        Regex("""(?i)\bpin\b[\s:#]*#?\s*\d{3,}""") to "pin-code-shape",
+    )
+
     data class ScanResult(
         val isToxic: Boolean,
         val triggers: List<Pair<String, String>> = emptyList()
@@ -48,6 +70,10 @@ object SnapshotSecurityScanner {
 
         if (keyword != null) {
             results.add(text to keyword)
+        }
+        // #803: keyword-invisible PII shapes (e.g. a "pin 4821" fragment).
+        SENSITIVE_SHAPES.firstOrNull { (re, _) -> re.containsMatchIn(text) }?.let { (_, label) ->
+            results.add(text to label)
         }
         node.children.forEach { walkAndFind(it, results) }
     }

--- a/matchers/rules/doordash/dropoff.json5
+++ b/matchers/rules/doordash/dropoff.json5
@@ -262,8 +262,15 @@
           }
         },
         {
+          "comment": "#803 F1/F3: bare 'gate 4821' (no 'code' token) — word-bounded, digit-adjacent (3+); the [\\s:#] separator class covers 'gate: 4821' / 'gate#4821' / 'Gate4821'. Masks the whole body incl. any embedded name.",
           "find": {
-            "hasTextMatchesRegex": "\\bpin\\b\\s*#?\\s*\\d{3}"
+            "hasTextMatchesRegex": "\\bgate[\\s:#]*\\d{3}"
+          }
+        },
+        {
+          "comment": "#803 F1/F3: 'pin 4821' / 'PIN: 4821' / 'pin:4821' / 'Pin4821'. The [\\s:#] separator class covers the colon variants the first cut missed; dropping the trailing \\b closes the fused 'Pin4821' shape. 'pinch'/'opinion' stay clean — the next char is constrained to [\\s:#] or a digit. Aligned byte-for-byte with SnapshotRedactor.PIN + the scanner shape (three-layer parity, #362 class).",
+          "find": {
+            "hasTextMatchesRegex": "\\bpin[\\s:#]*\\d{3}"
           }
         },
         {
@@ -371,8 +378,15 @@
           }
         },
         {
+          "comment": "#803 F1/F3: bare 'gate 4821' (no 'code' token) — word-bounded, digit-adjacent (3+); [\\s:#] covers 'gate: 4821'/'gate#4821'/'Gate4821'.",
           "find": {
-            "hasTextMatchesRegex": "\\bpin\\b\\s*#?\\s*\\d{3}"
+            "hasTextMatchesRegex": "\\bgate[\\s:#]*\\d{3}"
+          }
+        },
+        {
+          "comment": "#803 F1/F3: 'pin 4821' / 'PIN: 4821' / 'pin:4821' / 'Pin4821'. [\\s:#] separator + dropped trailing \\b close the colon + fused variants; 'pinch'/'opinion' stay clean. SSOT with SnapshotRedactor.PIN + the scanner shape.",
+          "find": {
+            "hasTextMatchesRegex": "\\bpin[\\s:#]*\\d{3}"
           }
         },
         {

--- a/matchers/rules/doordash/dropoff.json5
+++ b/matchers/rules/doordash/dropoff.json5
@@ -249,6 +249,86 @@
     {
       "id": "doordash.screen.dropoff_pin_entry",
       "priority": 63,
+      "comment": "#803: the id-less delivery-instructions body on this PIN-collect surface carried a customer full name + residence gate code + PIN past EVERY redaction layer — id-less (no viewId predicate), embedded mid-body (no whole-value name/marker match). The rule predicate vocabulary is per-node only (no sibling/parent relation), so the id-less free-text body cannot be isolated by STRUCTURE alone. These CONTENT-shape predicates instead mask the WHOLE offending node whenever it carries a gate code / PIN / address / whole-value name: a gate-code OR PIN fragment masks the entire body (embedded name included), which closes the FIELDED leak at the runtime capture edge. A bare embedded name with NO other PII anchor is the documented residual (the test-side pin keyword + SnapshotSecurityScanner shape + the #806 UNKNOWN CustomerTextMarkers path are the complementary controls). Mirrors dropoff_handoff's id-less shape set + the shared FIRST_LAST_INITIAL SSOT. Capture-only: never affects recognition/parse (this rule has no parse block; goldens unchanged).",
+      "redact": [
+        {
+          "find": {
+            "hasIdSuffix": "step_description"
+          }
+        },
+        {
+          "find": {
+            "hasTextContaining": "gate code"
+          }
+        },
+        {
+          "find": {
+            "hasTextMatchesRegex": "\\bpin\\b\\s*#?\\s*\\d{3}"
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "\\d{5}"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        },
+        {
+          "find": {
+            "hasTextStartsWith": "Apt "
+          },
+          "keepPrefix": [
+            "Apt "
+          ]
+        },
+        {
+          "find": {
+            "hasTextStartsWith": "\""
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^#?\\s?\\d{1,4}[A-Za-z]?$"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        },
+        {
+          "comment": "id-less whole-value first-name + last-initial — same canonical SSOT as SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN / dropoff_multi_order_confirm.",
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^\\s{0,8}[\\p{L}][\\p{L}'-]{0,20}( [\\p{L}][\\p{L}'-]{0,20}){0,3} [A-Z]\\.?\\s{0,8}$"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        }
+      ],
       "state": {
         "flow": "task:dropoff:arrived"
       },
@@ -279,6 +359,22 @@
       "comment": "#603: the 'hand it to customer' instruction is present the ENTIRE drive (en-route AND at-door), so keying on it alone fired a FALSE task:dropoff:arrived the moment nav started. The completion CTA ('Continue'/'Complete Delivery'/'Mark as delivered'/complete_delivery_steps_button) only appears once the dasher is actually at the door, so it is the real arrival discriminator. The en-route workflow-sheet frame (which lacks the CTA) then falls through to dropoff_pre_arrival (priority 73). KEEP THIS CTA SET IN SYNC with dropoff_navigation's reject and dropoff_pre_arrival_completion's require — all three describe the same 'delivery can be completed now' signal.",
       "priority": 64,
       "redact": [
+        {
+          "comment": "#803: same id-less instructions-body class as dropoff_pin_entry — mask the id-bearing step_description node and any node carrying a gate code / PIN fragment (masks the whole body, embedded name included). The rest of this block already handles the id-less address/name/quoted-note shapes.",
+          "find": {
+            "hasIdSuffix": "step_description"
+          }
+        },
+        {
+          "find": {
+            "hasTextContaining": "gate code"
+          }
+        },
+        {
+          "find": {
+            "hasTextMatchesRegex": "\\bpin\\b\\s*#?\\s*\\d{3}"
+          }
+        },
         {
           "find": {
             "any": [


### PR DESCRIPTION
Closes #803.

The blind class: a free-text delivery-instructions body in an **id-less** node
carried `«FirstName LastName»  gate code …  pin NNNN` past every redaction layer.
Why each layer missed (verified against the code): (1) `SnapshotRedactor.APT`'s
keyword alternation had no `pin`; (2) no pattern covers a full first+last name
**embedded inside** a longer body (`FIRST_LAST_INITIAL` is whole-value-anchored +
last-initial-shaped); (3) the body node is id-less, so the runtime rule-declared
`redact` (node predicates) never touched it — the on-device debug capture held it
raw; (4) `SnapshotSecurityScanner` had no marker for the prefix-less shape.

### Per-layer changes

**Layer 1 — `pin` keyword in `SnapshotRedactor` (test-side inbound-fixture scrub).**
Added a dedicated `PIN` regex, kept **separate** from the `APT` alternation on
purpose: "pin" needs a **digit-adjacency** guard the APT shape (`[:#\s]*[A-Za-z0-9-]+`)
lacks — folding it in would mask "PIN pad" / "pin it". `\bpin\b` (word-bounded, so
"shopping"/"opinion" are clean) + `≥3` trailing digits; the "pin" lead-in is kept,
the digits become `[redacted]`. So a NEW inbound fixture with `pin 4821` is scrubbed
before it can be committed.

**Layer 2 — rule-declared `redact` on the two dropoff instruction surfaces (PRIMARY,
runtime-edge control).** This is the part that closes the Pledge gap — a rule
`redact` masks the serialized envelope **on-device**, so the raw body no longer sits
in a debug capture.

Structural-predicate finding (bullet 2, verified): the rule predicate vocabulary is
**per-node only** — `hasText*`, `hasId*`, `hasNoId`, `hasClassName*`, `exists/any/all/not`;
there is **no sibling / parent / descendant relation**. The id-less free-text body's
only distinguishing feature from the id-less `"Hand it to customer"` heading is its
*content*, so it cannot be isolated by **structure** alone. Per the issue's guidance
("do NOT ship a brittle one"), I did **not** invent a positional/structural hack.
Instead I mask by **content shape** — and crucially, a rule `redact` masks the
**whole matched node**, so any of these firing takes the embedded name with it. Final
predicate set on BOTH `dropoff_pin_entry` and `dropoff_handoff`:
- `hasIdSuffix: step_description` — the id-bearing instruction body (robust).
- `hasTextContaining: "gate code"` — the "gate code NNN" phrasing.
- `hasTextMatchesRegex: "\bgate[\s:#]*\d{3}"` — a **bare** gate code ("gate 4821", no
  "code" token). Word-bounded, digit-adjacent (≥3). (Added per review F1/F3.)
- `hasTextMatchesRegex: "\bpin[\s:#]*\d{3}"` — a residence PIN. The `[\s:#]` separator
  class covers "PIN: 4821"/"pin:4821"; **no trailing `\b`** closes the fused "Pin4821".
  "pinch"/"opinion" stay clean (next char is constrained to `[\s:#]` or a digit).
  (Review F1 replaced the first cut `\bpin\b\s*#?\s*\d{3}`, which had no `:` and
  probe-leaked "PIN: 4821".)
- id-less street / zip / whole-value first-name+last-initial (shared
  `FIRST_LAST_INITIAL` SSOT) / Apt / quoted-note / short-number — mirrors
  `dropoff_handoff`'s existing id-less set, extended to `dropoff_pin_entry` (which had
  **no** redact block at all) and topped up on `dropoff_handoff` (which lacked
  step_description / gate-code / pin).

The three layers (rule redact, `SnapshotRedactor.PIN`, `SnapshotSecurityScanner`)
carry the **byte-aligned** `pin`/`gate` separator class + no-trailing-`\b` so they
can't drift on the colon/fused variants (#362 class).

Documented residual (honest, recomputed after F1/F3). The whole-body mask fires only
when SOME predicate matches, so what still evades the **runtime edge** on the id-less
body is any body whose only PII carries no matching anchor:
1. **Bare-name-only** bodies — a name with no gate/pin/address/zip/quote token and not
   whole-value name-shaped (e.g. "Casey, please leave it inside"). The named residual.
2. **A numeric access code introduced by a word other than `pin`/`gate`** — e.g.
   "code 4821", "call box 4821", "buzzer 4821". Four digits, so below the id-less
   `\d{5}` zip catch; not a `pin`/`gate` lead-in.
3. **Other in-body PII shapes the rule has no predicate for** — an embedded phone or
   email (the rule redact carries no phone/email predicate; the test-side
   `SnapshotRedactor` does, for the corpus).

The **actual fielded leak** (name + gate code + PIN) is now masked at the edge. The
residuals above fall to test-side layers 1 (`SnapshotRedactor` PHONE/EMAIL/APT/PIN) +
4 (scanner) for the **corpus**; on the **runtime** side they persist for recognized
frames (the `#806` `CustomerTextMarkers` prefix-marker path does not cover a
prefix-less body). Fully closing them would need either a per-node PII predicate the
vocabulary lacks, or an aggressive "mask every id-less TextView on this surface"
over-mask — deliberately not shipped (it would drop triage-useful capture text and the
issue directed against a brittle catch-all).

**Layer 3 — runtime edge posture.** Confirmed: with layer 2, an on-device capture of
`dropoff_pin_entry` / `dropoff_handoff` now has the instructions body masked in the
serialized envelope (`CompiledRedact.apply` runs in the capture writer, mapping the
whole node text → `[redacted:<4hex>]`). Redaction is **capture-only** — it never runs
before recognition, so parse output is unchanged (see below).

**Layer 4 — corpus-gate scanner shape.** `SnapshotSecurityScanner` gained a
regex-shape pass (`pin \d{3,}` → `pin-code-shape` trigger) so recurrence in ANY future
fixture fails the suite. Decision recorded in-code: an embedded full-name bigram
(`[A-Z][a-z]+ [A-Z][a-z]+`) was **deliberately not added** — the scanner runs over the
whole committed corpus, which legitimately carries merchant/street/UI two-word
capitalized phrases ("Maple Street", "Farmers Market", "Complete Delivery"); a bigram
scan would false-positive heavily on driver-owned, non-PII text. The whole-value
first-name+last-initial shape is already owned by
`SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN` and pinned by
`CaptureRedactionCorpusTest` FIX-4, so it needs no scanner duplicate.

### Security posture (Pledge surface)
- **Masked where:** the id-less instructions body (name/gate/pin) is now masked at the
  **runtime capture edge** (rule `redact`, on-device envelope) AND in the **test-side**
  inbound-fixture scrub (`SnapshotRedactor`); the corpus **gate** (`SnapshotSecurityScanner`)
  fails on a raw `pin \d{3,}` recurrence.
- **Fail direction:** toward privacy. Content-shape predicates mask the **whole** node,
  so a partial PII anchor scrubs the whole body; the redactor/scanner over-mask rather
  than under-mask.
- **Trusted / gated / scrubbed:** third-party UI text stays untrusted; recognition is
  unchanged (redact is post-classification, capture-only); no new plaintext sink.
- **Complementary, not duplicative:** master's `#806/#815` UNKNOWN-path
  `CustomerTextMarkers` scrub covers **unrecognized** frames; this work covers the
  **recognized** `dropoff_pin_entry` / `dropoff_handoff` frames (rule redact) + the
  test-side redactor/scanner. No overlap or regression.

### Goldens
`approved-parse-output.json` is **byte-identical** (verified: clean `git status` +
`ParseOutputGoldenTest` green with no regen). Both rules are parse-less; redaction never
touches recognition/parse.

### Tests
- `InstructionsBodyPiiScrubTest` — `pin`-mask positives incl. colon + fused variants
  ("PIN: 4821"/"pin:4821"/"Pin4821") + negatives ("PIN pad"/"pin it"/"Enter PIN
  code"/"opinion"); scanner positives (`pin 1234`, "PIN: 1234", "Pin1234", bare
  "gate 4821"/"Gate: 4821") + negatives (pin UI copy clean, `<3` digits clean).
- `CaptureRedactionCorpusTest` (+3) — synthetic live (un-redacted) `dropoff_pin_entry`
  and `dropoff_handoff` trees: recognition still lands on the surface, then the rule's
  redact masks the body's name/gate/pin **and** step_description while the require /
  CTA anchors survive; a variant case drives "PIN: …"/"pin:…"/"Pin…"/"gate …"/"Gate: …"
  bodies through the pin_entry redact (embedded "Casey Doe" masked with the code). The
  FIX-1c SSOT loop now pins `dropoff_pin_entry`'s name-shape copy too (F2).
- Full `testDebugUnitTest :domain:test` green; `AllMatchersSuite`, `CaptureBackstopCorpusTest`,
  `ParseOutputGoldenTest` green.

### Fable security review (APPROVE-WITH-FIXES → applied)
- **F1** — colon/fused `pin` variants leaked at the runtime edge; rule regex now
  `\bpin[\s:#]*\d{3}` on both blocks, plus a new bare-`\bgate[\s:#]*\d{3}` entry;
  test-side `SnapshotRedactor.PIN` + scanner aligned to the same separator class /
  no-trailing-`\b`. Corpus checked: **0** FP for either shape.
- **F2** — `dropoff_pin_entry` added to the FIX-1c SSOT loop; body sentence corrected.
- **F3** — residual paragraph recomputed above.

### Design-goal review
- **#5 SSOT:** the id-less name-shape regex reuses the canonical
  `FIRST_LAST_INITIAL_PATTERN` string. Its FIX-1c SSOT loop in
  `CaptureRedactionCorpusTest` now includes `dropoff_pin_entry` (review F2), so the
  4th copy of the pattern can't drift from the others — previously the loop only
  pinned `dropoff_navigation` + `dropoff_handoff`. The `pin`/`gate` separator-class
  shape is byte-aligned across the rule redact, `SnapshotRedactor.PIN`, and the
  scanner (three-layer parity).
- **#6 security & privacy first:** primary control is the runtime-edge rule redact
  (masks on-device envelope), backed by test-side scrub + corpus gate; fail-closed /
  toward-privacy; residual documented, not hidden.
- **#8 platform-agnostic core:** recognition stays **data** — the change is rule JSON
  (`matchers/rules/doordash/dropoff.json5`) + test-only Kotlin; no `:core:state` /
  `:core:pipeline` / `:domain` logic edits, no platform literal in code. The `redact`
  predicates go through the existing compiled-predicate vocabulary, not a Kotlin `when`.
- Other principles untouched by this diff.
