### PR TITLE
cleanup(rules): #819 drop dead {sessionEarnings} half from expanded delivery-summary dedupeKey

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
@@ -227,11 +227,6 @@ class ParseOutputGoldenTest {
 
     /**
      * Dead dedupeKey templates already known (ratchet — may only shrink):
-     * - `delivery_summary_expanded:sessionEarnings` — never parses non-null on
-     *   any expanded-summary capture; either the screen stopped showing it or
-     *   the extractor regressed. The expanded key still differentiates per
-     *   delivery via its `{totalPay}` half, so dedupe works; clean up the dead
-     *   half when the summary rules are next touched.
      * - `delivery_summary_collapsed:totalPay` — dedupeKeys are scanned
      *   POST-resolution here, so a `{field}` token only reaches this lint on a
      *   frame where the field parsed null (it survived interpolation). Most
@@ -249,10 +244,16 @@ class ParseOutputGoldenTest {
      * (The third original entry, `offer_popup:offerHash`, was the #427 bug —
      * fixed by the reserved `{parsedHash}` token, resolved post-factory by the
      * classifier via [DedupeTokens].)
+     * (`delivery_summary_expanded:sessionEarnings` was the mirror-image dead half on the
+     * EXPANDED rule — retired by #819, same treatment as #801's collapsed-rule fix above:
+     * the expanded dedupeKey dropped `{sessionEarnings}` in favour of `{totalPay}` alone,
+     * so the field no longer appears in any dedupeKey template and can't register here
+     * regardless of its parse outcome. The `sessionEarnings` parse itself is untouched —
+     * still id-anchored, still gracefully null on 0.230.0 — it just no longer drives
+     * dedupe.)
      * Entries are "ruleId:field".
      */
     private val knownDeadDedupeTemplates = setOf(
-        "doordash.screen.delivery_summary_expanded:sessionEarnings",
         "doordash.screen.delivery_summary_collapsed:totalPay",
     )
 

--- a/matchers/rules/doordash/dropoff.json5
+++ b/matchers/rules/doordash/dropoff.json5
@@ -1187,6 +1187,16 @@
           "isExpanded": {
             "literal": true
           },
+          // #819: mirror of the #801 collapsed-rule fix. Pre-0.230.0 the "This dash so
+          // far" session total was a single settled TextView with a stable
+          // `earnings_ticker` id; DoorDash 0.230.0 dropped that id here too, so this
+          // id-anchored find now gracefully returns null on 0.230.0 (the field is
+          // already optional) while still parsing older-version replays — NOT
+          // broadened onto the unreliable id-less animated digit-wheel (see the
+          // collapsed rule's comment below for why). The dead `{sessionEarnings}`
+          // dedupeKey half is retired in favour of `{totalPay}` (which 0.230.0 DOES
+          // render — the `final_value` id survives). See ParseOutputGoldenTest
+          // dedupeKey lint (the #427/#606/#801 dead-template class).
           "sessionEarnings": {
             "find": {
               "hasIdSuffix": "earnings_ticker"
@@ -1214,7 +1224,7 @@
             "prefix": "DeliveryBreakdown - {totalPay}",
             "category": "delivery_summary"
           },
-          "dedupeKey": "delivery-ss-expanded-{totalPay}-{sessionEarnings}",
+          "dedupeKey": "delivery-ss-expanded-{totalPay}",
           "throttleMs": 60000
         }
       ]


### PR DESCRIPTION
## Summary

Drops the dead `{sessionEarnings}` half from the **expanded** delivery-summary rule's
`dedupeKey`, mirroring the fix #817 already applied to the **collapsed** rule for #801.
This is the deferred item explicitly called out in #817's commit message.

DoorDash 0.230.0 dropped the `earnings_ticker` id from the expanded card too (not just
the collapsed one), so `sessionEarnings` genuinely never parses non-null on any
expanded-summary corpus frame — pinned as
`doordash.screen.delivery_summary_expanded:sessionEarnings` in
`ParseOutputGoldenTest.knownDeadDedupeTemplates`.

## Changes

- `matchers/rules/doordash/dropoff.json5`: expanded rule's
  `dedupeKey: "delivery-ss-expanded-{totalPay}-{sessionEarnings}"` →
  `"delivery-ss-expanded-{totalPay}"` (the `final_value` id survives on 0.230.0, so
  dedupe still differentiates per delivery). The `sessionEarnings` **parse field itself
  is untouched** — same treatment #817 gave the collapsed rule: the id-anchored find
  stays (graceful null on 0.230.0, still parses older-version replays); NOT broadened
  onto the unreliable id-less animated digit-wheel. Added a comment mirroring the
  collapsed rule's #801 explanation.
- `app/src/test/java/.../ParseOutputGoldenTest.kt`: removed
  `doordash.screen.delivery_summary_expanded:sessionEarnings` from
  `knownDeadDedupeTemplates` (ratchet shrink — the field no longer appears in any
  dedupeKey template, so it can't register in that lint regardless of parse outcome)
  and its KDoc bullet, replaced with a short cross-reference note explaining the #819
  retirement.

## Golden-diff description

`approved-parse-output.json` is **unaffected** — dedupeKey strings are not part of the
stored parse-output golden (only parsed field values are), so no regen was needed. This
is why `AllMatchersSuite`/`ParseOutputGoldenTest` passed clean without a
`-DupdateParseGolden=true` step.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` — BUILD SUCCESSFUL
      (includes `ParseOutputGoldenTest`, 4/4 tests passed, no golden regen needed)
- [x] `./gradlew testDebugUnitTest :domain:test` (full unit suite across modules) — BUILD
      SUCCESSFUL

### Design-goal review

- **SSOT (#5):** removes a dead, hand-duplicated dedupeKey half; the ratchet set now
  accurately reflects what's actually referenced. No new divergence introduced.
- **Platform-agnostic core (#8):** touches only DoorDash rule JSON (data) and a
  DoorDash-scoped test constant; no `:core:state`/`:core:pipeline`/`:domain` logic
  changed, no new platform literals in code.
- Other principles: not touched by this diff (pure rule-data + test-ratchet cleanup,
  no runtime behavior change beyond the dedupe-key string itself, no security/logging
  surface touched).

### Adversarial review

Pending — will run `/code-review` before merge per repo convention. Not merging this PR
myself; leaving for the developer/adversarial pass.
