### PR TITLE
fix(rules): #825 uber active_trip customer redact — bare-node Pledge leak

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -198,8 +198,8 @@ class CaptureRedactionCorpusTest {
     }
 
     /** The `hasTextMatchesRegex` strings in a screen rule's `redact` block (generated asset). */
-    private fun ruleRedactRegexes(ruleId: String): List<String> {
-        val root = Json.parseToJsonElement(File(rulesDir, "doordash.json").readText()).jsonObject
+    private fun ruleRedactRegexes(ruleId: String, platformFile: String = "doordash.json"): List<String> {
+        val root = Json.parseToJsonElement(File(rulesDir, platformFile).readText()).jsonObject
         val screen = root["screens"]!!.jsonArray.first {
             it.jsonObject["id"]?.jsonPrimitive?.content == ruleId
         }.jsonObject
@@ -271,7 +271,14 @@ class CaptureRedactionCorpusTest {
     fun `committed corpus carries no un-masked bare customer-name node (FIX 4)`() {
         val nameShape = Regex(SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN, RegexOption.IGNORE_CASE)
         // Folders whose owning rule declares the name-shape redact (FIX 3 included).
-        val folders = listOf("dropoff_multi_order_confirm", "dropoff_navigation", "dropoff_handoff")
+        // #825 added the uber trip surfaces (active_trip/splash/customer_chat/
+        // pickup_verification_items) to the set — each now carries the id-less
+        // name-shape redact, so a future un-masked bare name in their corpus is a
+        // test failure, not a permanent git leak.
+        val folders = listOf(
+            "dropoff_multi_order_confirm", "dropoff_navigation", "dropoff_handoff",
+            "active_trip", "splash", "customer_chat", "pickup_verification_items",
+        )
         val leaks = mutableListOf<String>()
         for (folder in folders) {
             for ((filename, node, _) in TestResourceLoader.loadSnapshots("snapshots/$folder")) {
@@ -381,6 +388,156 @@ class CaptureRedactionCorpusTest {
         assertFalse("PIN must not persist", masked.contains("9032"))
         assertFalse("step_description instruction must not persist", masked.contains("Text Jane"))
         assertTrue("arrival CTA anchor kept", masked.contains("Complete Delivery"))
+    }
+
+    // =========================================================================
+    // #825 — the uber `active_trip` bare-node customer-PII Pledge leak. The
+    // fielded on-job card renders the customer first-name+last-initial, street,
+    // gate code and unit as id-less nodes with NO lead-in marker, so the
+    // CustomerTextMarkers prefix backstop can't scrub them and the rule declared
+    // no `redact` — raw customer PII shipped to 4 recognized capture envelopes on
+    // 07-21. These pin the fix at the runtime capture edge: an injected synthetic
+    // live (un-redacted) capture must mask every PII node while the recognition
+    // anchors survive. Redaction is capture-only (these rules are parse-less; the
+    // goldens are byte-identical). Same cross-platform content-shape SSOT as #803.
+    // =========================================================================
+
+    private val uberNameHex = java.security.MessageDigest.getInstance("SHA-256")
+        .digest("casey t".toByteArray(Charsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
+        .take(4)
+
+    @Test
+    fun `uber active_trip redact masks the bare name, street, gate code, unit, and id-anchored address (#825)`() {
+        val rule = TestRulesetFactory.screenRuleset.ruleById("uber.screen.active_trip")!!
+        assertFalse("active_trip must now carry a redact block", rule.redact.isEmpty())
+
+        val tree = UiNode(
+            viewIdResourceName = "com.ubercab.driver:id/on_job_view", // recognition anchor
+            children = listOf(
+                UiNode(text = "Dropoff • 1 order"), // benign — must survive
+                UiNode(text = "Casey T."), // bare id-less customer name
+                UiNode(text = "42 Nowhere Ln"), // bare id-less street (fabricated)
+                UiNode(text = "Gate code 8888"), // customer gate code (fabricated)
+                UiNode(text = "Expected by 7:17 PM"), // benign — must survive
+                UiNode(
+                    viewIdResourceName = "com.ubercab.driver:id/ub__nav_address_view_poi_text",
+                    text = "42 Nowhere Ln",
+                ),
+                UiNode(
+                    viewIdResourceName = "com.ubercab.driver:id/ub__nav_address_view_address_text",
+                    text = "Springfield, ZZ 00000",
+                ),
+                UiNode(
+                    viewIdResourceName = "com.ubercab.driver:id/key_info_label",
+                    text = "Casey T.",
+                ),
+                UiNode(
+                    viewIdResourceName = "com.ubercab.driver:id/map_marker_title",
+                    text = "Apt 8888",
+                ),
+            ),
+        ).restoreParents()
+
+        val masked = serialize(rule.redact.apply(tree))
+        assertFalse("customer first name must not persist", masked.contains("Casey"))
+        assertFalse("street name must not persist", masked.contains("Nowhere"))
+        assertFalse("gate/unit number must not persist", masked.contains("8888"))
+        assertFalse("zip must not persist", masked.contains("00000"))
+        // Recognition anchors + benign chrome survive untouched (replay-safe).
+        assertTrue("on_job_view anchor kept", masked.contains("on_job_view"))
+        assertTrue("benign order line kept", masked.contains("Dropoff • 1 order"))
+        assertTrue("benign ETA kept", masked.contains("Expected by 7:17 PM"))
+        assertTrue("apt marker kept", masked.contains("Apt [redacted:"))
+    }
+
+    @Test
+    fun `uber active_trip bare-name redact carries the normalize customerName distinctness hex (#825)`() {
+        val rule = TestRulesetFactory.screenRuleset.ruleById("uber.screen.active_trip")!!
+        // The bare id-less name node masks via the normalize:customerName entry, so
+        // its 4hex equals sha256 of the canonical key ("casey t") — per-customer
+        // stable across the surface forms the name renders in.
+        val masked = rule.redact.apply(UiNode(text = "Casey T.")).text!!
+        assertFalse("name must not persist", masked.contains("Casey"))
+        assertEquals("normalize:customerName distinctness hex", "[redacted:$uberNameHex]", masked)
+    }
+
+    @Test
+    fun `uber active_trip name redact is SSOT with SnapshotRedactor FIRST_LAST_INITIAL (#825)`() {
+        assertTrue(
+            "active_trip must carry the canonical id-less name-shape regex byte-identical to " +
+                "SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN; found " +
+                ruleRedactRegexes("uber.screen.active_trip", "uber.json"),
+            ruleRedactRegexes("uber.screen.active_trip", "uber.json")
+                .contains(SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN),
+        )
+    }
+
+    @Test
+    fun `uber splash redact masks trip-underlay street, address, and bare name (#813 via #825)`() {
+        val rule = TestRulesetFactory.screenRuleset.ruleById("uber.screen.splash")!!
+        assertFalse("splash must now carry a redact block", rule.redact.isEmpty())
+        val tree = UiNode(
+            viewIdResourceName = "com.ubercab.driver:id/rootSplashBackground", // recognition anchor
+            children = listOf(
+                UiNode(
+                    viewIdResourceName = "com.ubercab.driver:id/ub__nav_maneuver_text",
+                    text = "Turn right onto Nowhere Canyon Drive",
+                ),
+                UiNode(
+                    viewIdResourceName = "com.ubercab.driver:id/ub__current_street_name_tv",
+                    text = "Nowhere Canyon Drive",
+                ),
+                UiNode(
+                    viewIdResourceName = "com.ubercab.driver:id/ub__nav_address_view_address_text",
+                    text = "Springfield, ZZ 00000",
+                ),
+                UiNode(text = "Casey T."), // bare id-less name
+                UiNode(text = "42 Nowhere Ln"), // bare id-less street (fabricated)
+            ),
+        ).restoreParents()
+        val masked = serialize(rule.redact.apply(tree))
+        assertFalse("customer name must not persist", masked.contains("Casey"))
+        assertFalse("street name must not persist", masked.contains("Nowhere"))
+        assertFalse("zip must not persist", masked.contains("00000"))
+        assertTrue("rootSplashBackground anchor kept", masked.contains("rootSplashBackground"))
+    }
+
+    @Test
+    fun `uber customer_chat redact masks the chat header name and gate-code instructions (#825)`() {
+        val rule = TestRulesetFactory.screenRuleset.ruleById("uber.screen.customer_chat")!!
+        assertFalse("customer_chat must now carry a redact block", rule.redact.isEmpty())
+        val tree = UiNode(
+            viewIdResourceName = "com.ubercab.driver:id/on_job_view",
+            children = listOf(
+                UiNode(
+                    viewIdResourceName = "com.ubercab.driver:id/ub__chat_header_title",
+                    text = "Casey T.",
+                ),
+                UiNode(text = "• Leave at door\n• Gate code 8888"), // delivery instructions
+                UiNode(text = "Verify order"), // benign — survives
+            ),
+        ).restoreParents()
+        val masked = serialize(rule.redact.apply(tree))
+        assertFalse("chat header customer name must not persist", masked.contains("Casey"))
+        assertFalse("gate code must not persist", masked.contains("8888"))
+        assertTrue("benign chrome kept", masked.contains("Verify order"))
+    }
+
+    @Test
+    fun `uber pickup_verification_items redact masks the bare customer name (#825)`() {
+        val rule = TestRulesetFactory.screenRuleset.ruleById("uber.screen.pickup_verification_items")!!
+        assertFalse("pickup_verification_items must now carry a redact block", rule.redact.isEmpty())
+        val tree = UiNode(
+            viewIdResourceName = "com.ubercab.driver:id/on_job_view",
+            children = listOf(
+                UiNode(text = "Verify order"), // recognition anchor — survives
+                UiNode(text = "Casey T."), // bare id-less customer name
+            ),
+        ).restoreParents()
+        val masked = serialize(rule.redact.apply(tree))
+        assertFalse("customer name must not persist", masked.contains("Casey"))
+        assertTrue("Verify order anchor kept", masked.contains("Verify order"))
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -436,6 +436,11 @@ class CaptureRedactionCorpusTest {
                     viewIdResourceName = "com.ubercab.driver:id/map_marker_title",
                     text = "Apt 8888",
                 ),
+                // #825 review HIGH-2: the map pin carries the address in contentDescription ONLY.
+                UiNode(
+                    viewIdResourceName = "com.ubercab.driver:id/map_marker_pin_head",
+                    contentDescription = "42 Nowhere Ln, Springfield ZZ",
+                ),
             ),
         ).restoreParents()
 
@@ -463,14 +468,23 @@ class CaptureRedactionCorpusTest {
     }
 
     @Test
-    fun `uber active_trip name redact is SSOT with SnapshotRedactor FIRST_LAST_INITIAL (#825)`() {
-        assertTrue(
-            "active_trip must carry the canonical id-less name-shape regex byte-identical to " +
-                "SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN; found " +
-                ruleRedactRegexes("uber.screen.active_trip", "uber.json"),
-            ruleRedactRegexes("uber.screen.active_trip", "uber.json")
-                .contains(SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN),
-        )
+    fun `every uber trip-surface name redact is SSOT with SnapshotRedactor FIRST_LAST_INITIAL (#825, MED-5)`() {
+        // All four surfaces copy the id-less name-shape regex; pin every copy to the SSOT so a
+        // silent drift on any one (the #362 duplicated-regex class) turns the build red.
+        for (id in listOf(
+            "uber.screen.active_trip",
+            "uber.screen.splash",
+            "uber.screen.customer_chat",
+            "uber.screen.pickup_verification_items",
+        )) {
+            assertTrue(
+                "$id must carry the canonical id-less name-shape regex byte-identical to " +
+                    "SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN; found " +
+                    ruleRedactRegexes(id, "uber.json"),
+                ruleRedactRegexes(id, "uber.json")
+                    .contains(SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN),
+            )
+        }
     }
 
     @Test
@@ -514,14 +528,40 @@ class CaptureRedactionCorpusTest {
                     viewIdResourceName = "com.ubercab.driver:id/ub__chat_header_title",
                     text = "Casey T.",
                 ),
+                // HIGH-1: the chat header also renders as "<Name I.> says:" in headline_text.
+                UiNode(
+                    viewIdResourceName = "com.ubercab.driver:id/headline_text",
+                    text = "Casey T. says:",
+                ),
                 UiNode(text = "• Leave at door\n• Gate code 8888"), // delivery instructions
+                // MED-3: chat wins over active_trip, so the trip underlay's id-bearing address
+                // must be scrubbed here too.
+                UiNode(
+                    viewIdResourceName = "com.ubercab.driver:id/ub__nav_address_view_poi_text",
+                    text = "42 Nowhere Ln",
+                ),
+                // HIGH-2: the map pin carries the address in contentDescription only.
+                UiNode(
+                    viewIdResourceName = "com.ubercab.driver:id/map_marker_pin_head",
+                    contentDescription = "42 Nowhere Ln, Springfield ZZ",
+                ),
                 UiNode(text = "Verify order"), // benign — survives
             ),
         ).restoreParents()
         val masked = serialize(rule.redact.apply(tree))
         assertFalse("chat header customer name must not persist", masked.contains("Casey"))
+        assertFalse("headline_text customer name must not persist (HIGH-1)", masked.contains("Casey"))
         assertFalse("gate code must not persist", masked.contains("8888"))
+        assertFalse("trip-underlay address must not persist (MED-3/HIGH-2)", masked.contains("Nowhere"))
         assertTrue("benign chrome kept", masked.contains("Verify order"))
+
+        // HIGH-1 normalize proof: "<Name> says:" must mask to the SAME distinctness hex as the bare
+        // name — i.e. customerNameKey strips the " says:" tail (→ "casey t"), so the chat header and
+        // its "says:" echo are ONE customer, not two.
+        val headline = rule.redact.apply(
+            UiNode(viewIdResourceName = "com.ubercab.driver:id/headline_text", text = "Casey T. says:"),
+        ).text!!
+        assertEquals("headline_text normalizes the ' says:' tail to the canonical key", "[redacted:$uberNameHex]", headline)
     }
 
     @Test

--- a/app/src/test/resources/snapshots/active_trip/2026-07-21_19-07-46-239__uber__accessibility.window__active_trip__f2a555.json
+++ b/app/src/test/resources/snapshots/active_trip/2026-07-21_19-07-46-239__uber__accessibility.window__active_trip__f2a555.json
@@ -1,0 +1,2023 @@
+{
+    "captureId": "0837a72c-8f59-4bcc-8ec4-55a1b88489d7",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784678866205,
+    "platform": "uber",
+    "ruleId": "uber.screen.active_trip",
+    "classificationName": "active_trip",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/on_job_view",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/glide_screen_stack_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/glide_active_view_container",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 0
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/active_container",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/background_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/screen_stack_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/ub__top_banner_container",
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 0
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/bottom_sheet_container",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 0,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant",
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 0,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 332
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_offline_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 0,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 332
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_overlay_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 0,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 332
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_background_view",
+                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 0,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 332
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "Unable to go offline",
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_overlay_text",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 0,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 332
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_online_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 0,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 332
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_padding_container",
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 0,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 332
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_action_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                    "right": 142,
+                                                                                                                                                                                                    "bottom": 332
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 142,
+                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                    "right": 938,
+                                                                                                                                                                                                    "bottom": 332
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "Trip Planner",
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_content_override",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 142,
+                                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                                            "right": 938,
+                                                                                                                                                                                                            "bottom": 332
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_grabber_bar",
+                                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 469,
+                                                                                                                                                                                                            "top": 154,
+                                                                                                                                                                                                            "right": 611,
+                                                                                                                                                                                                            "bottom": 163
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_content",
+                                                                                                                                                                                                        "class": "android.widget.RelativeLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 182,
+                                                                                                                                                                                                            "top": 202,
+                                                                                                                                                                                                            "right": 898,
+                                                                                                                                                                                                            "bottom": 265
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "text": "8 min",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_label_leading",
+                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 182,
+                                                                                                                                                                                                                    "top": 202,
+                                                                                                                                                                                                                    "right": 500,
+                                                                                                                                                                                                                    "bottom": 265
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_badges_holder",
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 516,
+                                                                                                                                                                                                                    "top": 202,
+                                                                                                                                                                                                                    "right": 563,
+                                                                                                                                                                                                                    "bottom": 265
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 516,
+                                                                                                                                                                                                                            "top": 210,
+                                                                                                                                                                                                                            "right": 563,
+                                                                                                                                                                                                                            "bottom": 257
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "text": "3.2 mi",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_label_trailing",
+                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 580,
+                                                                                                                                                                                                                    "top": 202,
+                                                                                                                                                                                                                    "right": 898,
+                                                                                                                                                                                                                    "bottom": 265
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_agenda_entry_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 938,
+                                                                                                                                                                                                    "top": 207,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 260
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 938,
+                                                                                                                                                                                                            "top": 207,
+                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                            "bottom": 260
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Agenda",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_agenda_button",
+                                                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 938,
+                                                                                                                                                                                                                    "top": 207,
+                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                    "bottom": 260
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 332,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 334
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 334,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2012
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/agenda_content_view",
+                                                                                                                                                                                        "class": "android.widget.ScrollView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 334,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2012
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 334,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 1201
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/agenda_content_parent",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 16,
+                                                                                                                                                                                                            "top": 351,
+                                                                                                                                                                                                            "right": 1064,
+                                                                                                                                                                                                            "bottom": 1192
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/agenda_content_top",
+                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 16,
+                                                                                                                                                                                                                    "top": 351,
+                                                                                                                                                                                                                    "right": 1064,
+                                                                                                                                                                                                                    "bottom": 934
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 16,
+                                                                                                                                                                                                                            "top": 351,
+                                                                                                                                                                                                                            "right": 1064,
+                                                                                                                                                                                                                            "bottom": 351
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 16,
+                                                                                                                                                                                                                                    "top": 351,
+                                                                                                                                                                                                                                    "right": 1064,
+                                                                                                                                                                                                                                    "bottom": 351
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/scope_summary_container",
+                                                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                            "left": 16,
+                                                                                                                                                                                                                                            "top": 351,
+                                                                                                                                                                                                                                            "right": 1064,
+                                                                                                                                                                                                                                            "bottom": 351
+                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                    },
+                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/task_scope__action_wrapper",
+                                                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                            "left": 16,
+                                                                                                                                                                                                                                            "top": 351,
+                                                                                                                                                                                                                                            "right": 1064,
+                                                                                                                                                                                                                                            "bottom": 351
+                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    },
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 16,
+                                                                                                                                                                                                                            "top": 353,
+                                                                                                                                                                                                                            "right": 1064,
+                                                                                                                                                                                                                            "bottom": 934
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 16,
+                                                                                                                                                                                                                                    "top": 353,
+                                                                                                                                                                                                                                    "right": 1064,
+                                                                                                                                                                                                                                    "bottom": 934
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                            "left": 16,
+                                                                                                                                                                                                                                            "top": 353,
+                                                                                                                                                                                                                                            "right": 1064,
+                                                                                                                                                                                                                                            "bottom": 934
+                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/earnertripflow_screenlayout_header",
+                                                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                    "left": 16,
+                                                                                                                                                                                                                                                    "top": 353,
+                                                                                                                                                                                                                                                    "right": 1064,
+                                                                                                                                                                                                                                                    "bottom": 353
+                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/earnertripflow_screenlayout_body",
+                                                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                    "left": 16,
+                                                                                                                                                                                                                                                    "top": 353,
+                                                                                                                                                                                                                                                    "right": 1064,
+                                                                                                                                                                                                                                                    "bottom": 934
+                                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                                            "left": 16,
+                                                                                                                                                                                                                                                            "top": 353,
+                                                                                                                                                                                                                                                            "right": 1064,
+                                                                                                                                                                                                                                                            "bottom": 934
+                                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                                    "left": 16,
+                                                                                                                                                                                                                                                                    "top": 353,
+                                                                                                                                                                                                                                                                    "right": 1064,
+                                                                                                                                                                                                                                                                    "bottom": 934
+                                                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                                                            "left": 16,
+                                                                                                                                                                                                                                                                            "top": 353,
+                                                                                                                                                                                                                                                                            "right": 1064,
+                                                                                                                                                                                                                                                                            "bottom": 934
+                                                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                                                    "left": 16,
+                                                                                                                                                                                                                                                                                    "top": 353,
+                                                                                                                                                                                                                                                                                    "right": 1064,
+                                                                                                                                                                                                                                                                                    "bottom": 934
+                                                                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                                                        "class": "android.widget.ViewSwitcher",
+                                                                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                                                                            "left": 16,
+                                                                                                                                                                                                                                                                                            "top": 353,
+                                                                                                                                                                                                                                                                                            "right": 1064,
+                                                                                                                                                                                                                                                                                            "bottom": 934
+                                                                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                                                                    "left": 16,
+                                                                                                                                                                                                                                                                                                    "top": 353,
+                                                                                                                                                                                                                                                                                                    "right": 1064,
+                                                                                                                                                                                                                                                                                                    "bottom": 934
+                                                                                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                                                                                            "left": 16,
+                                                                                                                                                                                                                                                                                                            "top": 353,
+                                                                                                                                                                                                                                                                                                            "right": 1064,
+                                                                                                                                                                                                                                                                                                            "bottom": 591
+                                                                                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                                                                                    "left": 16,
+                                                                                                                                                                                                                                                                                                                    "top": 353,
+                                                                                                                                                                                                                                                                                                                    "right": 1064,
+                                                                                                                                                                                                                                                                                                                    "bottom": 591
+                                                                                                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                                                                                                            "left": 50,
+                                                                                                                                                                                                                                                                                                                            "top": 446,
+                                                                                                                                                                                                                                                                                                                            "right": 102,
+                                                                                                                                                                                                                                                                                                                            "bottom": 497
+                                                                                                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                                                                "desc": "dropoff delivery",
+                                                                                                                                                                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                                                                                                    "left": 64,
+                                                                                                                                                                                                                                                                                                                                    "top": 460,
+                                                                                                                                                                                                                                                                                                                                    "right": 89,
+                                                                                                                                                                                                                                                                                                                                    "bottom": 485
+                                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                                                                                                    },
+                                                                                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                                                                                                            "left": 136,
+                                                                                                                                                                                                                                                                                                                            "top": 387,
+                                                                                                                                                                                                                                                                                                                            "right": 970,
+                                                                                                                                                                                                                                                                                                                            "bottom": 557
+                                                                                                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                                                                "text": "Dropoff • 1 order",
+                                                                                                                                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                                                                                                    "left": 136,
+                                                                                                                                                                                                                                                                                                                                    "top": 387,
+                                                                                                                                                                                                                                                                                                                                    "right": 970,
+                                                                                                                                                                                                                                                                                                                                    "bottom": 441
+                                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                                                                "text": "[redacted]",
+                                                                                                                                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                                                                                                    "left": 136,
+                                                                                                                                                                                                                                                                                                                                    "top": 441,
+                                                                                                                                                                                                                                                                                                                                    "right": 970,
+                                                                                                                                                                                                                                                                                                                                    "bottom": 503
+                                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                                                                "text": "Expected by 7:17 PM",
+                                                                                                                                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                                                                                                    "left": 136,
+                                                                                                                                                                                                                                                                                                                                    "top": 503,
+                                                                                                                                                                                                                                                                                                                                    "right": 970,
+                                                                                                                                                                                                                                                                                                                                    "bottom": 557
+                                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                                                                                                    },
+                                                                                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                                                                                        "desc": "chevron",
+                                                                                                                                                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                                                                                                            "left": 1004,
+                                                                                                                                                                                                                                                                                                                            "top": 460,
+                                                                                                                                                                                                                                                                                                                            "right": 1030,
+                                                                                                                                                                                                                                                                                                                            "bottom": 485
+                                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                                                                                    },
+                                                                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                                                                                            "left": 16,
+                                                                                                                                                                                                                                                                                                            "top": 591,
+                                                                                                                                                                                                                                                                                                            "right": 1064,
+                                                                                                                                                                                                                                                                                                            "bottom": 934
+                                                                                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                                                "text": "Address",
+                                                                                                                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                                                                                    "left": 137,
+                                                                                                                                                                                                                                                                                                                    "top": 625,
+                                                                                                                                                                                                                                                                                                                    "right": 1030,
+                                                                                                                                                                                                                                                                                                                    "bottom": 680
+                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                                                "text": "[address]",
+                                                                                                                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                                                                                    "left": 137,
+                                                                                                                                                                                                                                                                                                                    "top": 680,
+                                                                                                                                                                                                                                                                                                                    "right": 1030,
+                                                                                                                                                                                                                                                                                                                    "bottom": 734
+                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                                                "text": "San Antonio, TX",
+                                                                                                                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                                                                                    "left": 137,
+                                                                                                                                                                                                                                                                                                                    "top": 734,
+                                                                                                                                                                                                                                                                                                                    "right": 1030,
+                                                                                                                                                                                                                                                                                                                    "bottom": 788
+                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                                                "text": "View details",
+                                                                                                                                                                                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                                                                                    "left": 137,
+                                                                                                                                                                                                                                                                                                                    "top": 822,
+                                                                                                                                                                                                                                                                                                                    "right": 387,
+                                                                                                                                                                                                                                                                                                                    "bottom": 900
+                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/earnertripflow_screenlayout_footer",
+                                                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                    "left": 16,
+                                                                                                                                                                                                                                                    "top": 934,
+                                                                                                                                                                                                                                                    "right": 1064,
+                                                                                                                                                                                                                                                    "bottom": 934
+                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/agenda_content_footer",
+                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 85,
+                                                                                                                                                                                                                    "top": 1002,
+                                                                                                                                                                                                                    "right": 995,
+                                                                                                                                                                                                                    "bottom": 1123
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "text": "Waybill",
+                                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 438,
+                                                                                                                                                                                                                            "top": 1002,
+                                                                                                                                                                                                                            "right": 642,
+                                                                                                                                                                                                                            "bottom": 1123
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2012,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2014
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/agenda_overlay_button_frame",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2014,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 53,
+                                                                                                                                                                                            "top": 2105,
+                                                                                                                                                                                            "right": 195,
+                                                                                                                                                                                            "bottom": 2247
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "desc": "Preferences",
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/preferences_action_section",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 53,
+                                                                                                                                                                                                    "top": 2105,
+                                                                                                                                                                                                    "right": 195,
+                                                                                                                                                                                                    "bottom": 2247
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/bottom_section_button_icon",
+                                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 53,
+                                                                                                                                                                                                            "top": 2105,
+                                                                                                                                                                                                            "right": 195,
+                                                                                                                                                                                                            "bottom": 2247
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 195,
+                                                                                                                                                                                            "top": 2032,
+                                                                                                                                                                                            "right": 885,
+                                                                                                                                                                                            "bottom": 2320
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 195,
+                                                                                                                                                                                                    "top": 2032,
+                                                                                                                                                                                                    "right": 885,
+                                                                                                                                                                                                    "bottom": 2320
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/stop_request_button",
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 460,
+                                                                                                                                                                                                            "top": 2068,
+                                                                                                                                                                                                            "right": 620,
+                                                                                                                                                                                                            "bottom": 2228
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/carbon_action_button",
+                                                                                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 460,
+                                                                                                                                                                                                                    "top": 2068,
+                                                                                                                                                                                                                    "right": 620,
+                                                                                                                                                                                                                    "bottom": 2228
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/carbon_action_button_outline",
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 477,
+                                                                                                                                                                                                                    "top": 2085,
+                                                                                                                                                                                                                    "right": 602,
+                                                                                                                                                                                                                    "bottom": 2210
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/indicator_outline",
+                                                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 477,
+                                                                                                                                                                                                                            "top": 2085,
+                                                                                                                                                                                                                            "right": 602,
+                                                                                                                                                                                                                            "bottom": 2210
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    },
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/indicator_loading",
+                                                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 477,
+                                                                                                                                                                                                                            "top": 2085,
+                                                                                                                                                                                                                            "right": 602,
+                                                                                                                                                                                                                            "bottom": 2210
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/carbon_action_button_icon",
+                                                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 504,
+                                                                                                                                                                                                                    "top": 2112,
+                                                                                                                                                                                                                    "right": 575,
+                                                                                                                                                                                                                    "bottom": 2183
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "Stop New Requests",
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/stop_request_label",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 358,
+                                                                                                                                                                                                            "top": 2246,
+                                                                                                                                                                                                            "right": 722,
+                                                                                                                                                                                                            "bottom": 2302
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 885,
+                                                                                                                                                                                            "top": 2105,
+                                                                                                                                                                                            "right": 1027,
+                                                                                                                                                                                            "bottom": 2247
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            },
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/scroll_fade",
+                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 2329,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/home_screen_overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_left_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 36,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 143,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "desc": "Home",
+                                                                                                                                                                                "id": "com.ubercab.driver:id/profile_entry",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_icon",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_photo",
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/earnings_tracker_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 261,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 819,
+                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__tracker_entry_content_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_entry_public_mode_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__earnings_tracker_indicator_card",
+                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                                    "top": 149,
+                                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                                    "bottom": 229
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                        "text": "$0.00",
+                                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_counter_content_status",
+                                                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                            "left": 457,
+                                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                                            "right": 623,
+                                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 522,
+                                                                                                                                                                                                                    "top": 243,
+                                                                                                                                                                                                                    "right": 558,
+                                                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/my_hub_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 937,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "desc": "Search for places",
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/search_entry_button",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 937,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_center_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 540,
+                                                                                                                                                                            "top": 279,
+                                                                                                                                                                            "right": 540,
+                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_container",
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 136
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_view",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_control_top_right_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 1044,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 374
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_left_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 1980,
+                                                                                                                                                                                    "right": 179,
+                                                                                                                                                                                    "bottom": 2355
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_speed_intervention_container",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 18,
+                                                                                                                                                                                            "top": 1998,
+                                                                                                                                                                                            "right": 54,
+                                                                                                                                                                                            "bottom": 2034
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_safety_toolkit_container",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 18,
+                                                                                                                                                                                            "top": 2034,
+                                                                                                                                                                                            "right": 161,
+                                                                                                                                                                                            "bottom": 2177
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                    "top": 2052,
+                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                    "bottom": 2159
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__safety_toolkit_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                            "top": 2052,
+                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                            "bottom": 2159
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Safety Toolkit",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__safety_toolkit_button_container",
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                                    "top": 2052,
+                                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                                    "bottom": 2159
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__shield_animation_view",
+                                                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                                            "top": 2052,
+                                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                                            "bottom": 2159
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_container",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 901,
+                                                                                                                                                                                    "top": 1869,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2373
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                            "top": 1887,
+                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                            "bottom": 2195
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_ugc_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 1887,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 2030
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__ugc_map_button",
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 1887,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 2030
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Report a map issue",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__ugc_map_button_icon",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 1905,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 2012
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_top_right_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 1062,
+                                                                                                                                                                                                    "top": 2030,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 2034
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_bottom_right_buttons",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 2034,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 2195
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_nav_button_layout",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 2034,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 2177
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_bottom_right",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 2052,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 2159
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__nav_guidance_container",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__nav_guidance_maneuver_view",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 18,
+                                                                                                                                                                                    "top": 154,
+                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/swipe_nav_guidance_maneuver_view",
+                                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 18,
+                                                                                                                                                                                            "top": 154,
+                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                            "bottom": 329
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__nav_address_view",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 18,
+                                                                                                                                                                                                    "top": 154,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 325
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 89,
+                                                                                                                                                                                                            "top": 172,
+                                                                                                                                                                                                            "right": 991,
+                                                                                                                                                                                                            "bottom": 307
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "text": "[address]",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__nav_address_view_poi_text",
+                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 89,
+                                                                                                                                                                                                                    "top": 172,
+                                                                                                                                                                                                                    "right": 991,
+                                                                                                                                                                                                                    "bottom": 236
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "text": "San Antonio, TX",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__nav_address_view_address_text",
+                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 89,
+                                                                                                                                                                                                                    "top": 243,
+                                                                                                                                                                                                                    "right": 991,
+                                                                                                                                                                                                                    "bottom": 307
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -17,6 +17,12 @@
         "shape": null,
         "fields": {}
     },
+    "active_trip/2026-07-21_19-07-46-239__uber__accessibility.window__active_trip__f2a555.json": {
+        "ruleId": "uber.screen.active_trip",
+        "intent": "active_trip",
+        "shape": null,
+        "fields": {}
+    },
     "active_trip/2026-07-21_19-14-49-677__uber__accessibility.window__active_trip__6f786c.json": {
         "ruleId": "uber.screen.active_trip",
         "intent": "active_trip",

--- a/matchers/rules/uber.json5
+++ b/matchers/rules/uber.json5
@@ -261,6 +261,94 @@
     {
       "id": "uber.screen.splash",
       "priority": 40,
+      "comment": "#813 (found by the #825 audit): splash anchors on rootSplashBackground ALONE and can win classification over a live trip underlay whose nav/address nodes carry customer street names and (id-less) name/address lines — with no redact those shipped raw to the capture envelope. Same capture-only content-shape SSOT set as active_trip (#803/#825), plus id anchors for the nav maneuver / current-street / destination-address views the trip underlay renders. Disk-only; never a recognition regression (splash has no parse block).",
+      "redact": [
+        {
+          "find": {
+            "hasTextContaining": "gate code"
+          }
+        },
+        {
+          "find": {
+            "hasTextMatchesRegex": "\\bgate[\\s:#]*\\d{3}"
+          }
+        },
+        {
+          "find": {
+            "hasTextMatchesRegex": "\\bpin[\\s:#]*\\d{3}"
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "\\d{5}"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        },
+        {
+          "find": {
+            "hasTextStartsWith": "Apt "
+          },
+          "keepPrefix": [
+            "Apt "
+          ]
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^\\s{0,8}[\\p{L}][\\p{L}'-]{0,20}( [\\p{L}][\\p{L}'-]{0,20}){0,3} [A-Z]\\.?\\s{0,8}$"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          },
+          "normalize": "customerName"
+        },
+        {
+          "find": {
+            "hasIdSuffix": "ub__nav_address_view_poi_text"
+          }
+        },
+        {
+          "find": {
+            "hasIdSuffix": "ub__nav_address_view_address_text"
+          }
+        },
+        {
+          "find": {
+            "hasIdSuffix": "ub__nav_maneuver_text"
+          }
+        },
+        {
+          "find": {
+            "hasIdSuffix": "ub__current_street_name_tv"
+          }
+        },
+        {
+          "find": {
+            "hasIdSuffix": "key_info_label"
+          }
+        }
+      ],
       "require": {
         "exists": {
           "hasIdSuffix": "rootSplashBackground"
@@ -314,6 +402,74 @@
     {
       "id": "uber.screen.pickup_verification_items",
       "priority": 52,
+      "comment": "#825 audit: this verify-order surface carries a bare (id-less) customer first-name + last-initial line with no lead-in marker, past every scrub layer. Same capture-only content-shape SSOT set as active_trip (#803/#825). Disk-only; never a recognition regression (no parse block).",
+      "redact": [
+        {
+          "find": {
+            "hasTextContaining": "gate code"
+          }
+        },
+        {
+          "find": {
+            "hasTextMatchesRegex": "\\bgate[\\s:#]*\\d{3}"
+          }
+        },
+        {
+          "find": {
+            "hasTextMatchesRegex": "\\bpin[\\s:#]*\\d{3}"
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "\\d{5}"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        },
+        {
+          "find": {
+            "hasTextStartsWith": "Apt "
+          },
+          "keepPrefix": [
+            "Apt "
+          ]
+        },
+        {
+          "find": {
+            "hasTextStartsWith": "\""
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^\\s{0,8}[\\p{L}][\\p{L}'-]{0,20}( [\\p{L}][\\p{L}'-]{0,20}){0,3} [A-Z]\\.?\\s{0,8}$"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          },
+          "normalize": "customerName"
+        }
+      ],
       "state": {
         "flow": "task:pickup:arrived",
         "modeHint": "online"
@@ -348,6 +504,79 @@
     {
       "id": "uber.screen.customer_chat",
       "priority": 55,
+      "comment": "#825 audit: the chat surface renders the customer name in ub__chat_header_title and carries the delivery-instruction supporting text (gate code) plus the underlying trip card's bare name/address — none of it was redacted. Same capture-only content-shape SSOT set as active_trip (#803/#825) + the chat-header id anchor. Chat MESSAGE bodies (free customer-typed text) beyond a name shape are the documented residual (a message that is neither a name shape nor a gate/pin/address token is not isolable by a per-node predicate). Disk-only; never a recognition regression.",
+      "redact": [
+        {
+          "find": {
+            "hasIdSuffix": "ub__chat_header_title"
+          }
+        },
+        {
+          "find": {
+            "hasTextContaining": "gate code"
+          }
+        },
+        {
+          "find": {
+            "hasTextMatchesRegex": "\\bgate[\\s:#]*\\d{3}"
+          }
+        },
+        {
+          "find": {
+            "hasTextMatchesRegex": "\\bpin[\\s:#]*\\d{3}"
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "\\d{5}"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        },
+        {
+          "find": {
+            "hasTextStartsWith": "Apt "
+          },
+          "keepPrefix": [
+            "Apt "
+          ]
+        },
+        {
+          "find": {
+            "hasTextStartsWith": "\""
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^\\s{0,8}[\\p{L}][\\p{L}'-]{0,20}( [\\p{L}][\\p{L}'-]{0,20}){0,3} [A-Z]\\.?\\s{0,8}$"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          },
+          "normalize": "customerName"
+        }
+      ],
       "state": {
         "modeHint": "online"
       },
@@ -510,6 +739,103 @@
     {
       "id": "uber.screen.active_trip",
       "priority": 100,
+      "comment": "#825 (HIGH Pledge): the fielded on-job card renders the customer's first-name + last-initial, street, gate code and unit as BARE (id-less) nodes — no 'Deliver to '/'Pickup for ' lead-in in the same node — so CustomerTextMarkers' prefix backstop structurally cannot scrub them, and this rule declared no `redact`, so raw customer PII shipped to the capture envelope (4 recognized frames on 07-21). Redaction is capture-only (never touches recognition/parse/dedup — this rule has no parse block, goldens byte-identical). The id-less CONTENT-shape entries are the same cross-platform SSOT set proven on doordash.screen.dropoff_pin_entry (#803): whole-node mask of any node carrying a gate code / PIN / street / zip / unit / quoted note / whole-value first-name+last-initial. Plus uber id anchors for the nav destination address view and the on-card name label. Accepted over-mask (privacy-first, disk-only): a store nav address on a PICKUP leg (this flow is phase-less) or a numeric chrome node (e.g. an ETA) may also mask — safe, never a recognition regression. Residual: a bare city/state line with no zip ('San Antonio, TX') is kept (matches the corpus keep-decision; not identifying alone) and an id-less possessive landmark note is the documented prefix-less residual.",
+      "redact": [
+        {
+          "find": {
+            "hasTextContaining": "gate code"
+          }
+        },
+        {
+          "find": {
+            "hasTextMatchesRegex": "\\bgate[\\s:#]*\\d{3}"
+          }
+        },
+        {
+          "find": {
+            "hasTextMatchesRegex": "\\bpin[\\s:#]*\\d{3}"
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "\\d{5}"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        },
+        {
+          "find": {
+            "hasTextStartsWith": "Apt "
+          },
+          "keepPrefix": [
+            "Apt "
+          ]
+        },
+        {
+          "find": {
+            "hasTextStartsWith": "\""
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^#?\\s?\\d{1,4}[A-Za-z]?$"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        },
+        {
+          "comment": "id-less whole-value first-name + last-initial — same canonical SSOT as SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN / dropoff_multi_order_confirm. normalize customerName gives a per-customer-stable mask hex across the surface FORMS the name renders in.",
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^\\s{0,8}[\\p{L}][\\p{L}'-]{0,20}( [\\p{L}][\\p{L}'-]{0,20}){0,3} [A-Z]\\.?\\s{0,8}$"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          },
+          "normalize": "customerName"
+        },
+        {
+          "comment": "#825 uber id anchors: the nav destination address view (poi = street line, address = city/state) and the on-card key info label carry the customer address / name with a stable viewId.",
+          "find": {
+            "hasIdSuffix": "ub__nav_address_view_poi_text"
+          }
+        },
+        {
+          "find": {
+            "hasIdSuffix": "ub__nav_address_view_address_text"
+          }
+        },
+        {
+          "find": {
+            "hasIdSuffix": "key_info_label"
+          }
+        }
+      ],
       "state": {
         // #762 D2: a coarse in-job surface — `on_job_view` cannot tell pickup from dropoff, so it
         // declares the phase-less `task:active` flow (consumes the accepted offer into a job, holds

--- a/matchers/rules/uber.json5
+++ b/matchers/rules/uber.json5
@@ -261,7 +261,7 @@
     {
       "id": "uber.screen.splash",
       "priority": 40,
-      "comment": "#813 (found by the #825 audit): splash anchors on rootSplashBackground ALONE and can win classification over a live trip underlay whose nav/address nodes carry customer street names and (id-less) name/address lines — with no redact those shipped raw to the capture envelope. Same capture-only content-shape SSOT set as active_trip (#803/#825), plus id anchors for the nav maneuver / current-street / destination-address views the trip underlay renders. Disk-only; never a recognition regression (splash has no parse block).",
+      "comment": "#813 (found by the #825 audit): splash anchors on rootSplashBackground ALONE and can win classification over a live trip underlay whose nav/address nodes carry customer street names and (id-less) name/address lines — with no redact those shipped raw to the capture envelope. Carries the FULL cross-platform content-shape SSOT set from doordash.screen.dropoff_pin_entry (#803) — gate code / PIN / street / zip / apt / quoted note / bare unit / whole-value first-name+last-initial — plus id anchors for the nav maneuver / current-street / destination-address views and the map pin head (address in contentDescription) the trip underlay renders. Capture-only; never a recognition regression (splash has no parse block).",
       "redact": [
         {
           "find": {
@@ -312,6 +312,23 @@
         },
         {
           "find": {
+            "hasTextStartsWith": "\""
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^#?\\s?\\d{1,4}[A-Za-z]?$"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        },
+        {
+          "find": {
             "all": [
               {
                 "hasTextMatchesRegex": "^\\s{0,8}[\\p{L}][\\p{L}'-]{0,20}( [\\p{L}][\\p{L}'-]{0,20}){0,3} [A-Z]\\.?\\s{0,8}$"
@@ -346,6 +363,11 @@
         {
           "find": {
             "hasIdSuffix": "key_info_label"
+          }
+        },
+        {
+          "find": {
+            "hasIdSuffix": "map_marker_pin_head"
           }
         }
       ],
@@ -402,7 +424,7 @@
     {
       "id": "uber.screen.pickup_verification_items",
       "priority": 52,
-      "comment": "#825 audit: this verify-order surface carries a bare (id-less) customer first-name + last-initial line with no lead-in marker, past every scrub layer. Same capture-only content-shape SSOT set as active_trip (#803/#825). Disk-only; never a recognition regression (no parse block).",
+      "comment": "#825 audit: this verify-order surface carries a bare (id-less) customer first-name + last-initial line with no lead-in marker, past every scrub layer. Carries the FULL cross-platform content-shape SSOT set from doordash.screen.dropoff_pin_entry (#803) — gate code / PIN / street / zip / apt / quoted note / bare unit / whole-value first-name+last-initial. The active_trip/customer_chat nav-destination id anchors are DELIBERATELY OMITTED: this is a task:pickup:arrived surface, so the nav destination is the STORE (not customer PII). Capture-only; never a recognition regression (no parse block).",
       "redact": [
         {
           "find": {
@@ -454,6 +476,18 @@
         {
           "find": {
             "hasTextStartsWith": "\""
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^#?\\s?\\d{1,4}[A-Za-z]?$"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
           }
         },
         {
@@ -504,12 +538,19 @@
     {
       "id": "uber.screen.customer_chat",
       "priority": 55,
-      "comment": "#825 audit: the chat surface renders the customer name in ub__chat_header_title and carries the delivery-instruction supporting text (gate code) plus the underlying trip card's bare name/address — none of it was redacted. Same capture-only content-shape SSOT set as active_trip (#803/#825) + the chat-header id anchor. Chat MESSAGE bodies (free customer-typed text) beyond a name shape are the documented residual (a message that is neither a name shape nor a gate/pin/address token is not isolable by a per-node predicate). Disk-only; never a recognition regression.",
+      "comment": "#825 audit: the chat surface renders the customer name in ub__chat_header_title AND headline_text ('<Name I.> says:'), carries the delivery-instruction supporting text (gate code), and — because this rule (priority 55) WINS the frame over active_trip (100) and only the winning rule's redact applies — must ALSO scrub the underlying trip card's id-bearing nav destination address / on-card name (its hasNoId content shapes can't reach those). Carries the FULL cross-platform content-shape SSOT set from doordash.screen.dropoff_pin_entry (#803) — gate code / PIN / street / zip / apt / quoted note / bare unit / whole-value first-name+last-initial — plus id anchors: chat header + headline (normalize customerName strips the ' says:' tail via customerNameKey), nav destination views, on-card label, map pin head (address in contentDescription). Chat MESSAGE bodies (free customer-typed text) beyond a name shape are the documented residual (a message that is neither a name shape nor a gate/pin/address token is not isolable by a per-node predicate). Capture-only; never a recognition regression.",
       "redact": [
         {
           "find": {
             "hasIdSuffix": "ub__chat_header_title"
           }
+        },
+        {
+          "comment": "#825 review HIGH-1: the chat header ALSO renders as headline_text '<Name I.> says:' — the name regex is whole-value anchored so the ' says:' tail defeats it. normalize:customerName gives the stable per-customer hex (customerNameKey('Casey T. says:') → 'casey t', tail stripped).",
+          "find": {
+            "hasIdSuffix": "headline_text"
+          },
+          "normalize": "customerName"
         },
         {
           "find": {
@@ -567,6 +608,18 @@
           "find": {
             "all": [
               {
+                "hasTextMatchesRegex": "^#?\\s?\\d{1,4}[A-Za-z]?$"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        },
+        {
+          "find": {
+            "all": [
+              {
                 "hasTextMatchesRegex": "^\\s{0,8}[\\p{L}][\\p{L}'-]{0,20}( [\\p{L}][\\p{L}'-]{0,20}){0,3} [A-Z]\\.?\\s{0,8}$"
               },
               {
@@ -575,6 +628,27 @@
             ]
           },
           "normalize": "customerName"
+        },
+        {
+          "comment": "#825 review MED-3: chat (priority 55) wins over active_trip (100), so the trip underlay's id-bearing customer address / on-card name / map pin must be scrubbed HERE too.",
+          "find": {
+            "hasIdSuffix": "ub__nav_address_view_poi_text"
+          }
+        },
+        {
+          "find": {
+            "hasIdSuffix": "ub__nav_address_view_address_text"
+          }
+        },
+        {
+          "find": {
+            "hasIdSuffix": "key_info_label"
+          }
+        },
+        {
+          "find": {
+            "hasIdSuffix": "map_marker_pin_head"
+          }
         }
       ],
       "state": {
@@ -820,7 +894,7 @@
           "normalize": "customerName"
         },
         {
-          "comment": "#825 uber id anchors: the nav destination address view (poi = street line, address = city/state) and the on-card key info label carry the customer address / name with a stable viewId.",
+          "comment": "#825 uber id anchors: the nav destination address view (poi = street line, address = city/state) and the on-card key info label carry the customer address / name with a stable viewId. map_marker_pin_head carries the customer address in contentDescription ONLY (no text) — the content-shape entries above scan node.text, so only an id-keyed entry reaches the desc (CompiledRedact.maskNode masks desc on an id match).",
           "find": {
             "hasIdSuffix": "ub__nav_address_view_poi_text"
           }
@@ -833,6 +907,11 @@
         {
           "find": {
             "hasIdSuffix": "key_info_label"
+          }
+        },
+        {
+          "find": {
+            "hasIdSuffix": "map_marker_pin_head"
           }
         }
       ],


### PR DESCRIPTION
Closes #825.

## Summary

`uber.screen.active_trip` declared no `redact` block. The fielded on-job card renders the customer's **first-name + last-initial**, **street**, **gate code** and **unit** as **bare (id-less) nodes** — with no `Deliver to `/`Pickup for ` lead-in *in the same node* — so the `CustomerTextMarkers` prefix backstop structurally cannot scrub them. Result: **raw customer PII shipped to 4 recognized capture envelopes on 07-21** (HIGH-severity Pledge surface). On one frame the backstop scrubbed a sibling `Deliver to ` node while the bare name leaked twice on the same frame.

This adds a **capture-only** `redact` block to `active_trip` (and to three more surfaces the audit found leaking the same way), reusing the exact cross-platform content-shape SSOT set proven on `doordash.screen.dropoff_pin_entry` (#803).

## Node-structure evidence (redacted/described)

Inspected all present 07-21 `active_trip` frames. The customer-PII surface is **id-less** across three card layouts (`top_info_row_container`, `middle_section_container`, `earnertripflow_screenlayout_body`):

| Field | Node | Why the old layers missed it |
|---|---|---|
| Customer name (`Firstname I.`) | id-less `TextView` | no viewId → not in `PII_ID_SUFFIXES`; no marker prefix → `CustomerTextMarkers` miss |
| Street line (`<num> <Street>`) | id-less `TextView` **and** `ub__nav_address_view_poi_text` | id-less card copy; the id'd nav copy had no redact |
| City/state | id-less `TextView` **and** `ub__nav_address_view_address_text` | — |
| Gate code (`Gate code #NNNN`) | id-less `TextView` | free-text, no marker |
| Unit (`Apt NNNN`) | `map_marker_title` | polymorphic id (also holds `Entrance`/`1 min`) |
| On-card name | `key_info_label` | — |

Store names (`P. Terry's Burger Stand`) and store codes are **kept** — merchants are not PII.

## What the redact covers

Whole-node mask of any node carrying (all capture-only, `[redacted:<4hex>]`):
- **Customer name** — id-less whole-value `FIRST_LAST_INITIAL_PATTERN` + `hasNoId` + `normalize: customerName` (per-customer-stable hex across the surface forms the name renders in; byte-identical SSOT with `SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN`).
- **Gate code / PIN / street / zip / unit / quoted note** — the same id-less content-shape set as `dropoff_pin_entry` (#803).
- **Uber id anchors** — `ub__nav_address_view_poi_text`, `ub__nav_address_view_address_text`, `key_info_label` (and, on splash, `ub__nav_maneuver_text` / `ub__current_street_name_tv`).

## Audit findings (task 5) — all fixed in-PR

The same bare-node class was found on three more recognized uber surfaces (evidence: the #829 corpus fixtures carried `SnapshotRedactor`-masked tokens under rules with **no** `redact`, i.e. a runtime leak). All fixed here with the same set:

- **`uber.screen.splash` (#813)** — anchors on `rootSplashBackground` alone and can win classification over a live trip underlay whose `ub__nav_maneuver_text` / `ub__current_street_name_tv` / address nodes carry customer street names, plus id-less name/address lines.
- **`uber.screen.customer_chat`** — `ub__chat_header_title` customer name + gate-code delivery instructions.
- **`uber.screen.pickup_verification_items`** — a bare id-less customer name line.

## Security / privacy posture

- **What's scrubbed:** customer name, street, gate code, PIN, zip, unit, quoted note, and the nav destination-address / on-card-name id nodes — masked in the **serialized envelope only**.
- **What's trusted / unchanged:** recognition, parse, the state machine, and the dedup `contentHash` all run on the **original** tree (these rules are parse-less → goldens byte-identical; the only golden delta is the new corpus frame's own empty-fields entry).
- **Fail-closed:** the mask hex falls back to plain `[redacted]` if the distinctness hash can't be computed; the `[redacted` prefix is always kept so downstream `contains("[redacted")` checks still classify the node as redacted.
- **Accepted over-mask (privacy-first, disk-only):** because `active_trip` is phase-less, a **store** nav address on a PICKUP leg (store addresses are not PII) or a numeric chrome node (e.g. an ETA) may also mask — safe, never a recognition regression.
- **Known residuals:** a bare city/state line with no zip (`San Antonio, TX` — kept, matches the #829 corpus keep-decision; not identifying alone); an id-less possessive landmark note; free chat-message bodies that are neither a name shape nor a gate/pin/address token (a per-node predicate can't isolate them). Documented in the rule comments.

## Test plan

- `CaptureRedactionCorpusTest` (the #820 mutation-teeth pattern): injected synthetic **live (un-redacted)** captures prove each of the four rules masks every PII node while the recognition anchors survive; the bare-name `normalize` hex is pinned to `sha256` of the canonical key; the `active_trip` name regex is asserted **SSOT** with `SnapshotRedactor`; the FIX-4 committed-corpus bare-name guard now covers the four uber folders.
- New corpus frame (`active_trip/2026-07-21_19-07-46-...json`) anonymized **through the production `SnapshotRedactor`** + a manual PII sweep (0 residual name/street/gate/pin/unit tokens); parse golden regenerated (one new active_trip entry, empty fields).
- `./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` green; full `./gradlew :app:testDebugUnitTest :domain:test` green.
- **PII verification:** grepped the staged diff for the real customer name/street tokens (none — all test literals are fabricated: `Casey T.` / `42 Nowhere Ln` / `Springfield, ZZ 00000` / `8888`); post-commit `git log -S"Lauren P."` and `git log -S"Sable Cyn"` both return **no commits**, proving the real customer name and street never entered history.
