### PR TITLE
fix(rules): #827 uber offer unit-anchored time/miles parse + #813 storeName parse & dropoff-line redact

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -56,6 +56,55 @@ class CaptureRedactionCorpusTest {
     }
 
     /**
+     * #813 — the uber.screen.offer redact is a PRIMARY privacy control for the
+     * offer card's dropoff intersection line (a prefix-less address line the
+     * `CustomerTextMarkers` backstop structurally can't own), and it had no
+     * automated coverage: `CaptureRedactionCorpusTest`'s other cases never touch
+     * this rule, and the marker-based backstop test is blind to it by
+     * construction. This is the teeth — a later predicate edit or Uber shape
+     * change that silently un-masks every offer dropoff line goes RED here.
+     *
+     * Runs the PRODUCTION redact over a real committed offer frame and asserts
+     * the dropoff line masks while the store name, pay, and the fused time/mi
+     * node stay raw (the over-match guard — store names never carry a ", ", the
+     * same discriminator the storeName parse uses).
+     */
+    @Test
+    fun `uber offer redact masks the dropoff intersection line, keeps store pay and time`() {
+        val rule = TestRulesetFactory.screenRuleset.ruleById("uber.screen.offer")!!
+        assertFalse("offer rule must declare a redact block", rule.redact.isEmpty())
+
+        // A real committed offer frame: store "Costco Wholesale (Sonterra Park)",
+        // dropoff "Sample St & Sample Ave, San Antonio", pay "$15.01", fused
+        // "40 min (17.5 mi) total". (The intersection is already anonymized in
+        // the corpus; the redact predicate matches the ", <City>" shape, not any
+        // literal street.)
+        val fixture = File("src/test/resources/snapshots/offer")
+            .listFiles { _, n -> n.contains("uber") && n.endsWith(".json") }!!
+            .first { it.readText().contains("Costco Wholesale") }
+        val real = TestResourceLoader.loadNode(fixture)
+
+        val redactedJson = serialize(rule.redact.apply(real))
+
+        // Dropoff intersection line is masked (customer-area PII).
+        assertFalse(
+            "dropoff intersection line must not persist raw",
+            redactedJson.contains("Sample St & Sample Ave, San Antonio"),
+        )
+        assertTrue(
+            "the masked dropoff line carries a [redacted:<4hex>] token",
+            Regex("""\[redacted:[0-9a-f]{4}]""").containsMatchIn(redactedJson),
+        )
+        // Over-match guard: store name, pay, and the fused time/mi node stay RAW.
+        assertTrue(
+            "store name kept (no ', ' → not matched)",
+            redactedJson.contains("Costco Wholesale (Sonterra Park)"),
+        )
+        assertTrue("pay kept", redactedJson.contains("\$15.01"))
+        assertTrue("fused time/mi node kept", redactedJson.contains("40 min (17.5 mi) total"))
+    }
+
+    /**
      * #623 frame-invariance ACROSS RULES (VET V5): the SAME customer token, seen
      * under three different production redact blocks (each with a different marker
      * prefix / node predicate), must redact to the SAME 4hex distinctness suffix —

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
@@ -195,10 +195,9 @@ class ParseOutputGoldenTest {
         // awaiting_offer landed 2026-07-19. The 2026-07-21 dash (second Uber attempt) closed the
         // rest: offer, earnings_activity, session_summary, customer_chat, delivery_confirmation,
         // and pickup_verification_items all landed corpus. The uber.screen.offer "Offer -
-        // {storeName}" effect template is still a dead effect-arg on the fielded frames — now
-        // exercised by the offer corpus and PINNED in knownDeadArgTemplates (#606/#801-analog,
-        // filed for a rule-side pass) rather than dodged by withholding the capture. Only post_trip
-        // still has zero snapshots in the corpus (#433).
+        // {storeName}" effect template was a dead effect-arg on the fielded frames; #813 gave the
+        // rule a top-level storeName parse so it now interpolates (pin removed from
+        // knownDeadArgTemplates). Only post_trip still has zero snapshots in the corpus (#433).
         "post_trip",
     )
 
@@ -341,12 +340,10 @@ class ParseOutputGoldenTest {
      */
     private val knownDeadArgTemplates = setOf(
         "doordash.screen.delivery_summary_collapsed:totalPay",
-        // uber.screen.offer's "Offer - {storeName}" effect arg fails to interpolate on the
-        // fielded offer frames (the rule doesn't parse storeName off that layout) — surfaced by
-        // the 2026-07-21 offer corpus, which was previously withheld precisely to dodge this
-        // (see knownUncoveredIntents). Pinned here (not fixed) — corpus PR; filed for a rule-side
-        // pass (#606/#801-analog). #827's fused time/miles parse pass is the natural place to fix it.
-        "uber.screen.offer:storeName",
+        // uber.screen.offer:storeName was FIXED in #813: the rule now parses a
+        // top-level storeName (scoped to the offer card) so "Offer - {storeName}"
+        // interpolates on every fielded offer frame. Pin removed (the lint asserts
+        // known == dead, so a stale pin fails).
     )
 
     @Test

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -2987,7 +2987,7 @@
         "intent": "offer",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=6c0dcd4a19f333e13f16e048392035568d130793baa3bdb085fc8bafc93f829d, itemCount=0, payAmount=15.01, payTextRaw=null, distanceMiles=40.0, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=40, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Costco Wholesale (Sonterra Park), itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=0e9b7f0d5d3885e6a37895cc7eefae3b69a2f16a6957932e0ffbcba647a81676, itemCount=0, payAmount=15.01, payTextRaw=null, distanceMiles=17.5, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=40, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Costco Wholesale (Sonterra Park), itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
         }
     },
     "offer/2026-07-21_18-38-16-682__uber__accessibility.window__offer__9e2877.json": {
@@ -2995,7 +2995,7 @@
         "intent": "offer",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=0cbd89d58948c410312de7a26d24fd69980c961e2b523d6607c0afc6c2a3ab31, itemCount=0, payAmount=10.08, payTextRaw=null, distanceMiles=30.0, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=30, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Buttermilk Sky Pie, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=fc2cbdc99f2158deb74425dfaf2bf6c2b7395083e2fab646da70449fe5d9e05f, itemCount=0, payAmount=10.08, payTextRaw=null, distanceMiles=12.3, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=30, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Buttermilk Sky Pie, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
         }
     },
     "offer/2026-07-21_18-40-26-194__uber__accessibility.window__offer__2d8f1d.json": {
@@ -3003,7 +3003,7 @@
         "intent": "offer",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=de8679f6fc77daa69d1f0fcb46bcc5ee73ea2afd07afc6456c2e81d8bbb84ce4, itemCount=0, payAmount=8.54, payTextRaw=null, distanceMiles=33.0, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=33, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=BJ's Restaurant & Brewhouse (San Antonio #480), itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=554490d501c5d175c5a3aa235d53a57b6912ed72b7162dc68159d1972f9fa8bf, itemCount=0, payAmount=8.54, payTextRaw=null, distanceMiles=12.8, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=33, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=BJ's Restaurant & Brewhouse (San Antonio #480), itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
         }
     },
     "offer/2026-07-21_18-44-21-714__uber__accessibility.window__offer__3e789f.json": {
@@ -3011,7 +3011,7 @@
         "intent": "offer",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=e50642a868468ff9fc782f4e505e9c1c69fc76b1f9893c40ae5cafc973d80eac, itemCount=0, payAmount=7.9, payTextRaw=null, distanceMiles=19.0, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Thai Buri (8728401), itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=b3dd7bb57085615c51d4de209190f9a34a35e855f691f69ebc9be536a176abb4, itemCount=0, payAmount=7.9, payTextRaw=null, distanceMiles=3.9, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=19, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Thai Buri (8728401), itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_163448_533_OFFER_POPUP.json": {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformRegistry.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformRegistry.kt
@@ -104,6 +104,7 @@ object TransformRegistry {
             "parseTime" -> parseTimeTextToMillis(value)
             "parseDuration" -> parseDuration(value)
             "parseHrMin" -> parseHrMin(value)
+            "parseMinutes" -> parseMinutes(value)
             "parseLeadingInt" -> parseLeadingInt(value)
             "parsePercent" -> parsePercent(value)
             "sha256" -> sha256OrNull(value)
@@ -229,7 +230,7 @@ object TransformRegistry {
 
     private val knownPlainTransforms = setOf(
         "parseCurrency", "parseDistance", "parseItemCount", "parseDeadline",
-        "parseTime", "parseDuration", "parseHrMin", "parseLeadingInt",
+        "parseTime", "parseDuration", "parseHrMin", "parseMinutes", "parseLeadingInt",
         "parsePercent", "sha256", "normalizeCustomerName", "trim", "lower", "upper",
         "toDouble", "toInt", "stripDeadlinePrefix",
     )
@@ -321,10 +322,37 @@ object TransformRegistry {
 
     /**
      * Parses distance: "5.5 mi", "Additional 2.6 mi", "500 ft" (converts ft to mi).
+     *
+     * Unit-anchored (#827): read the number bound to its OWN "mi" token with a
+     * word boundary so "mi" can NEVER match inside "min". Uber fuses time and
+     * distance in one node — e.g. "40 min (17.5 mi) total" — and the old
+     * leading-number read returned the 40-*minute* value as 40.0 miles (the real
+     * 17.5 mi discarded, then re-modeled ≈2.7× on every offer). Falls back to a
+     * "ft" number (converted), then any leading number for legacy single-value
+     * nodes ("5.5 mi", "500 ft") — byte-identical to the old behaviour there.
      */
     private fun parseDistance(text: String): Double? {
+        Regex("(\\d+(?:\\.\\d+)?)\\s*mi\\b", RegexOption.IGNORE_CASE).find(text)?.let {
+            return it.groupValues[1].toDoubleOrNull()
+        }
+        Regex("(\\d+(?:\\.\\d+)?)\\s*ft\\b", RegexOption.IGNORE_CASE).find(text)?.let {
+            return it.groupValues[1].toDoubleOrNull()?.div(5280.0)
+        }
         val num = Regex("(\\d+(?:\\.\\d+)?)").find(text)?.value?.toDoubleOrNull() ?: return null
         return if (text.contains("ft", true)) num / 5280.0 else num
+    }
+
+    /**
+     * Parses whole minutes bound to their OWN "min" token (#827): "40 min
+     * (17.5 mi) total" -> 40, "+ 19 min (+ 3.9 mi) total" -> 19. Unlike
+     * [parseLeadingInt] (which reads the node's leading token and returns null on
+     * the "+ 19 min" add-on shape because the leading token is "+"), this anchors
+     * on the unit, so it is robust to any lead-in and can never pick up the miles
+     * value. Returns null when no "min" token is present.
+     */
+    private fun parseMinutes(text: String): Int? {
+        return Regex("(\\d+)\\s*min\\b", RegexOption.IGNORE_CASE)
+            .find(text)?.groupValues?.get(1)?.toIntOrNull()
     }
 
     /**

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,19 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — #827 (Part 1) + #813 — Uber offer time/miles parse + storeName + dropoff redact.** The
+  Uber offer's fused `NN min (NN.N mi) total` node now parses distance from the parenthetical miles
+  (was reading the *minutes* value as miles, ≈2.7× on every offer), minutes from the `min` token
+  (robust to the `+ NN min` add-on lead-in), a top-level `storeName` (so the `Offer - <store>`
+  screenshot filename interpolates instead of literal `{storeName}`), and redacts the dropoff
+  intersection line (`<St> & <St>, <City>`) in the capture envelope.
+  **What to watch / desk-side:** after an Uber offer, the offer screenshot should be named
+  `Offer - <real store>.png` (not `Offer - {storeName}.png`); the offer's estimated $/hr and $/mi
+  should be sane (a 17.5 mi offer no longer reads as 40 mi). **Desk:** in the pull's `offer_records`,
+  Uber `distanceMiles` should match the `(NN.N mi)` on the card, not the minutes; grep the recognized
+  Uber offer capture tree for `& .*, San Antonio` / `, [A-Z][a-z]+$` intersection lines → every hit
+  must be `[redacted:<4hex>]`, while store names (which contain no `, `) stay raw.
+  - Confirmed: 0/2
 - **🆕 NEW — #806 / PR #815 — UNKNOWN-path customer scrub (screen + notification + click).** The
   `CustomerTextMarkers` backstop now scrubs UNKNOWN envelopes too (plus a new "Pickup for " marker), so
   an unrecognized customer-bearing surface can no longer persist a marker-prefixed name raw.

--- a/docs/rules.schema.json
+++ b/docs/rules.schema.json
@@ -915,6 +915,7 @@
         "parseTime",
         "parseDuration",
         "parseHrMin",
+        "parseMinutes",
         "parseLeadingInt",
         "parsePercent",
         "sha256",

--- a/matchers/rules/uber.json5
+++ b/matchers/rules/uber.json5
@@ -353,8 +353,11 @@
       // redact is the primary control. Anchored on the trailing ", <City>" address
       // shape — the pickup store TextView never contains a ", " (the same
       // discriminator the storeName parse uses), so store names are NOT
-      // over-redacted. Documented residual: a dropoff line rendered without a city
-      // tail would be missed, but every fielded shape carries ", <City>".
+      // over-redacted. Documented residuals: (1) a dropoff line rendered without a
+      // city tail would be missed, but every fielded shape carries ", <City>";
+      // (2) the `find` selects on node.text only (hasTextMatchesRegex is a text
+      // containsMatchIn), so a desc-only rendering of the line would escape
+      // selection — all fielded fixtures render it as text.
       "redact": [
         {
           "find": {

--- a/matchers/rules/uber.json5
+++ b/matchers/rules/uber.json5
@@ -120,6 +120,19 @@
             "flow": "offer:presented",
             "modeHint": "online"
           },
+          "bind": {
+            // #813: scope storeName to the offer card so the top-level find can't
+            // stray onto a map_marker_title annotation (an earlier-in-tree store
+            // pin, sometimes a dropoff) or the "New requests" browse pill — both
+            // live OUTSIDE primary_touch_area. The card store TextView is id-less,
+            // so the read below reuses the same negation predicate the orders[]
+            // extract uses; binding the card is what makes the first-match safe.
+            "offerCard": {
+              "find": {
+                "hasIdSuffix": "primary_touch_area"
+              }
+            }
+          },
           "require": {
             "all": [
               {
@@ -156,19 +169,94 @@
                 "read": "text",
                 "transform": "parseCurrency"
               },
+              // #827: Uber fuses time+distance in ONE node ("40 min (17.5 mi)
+              // total"). The finder is word-boundary anchored (mi\\b) so it
+              // targets the "(17.5 mi)" parenthetical and can never latch the "mi"
+              // inside "min"; parseDistance is likewise unit-anchored, reading the
+              // number bound to its own "mi" token rather than the node's leading
+              // number (which was the 40-minute value).
               "distance": {
                 "find": {
-                  "hasTextMatchesRegex": "\\d[\\d.]*\\s*mi"
+                  "hasTextMatchesRegex": "\\d[\\d.]*\\s*mi\\b"
                 },
                 "read": "text",
                 "transform": "parseDistance"
               },
+              // #827: parseMinutes reads the number bound to its own "min" token —
+              // robust to the "+ 19 min" add-on lead-in (parseLeadingInt returned
+              // null there because the leading token is "+") and structurally
+              // unable to pick up the miles value. The finder is min\\b anchored so
+              // it targets the singular "N min" total node and skips a plural
+              // "N mins away" ETA line (both can co-occur; the ETA line would
+              // otherwise be found first and parse null).
               "timeToCompleteMinutes": {
                 "find": {
-                  "hasTextMatchesRegex": "\\d+\\s*min"
+                  "hasTextMatchesRegex": "\\d+\\s*min\\b"
                 },
                 "read": "text",
-                "transform": "parseLeadingInt"
+                "transform": "parseMinutes"
+              },
+              // #813: top-level storeName so the "Offer - {storeName}" screenshot
+              // prefix interpolates (it resolves against the raw parse map, which
+              // never held the nested orders[].storeName). Scoped to the offer
+              // card (bind above); same negation predicate as orders[] — the store
+              // TextView is the first card text that is not a price/badge/label,
+              // the duration ("min"), or the dropoff line (", <city>").
+              "storeName": {
+                "from": "offerCard",
+                "find": {
+                  "all": [
+                    {
+                      "hasClassName": "android.widget.TextView"
+                    },
+                    {
+                      "not": {
+                        "any": [
+                          {
+                            "hasTextMatchesRegex": "^\\$"
+                          },
+                          {
+                            "hasTextMatchesRegex": "^\\+"
+                          },
+                          {
+                            "hasTextContaining": "min"
+                          },
+                          {
+                            "hasText": "Accept"
+                          },
+                          {
+                            "hasText": "Match"
+                          },
+                          {
+                            "hasText": "Delivery"
+                          },
+                          {
+                            "hasTextContaining": "Exclusive"
+                          },
+                          {
+                            "hasTextContaining": "Guaranteed"
+                          },
+                          {
+                            "hasTextContaining": "Includes"
+                          },
+                          {
+                            "hasTextContaining": "Add a"
+                          },
+                          {
+                            "hasTextContaining": "Shop &"
+                          },
+                          {
+                            "hasTextMatchesRegex": "^\\d+ items?"
+                          },
+                          {
+                            "hasTextContaining": ", "
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "read": "text"
               },
               "orders": {
                 "each": {
@@ -255,6 +343,23 @@
               "throttleMs": 60000
             }
           ]
+        }
+      ],
+      // #813(b): the offer card's dropoff line — a street intersection or single
+      // road followed by ", <City>" ("Sample St & Sample Ave, San Antonio",
+      // "Sample Rd, San Antonio") — is customer-area PII that shipped RAW to the
+      // capture envelope. It carries no lead-in prefix, so the CustomerTextMarkers
+      // backstop ("Deliver to "/"Pickup for ") can't own it; this rule-declared
+      // redact is the primary control. Anchored on the trailing ", <City>" address
+      // shape — the pickup store TextView never contains a ", " (the same
+      // discriminator the storeName parse uses), so store names are NOT
+      // over-redacted. Documented residual: a dropoff line rendered without a city
+      // tail would be missed, but every fielded shape carries ", <City>".
+      "redact": [
+        {
+          "find": {
+            "hasTextMatchesRegex": ",\\s[A-Z][a-zA-Z]+(\\s[A-Z][a-zA-Z]+){0,4}$"
+          }
         }
       ]
     },


### PR DESCRIPTION
Reworks `uber.screen.offer` in `matchers/rules/uber.json5` to fix two defects surfaced by the 2026-07-21 offer corpus (PR #829). Recognition-only; no `:core:state` / Kotlin state-machine change.

## #827 Part 1 — the mi⊂min swap
Uber renders time+distance **fused in one node**: `40 min (17.5 mi) total`. The distance finder `\d[\d.]*\s*mi` matched `40 min` (`mi` is a prefix of `min`) and `parseDistance` took the node's **leading number**, so `distanceMiles` was the **40-minute value** — the real 17.5 mi discarded, then re-modeled ≈2.7× on every offer (all 17 offer_records from 07-21).

**Fix — extract each value from the group adjacent to its OWN unit:**

| | before | after |
|---|---|---|
| distance finder | `\d[\d.]*\s*mi` (matches `40 min`) | `\d[\d.]*\s*mi\b` (targets `(17.5 mi)`, `mi` can't match inside `min`) |
| `parseDistance` | `Regex("(\d+(?:\.\d+)?)").find` → node's **leading** number | `Regex("(\d+(?:\.\d+)?)\s*mi\b")` → number bound to its own `mi` token; ft / leading-number fallbacks kept (byte-identical for legacy `5.5 mi` / `500 ft` nodes — **no DoorDash golden change**) |
| minutes finder | `\d+\s*min` | `\d+\s*min\b` (targets singular `NN min` total, skips `N mins away` ETA) |
| minutes transform | `parseLeadingInt` (returns null on `+ 19 min` — leading token is `+`) | **new** `parseMinutes` = `Regex("(\d+)\s*min\b")` → int, unit-anchored |

`mi\b` / `min\b`: `mi)` and `min ` end on a word boundary; `mi` inside `min` (word char follows) and `min` inside `mins` do not.

## #813 — dead `{storeName}` template + dropoff-line PII leak
**(a)** The rule declared `"Offer - {storeName}"` but never parsed a top-level `storeName` (it lives nested in `orders[]`; effect args resolve against the **raw parse map**), so every offer screenshot saved the literal `Offer - {storeName}.png` (#606/#801 class). Added a top-level `storeName` parse **scoped to the offer card** (`bind: offerCard = primary_touch_area`) reusing the same negation predicate as `orders[]` — the store is the first card text that isn't a price/badge/label, the duration (`min`), or the dropoff line (`, <city>`). Scoping is load-bearing: `map_marker_title` annotations and the "New requests" browse pill live outside `primary_touch_area` and would otherwise be found first in tree order. The pinned dead-arg-template `uber.screen.offer:storeName` is removed from `ParseOutputGoldenTest` (lint asserts `known == dead`; a stale pin fails).

> Note: the corpus's 4 committed offer frames contain **no** `map_marker_title` node, so sourcing `storeName` from that id (as the issue suggested) would parse null on all of them and the pin could not be removed. The offer-card store TextView is the always-present, single, unambiguous source and keeps `storeName` consistent with `orders[].storeName` (SSOT).

**(b) Privacy — redact the dropoff intersection line.** The offer card's dropoff line (`<St> & <St>, <City>` or `<Rd>, <City>`) is customer-area PII that shipped **raw** to the capture envelope: it carries no lead-in prefix so the `CustomerTextMarkers` backstop can't own it. Added a rule `redact` anchored on the trailing `, <City>` address shape: `,\s[A-Z][a-zA-Z]+(\s[A-Z][a-zA-Z]+){0,4}$` (bounded quantifier — the unbounded `(…)*` first draft was rejected by `RegexSafety` as a ReDoS nest). The store TextView never contains a `, ` (the same discriminator the `storeName` parse uses), so **store names are not over-redacted** — verified against all fielded stores/labels. **Residual:** a dropoff line rendered without a city tail is not caught by the anchor; every fielded shape carries `, <City>`.

## Golden delta
`approved-parse-output.json` — characterization flip on the **4 uber offer frames only** (no DoorDash entries touched, confirming `parseDistance` back-compat):
- `e14380`: distanceMiles **40.0 → 17.5** (minutes 40 unchanged)
- `9e2877`: **30.0 → 12.3** (minutes 30)
- `2d8f1d`: **33.0 → 12.8** (minutes 33)
- `3e789f` (add-on): **19.0 → 3.9**, timeToCompleteMinutes **null → 19**
- each `offerHash` follows (derived from pay/distance/time/stores)

`storeName` is a raw-map parse field consumed only by template interpolation, not part of `ParsedOffer`, so it correctly does not appear in the golden; its fix is proven by the dead-template lint now passing with the pin removed.

## Corpus additions
None. All 12 raw 07-22 offer frames are single-store, single fused-node offers already shape-covered by the 4 committed frames (no multi-store / two-order shape present to add).

## Out of scope
- #827 Part 2 (the seq-615 "Unknown Store" finder miss) — recapture-gated, stays open.
- #830 OfferLifecycle / state changes — no Kotlin state code touched.

## Test plan
- `*AllMatchersSuite*` — green (recognition + all `CaptureRedactionCorpusTest` / backstop tests).
- Full `:app:testDebugUnitTest` + `:domain:test` — green.
- Golden regenerated with `-DupdateParseGolden=true`, diff reviewed (above) and committed.
- Redact regex verified in isolation: matches all fielded dropoff intersections, matches **no** store name or card label.
- Field-test checklist item added (`docs/field-testing/README.md`, 0/2).
