### PR TITLE
feat(rules): #796 recognition-gap batch — dropoff issue menu, task feedback, receipt photo, barcode sub-flow, zone variant, Quality Rate

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -153,6 +153,7 @@ class CaptureRedactionCorpusTest {
             "doordash.screen.pickup_resolution_options",
             "doordash.screen.pickup_unassigned_confirmation",
             "doordash.screen.pickup_unassign_survey",
+            "doordash.screen.dropoff_issue_resolution",
         )
         val maskShape = Regex("""^For \[redacted:[0-9a-f]{4}\]$""")
         for (id in forFamily) {

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -493,6 +493,12 @@
             "zoneName": null
         }
     },
+    "dash_navigate_to_zone_loading/dash_navigate_to_zone_loading.json": {
+        "ruleId": "doordash.screen.dash_navigate_to_zone_loading",
+        "intent": "dash_navigate_to_zone_loading",
+        "shape": null,
+        "fields": {}
+    },
     "dash_paused/2026-02-09_09-41-00__DASH_PAUSED__f8b86141.json": {
         "ruleId": "doordash.screen.dash_paused",
         "intent": "dash_paused",
@@ -865,6 +871,18 @@
     "dash_time_picker/2026-07-16_13-36-15-282__doordash__accessibility.window__dash_time_picker__dc6142.json": {
         "ruleId": "doordash.screen.dash_time_picker",
         "intent": "dash_time_picker",
+        "shape": null,
+        "fields": {}
+    },
+    "dasher_rewards/dasher_rewards_about.json": {
+        "ruleId": "doordash.screen.dasher_rewards",
+        "intent": "dasher_rewards",
+        "shape": null,
+        "fields": {}
+    },
+    "dasher_rewards/dasher_rewards_board.json": {
+        "ruleId": "doordash.screen.dasher_rewards",
+        "intent": "dasher_rewards",
         "shape": null,
         "fields": {}
     },
@@ -1441,6 +1459,18 @@
     "dropoff_handoff/20260128_180855_435_DROPOFF_DETAILS_PRE_ARRIVAL.json": {
         "ruleId": "doordash.screen.dropoff_handoff",
         "intent": "dropoff_handoff",
+        "shape": null,
+        "fields": {}
+    },
+    "dropoff_issue_menu/dropoff_issue_menu.json": {
+        "ruleId": "doordash.screen.dropoff_issue_menu",
+        "intent": "dropoff_issue_menu",
+        "shape": null,
+        "fields": {}
+    },
+    "dropoff_issue_resolution/dropoff_issue_resolution.json": {
+        "ruleId": "doordash.screen.dropoff_issue_resolution",
+        "intent": "dropoff_issue_resolution",
         "shape": null,
         "fields": {}
     },
@@ -3242,6 +3272,24 @@
         "shape": null,
         "fields": {}
     },
+    "performance_orders_list/performance_orders_list.json": {
+        "ruleId": "doordash.screen.performance_orders_list",
+        "intent": "performance_orders_list",
+        "shape": null,
+        "fields": {}
+    },
+    "performance_rate_detail/performance_rate_completion.json": {
+        "ruleId": "doordash.screen.performance_rate_detail",
+        "intent": "performance_rate_detail",
+        "shape": null,
+        "fields": {}
+    },
+    "performance_rate_detail/performance_rate_quality.json": {
+        "ruleId": "doordash.screen.performance_rate_detail",
+        "intent": "performance_rate_detail",
+        "shape": null,
+        "fields": {}
+    },
     "pickup_arrival/20260128_190230_416_PICKUP_DETAILS_POST_ARRIVAL_PICKUP_SINGLE.json": {
         "ruleId": "doordash.screen.pickup_arrival",
         "intent": "pickup_arrival",
@@ -3556,6 +3604,24 @@
             "storeName": "Torchy's Tacos",
             "subFlow": "ARRIVED"
         }
+    },
+    "pickup_barcode_confirm/pickup_barcode_confirm.json": {
+        "ruleId": "doordash.screen.pickup_barcode_confirm",
+        "intent": "pickup_barcode_confirm",
+        "shape": null,
+        "fields": {}
+    },
+    "pickup_barcode_scan_failed/pickup_barcode_not_recognized.json": {
+        "ruleId": "doordash.screen.pickup_barcode_scan_failed",
+        "intent": "pickup_barcode_scan_failed",
+        "shape": null,
+        "fields": {}
+    },
+    "pickup_barcode_scan_failed/pickup_barcode_scan_failed_sheet.json": {
+        "ruleId": "doordash.screen.pickup_barcode_scan_failed",
+        "intent": "pickup_barcode_scan_failed",
+        "shape": null,
+        "fields": {}
     },
     "pickup_barcode_scan_issue/gopuff_barcode_scan_issue.json": {
         "ruleId": "doordash.screen.pickup_barcode_scan_issue",
@@ -4217,6 +4283,18 @@
         "shape": null,
         "fields": {}
     },
+    "pickup_receipt_photo/pickup_receipt_photo_confirm.json": {
+        "ruleId": "doordash.screen.pickup_receipt_photo",
+        "intent": "pickup_receipt_photo",
+        "shape": null,
+        "fields": {}
+    },
+    "pickup_receipt_photo/pickup_receipt_photo_intro.json": {
+        "ruleId": "doordash.screen.pickup_receipt_photo",
+        "intent": "pickup_receipt_photo",
+        "shape": null,
+        "fields": {}
+    },
     "pickup_resolution_options/2026-06-12__doordash__pickup_resolution_options__56f6eb.json": {
         "ruleId": "doordash.screen.pickup_resolution_options",
         "intent": "pickup_resolution_options",
@@ -4694,6 +4772,12 @@
     "promos/2026-07-18_15-24-47-887__doordash__accessibility.window__promos__31322b.json": {
         "ruleId": "doordash.screen.promos",
         "intent": "promos",
+        "shape": null,
+        "fields": {}
+    },
+    "quality_rate_intro/quality_rate_intro.json": {
+        "ruleId": "doordash.screen.quality_rate_intro",
+        "intent": "quality_rate_intro",
         "shape": null,
         "fields": {}
     },
@@ -5591,6 +5675,18 @@
     "splash/2026-07-19_13-31-50-295__uber__accessibility.window__splash__c145ff.json": {
         "ruleId": "uber.screen.splash",
         "intent": "splash",
+        "shape": null,
+        "fields": {}
+    },
+    "task_feedback/task_feedback_categories.json": {
+        "ruleId": "doordash.screen.task_feedback",
+        "intent": "task_feedback",
+        "shape": null,
+        "fields": {}
+    },
+    "task_feedback/task_feedback_thumbs.json": {
+        "ruleId": "doordash.screen.task_feedback",
+        "intent": "task_feedback",
         "shape": null,
         "fields": {}
     },

--- a/app/src/test/resources/snapshots/dash_navigate_to_zone_loading/dash_navigate_to_zone_loading.json
+++ b/app/src/test/resources/snapshots/dash_navigate_to_zone_loading/dash_navigate_to_zone_loading.json
@@ -1,0 +1,247 @@
+{
+    "captureId": "da812fbe-0a8d-4c26-b78f-e4cd291205ac",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1783279962580,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": -213,
+                    "top": 0,
+                    "right": 866,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Current dash",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 144,
+                                                                            "right": 125,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "text": "Navigate to zone",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 133,
+                                                                            "top": 163,
+                                                                            "right": 448,
+                                                                            "bottom": 213
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "text": "TX: Northwest San Antonio",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 133,
+                                                                            "top": 213,
+                                                                            "right": 514,
+                                                                            "bottom": 251
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 866,
+                                                                            "top": 144,
+                                                                            "right": 1080,
+                                                                            "bottom": 269
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "desc": "Safety",
+                                                                                "id": "com.doordash.driverapp:id/action_dasher_safety",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 866,
+                                                                                    "top": 153,
+                                                                                    "right": 973,
+                                                                                    "bottom": 260
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "desc": "Help",
+                                                                                "id": "com.doordash.driverapp:id/action_self_help",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 973,
+                                                                                    "top": 153,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 260
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 278,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 278,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 278,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "desc": "Loading",
+                                                                                "id": "com.doordash.driverapp:id/loading_view",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 496,
+                                                                                    "top": 1268,
+                                                                                    "right": 585,
+                                                                                    "bottom": 1357
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/dasher_rewards/dasher_rewards_about.json
+++ b/app/src/test/resources/snapshots/dasher_rewards/dasher_rewards_about.json
@@ -1,0 +1,1440 @@
+{
+    "captureId": "a3d2c190-a2c1-4095-ac11-ca68ee460e8b",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784406866307,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/main_content",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Navigate up",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 144,
+                                                                            "right": 125,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "text": "Dasher Rewards",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 133,
+                                                                            "top": 175,
+                                                                            "right": 526,
+                                                                            "bottom": 238
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 1080,
+                                                                            "top": 144,
+                                                                            "right": 1080,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 278,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 278,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/reward_info_epoxy_recyclerview",
+                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 278,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 278,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 655
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 278,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 655
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "What are Dasher Rewards?",
+                                                                                                "id": "com.doordash.driverapp:id/title_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 314,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 366
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Dasher Rewards is our new pilot program that recognizes your effort and commitment to delivering to your customers. As you achieve higher ratings, you can unlock more rewards to help maximize your dashing experience. See program rules.",
+                                                                                                "id": "com.doordash.driverapp:id/description_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 384,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 619
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 655,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 677
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 655,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 677
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/top_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 655,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 657
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/middle_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 657,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 675
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/bottom_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 675,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 677
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 677,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 801
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 677,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 801
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "What ratings are required for each level?",
+                                                                                                "id": "com.doordash.driverapp:id/title_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 713,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 765
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 801,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 920
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.widget.LinearLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 801,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 920
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Acceptance rate",
+                                                                                                "id": "com.doordash.driverapp:id/first_rating_value",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 226,
+                                                                                                    "top": 819,
+                                                                                                    "right": 435,
+                                                                                                    "bottom": 902
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Completion rate",
+                                                                                                "id": "com.doordash.driverapp:id/second_rating_value",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 435,
+                                                                                                    "top": 819,
+                                                                                                    "right": 644,
+                                                                                                    "bottom": 902
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Customer rating",
+                                                                                                "id": "com.doordash.driverapp:id/third_rating_value",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 644,
+                                                                                                    "top": 819,
+                                                                                                    "right": 853,
+                                                                                                    "bottom": 902
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Deliveries last 30d",
+                                                                                                "id": "com.doordash.driverapp:id/fourth_rating_value",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 853,
+                                                                                                    "top": 819,
+                                                                                                    "right": 1062,
+                                                                                                    "bottom": 902
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 920,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1082
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 920,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1082
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/container",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 18,
+                                                                                                    "top": 929,
+                                                                                                    "right": 1062,
+                                                                                                    "bottom": 1073
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/chart",
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 18,
+                                                                                                            "top": 929,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 1073
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 18,
+                                                                                                                    "top": 947,
+                                                                                                                    "right": 226,
+                                                                                                                    "bottom": 1055
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/tier_icon",
+                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 86,
+                                                                                                                            "top": 947,
+                                                                                                                            "right": 157,
+                                                                                                                            "bottom": 1018
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Silver",
+                                                                                                                        "id": "com.doordash.driverapp:id/tier_name",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 83,
+                                                                                                                            "top": 1018,
+                                                                                                                            "right": 161,
+                                                                                                                            "bottom": 1055
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "50%",
+                                                                                                                "id": "com.doordash.driverapp:id/first_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 226,
+                                                                                                                    "top": 947,
+                                                                                                                    "right": 435,
+                                                                                                                    "bottom": 1055
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "90%",
+                                                                                                                "id": "com.doordash.driverapp:id/second_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 435,
+                                                                                                                    "top": 947,
+                                                                                                                    "right": 644,
+                                                                                                                    "bottom": 1055
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "4.5",
+                                                                                                                "id": "com.doordash.driverapp:id/third_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 644,
+                                                                                                                    "top": 947,
+                                                                                                                    "right": 853,
+                                                                                                                    "bottom": 1055
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "--",
+                                                                                                                "id": "com.doordash.driverapp:id/fourth_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 853,
+                                                                                                                    "top": 947,
+                                                                                                                    "right": 1062,
+                                                                                                                    "bottom": 1055
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1082,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1244
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1082,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1244
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/container",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 18,
+                                                                                                    "top": 1091,
+                                                                                                    "right": 1062,
+                                                                                                    "bottom": 1235
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/chart",
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 18,
+                                                                                                            "top": 1091,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 1235
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 18,
+                                                                                                                    "top": 1109,
+                                                                                                                    "right": 226,
+                                                                                                                    "bottom": 1217
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/tier_icon",
+                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 86,
+                                                                                                                            "top": 1109,
+                                                                                                                            "right": 157,
+                                                                                                                            "bottom": 1180
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Gold",
+                                                                                                                        "id": "com.doordash.driverapp:id/tier_name",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 87,
+                                                                                                                            "top": 1180,
+                                                                                                                            "right": 156,
+                                                                                                                            "bottom": 1217
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "70%",
+                                                                                                                "id": "com.doordash.driverapp:id/first_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 226,
+                                                                                                                    "top": 1109,
+                                                                                                                    "right": 435,
+                                                                                                                    "bottom": 1217
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "95%",
+                                                                                                                "id": "com.doordash.driverapp:id/second_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 435,
+                                                                                                                    "top": 1109,
+                                                                                                                    "right": 644,
+                                                                                                                    "bottom": 1217
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "4.5",
+                                                                                                                "id": "com.doordash.driverapp:id/third_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 644,
+                                                                                                                    "top": 1109,
+                                                                                                                    "right": 853,
+                                                                                                                    "bottom": 1217
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "--",
+                                                                                                                "id": "com.doordash.driverapp:id/fourth_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 853,
+                                                                                                                    "top": 1109,
+                                                                                                                    "right": 1062,
+                                                                                                                    "bottom": 1217
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1244,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1406
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1244,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1406
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/container",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 18,
+                                                                                                    "top": 1253,
+                                                                                                    "right": 1062,
+                                                                                                    "bottom": 1397
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/chart",
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 18,
+                                                                                                            "top": 1253,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 1397
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 18,
+                                                                                                                    "top": 1271,
+                                                                                                                    "right": 226,
+                                                                                                                    "bottom": 1379
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/tier_icon",
+                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 86,
+                                                                                                                            "top": 1271,
+                                                                                                                            "right": 157,
+                                                                                                                            "bottom": 1342
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Platinum",
+                                                                                                                        "id": "com.doordash.driverapp:id/tier_name",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 58,
+                                                                                                                            "top": 1342,
+                                                                                                                            "right": 185,
+                                                                                                                            "bottom": 1379
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "70%",
+                                                                                                                "id": "com.doordash.driverapp:id/first_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 226,
+                                                                                                                    "top": 1271,
+                                                                                                                    "right": 435,
+                                                                                                                    "bottom": 1379
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "95%",
+                                                                                                                "id": "com.doordash.driverapp:id/second_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 435,
+                                                                                                                    "top": 1271,
+                                                                                                                    "right": 644,
+                                                                                                                    "bottom": 1379
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "4.7",
+                                                                                                                "id": "com.doordash.driverapp:id/third_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 644,
+                                                                                                                    "top": 1271,
+                                                                                                                    "right": 853,
+                                                                                                                    "bottom": 1379
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "100",
+                                                                                                                "id": "com.doordash.driverapp:id/fourth_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 853,
+                                                                                                                    "top": 1271,
+                                                                                                                    "right": 1062,
+                                                                                                                    "bottom": 1379
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1406,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1459
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/container",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1406,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1459
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1459,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1481
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1459,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1481
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/top_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1459,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1461
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/middle_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1461,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1479
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/bottom_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1479,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1481
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1481,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1647
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1481,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1647
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "How to unlock Silver level",
+                                                                                                "id": "com.doordash.driverapp:id/title_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1517,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1569
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Based on your current ratings",
+                                                                                                "id": "com.doordash.driverapp:id/subtitle_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1569,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1611
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1647,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1794
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1647,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1794
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Acceptance rate",
+                                                                                                "id": "com.doordash.driverapp:id/rating_name_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1674,
+                                                                                                    "right": 734,
+                                                                                                    "bottom": 1721
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Raise to 50%",
+                                                                                                "id": "com.doordash.driverapp:id/rating_description_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1721,
+                                                                                                    "right": 734,
+                                                                                                    "bottom": 1763
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "47%",
+                                                                                                "id": "com.doordash.driverapp:id/current_rating_value_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 752,
+                                                                                                    "top": 1700,
+                                                                                                    "right": 823,
+                                                                                                    "bottom": 1742
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/rating_status_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 841,
+                                                                                                    "top": 1694,
+                                                                                                    "right": 895,
+                                                                                                    "bottom": 1748
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "50%",
+                                                                                                "id": "com.doordash.driverapp:id/expected_rating_value_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 913,
+                                                                                                    "top": 1700,
+                                                                                                    "right": 990,
+                                                                                                    "bottom": 1742
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/end_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 990,
+                                                                                                    "top": 1694,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1748
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/rating_info_divider_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1790,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1794
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1794,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1899
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1794,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1899
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Completion rate",
+                                                                                                "id": "com.doordash.driverapp:id/rating_name_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1821,
+                                                                                                    "right": 826,
+                                                                                                    "bottom": 1868
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "99%",
+                                                                                                "id": "com.doordash.driverapp:id/expected_rating_value_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 916,
+                                                                                                    "top": 1826,
+                                                                                                    "right": 990,
+                                                                                                    "bottom": 1868
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/rating_status_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 844,
+                                                                                                    "top": 1820,
+                                                                                                    "right": 898,
+                                                                                                    "bottom": 1874
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/end_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 990,
+                                                                                                    "top": 1820,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1874
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/rating_info_divider_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1895,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1899
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1899,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2004
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1899,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2004
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Customer rating",
+                                                                                                "id": "com.doordash.driverapp:id/rating_name_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1926,
+                                                                                                    "right": 828,
+                                                                                                    "bottom": 1973
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "4.97",
+                                                                                                "id": "com.doordash.driverapp:id/expected_rating_value_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 918,
+                                                                                                    "top": 1931,
+                                                                                                    "right": 990,
+                                                                                                    "bottom": 1973
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/rating_status_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 846,
+                                                                                                    "top": 1925,
+                                                                                                    "right": 900,
+                                                                                                    "bottom": 1979
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/end_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 990,
+                                                                                                    "top": 1925,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1979
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 2004,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2057
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/container",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2004,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2057
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 2057,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2079
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2057,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2079
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/top_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 2057,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2059
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/middle_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 2059,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2077
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/bottom_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 2077,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2079
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 2079,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2203
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2079,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2203
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Available rewards",
+                                                                                                "id": "com.doordash.driverapp:id/title_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 2115,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 2167
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 2203,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2345
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2203,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2345
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/tier_icon",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 2239,
+                                                                                                    "right": 107,
+                                                                                                    "bottom": 2310
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Silver",
+                                                                                                "id": "com.doordash.driverapp:id/tier_name",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 134,
+                                                                                                    "top": 2248,
+                                                                                                    "right": 250,
+                                                                                                    "bottom": 2300
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/locked_icon",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 990,
+                                                                                                    "top": 2252,
+                                                                                                    "right": 1035,
+                                                                                                    "bottom": 2297
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 2345,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2345,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/reward_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 2371,
+                                                                                                    "right": 89,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Priority for high paying offers",
+                                                                                                "id": "com.doordash.driverapp:id/reward_name_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 116,
+                                                                                                    "top": 2372,
+                                                                                                    "right": 954,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/end_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 990,
+                                                                                                    "top": 2371,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/reward_info_divider_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 116,
+                                                                                                    "top": 2446,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/dasher_rewards/dasher_rewards_board.json
+++ b/app/src/test/resources/snapshots/dasher_rewards/dasher_rewards_board.json
@@ -1,0 +1,1534 @@
+{
+    "captureId": "4ab80290-004c-4a28-b7ee-bbc22fb18f8c",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784406871035,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/main_content",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Navigate up",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 144,
+                                                                            "right": 125,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "text": "Dasher Rewards",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 133,
+                                                                            "top": 175,
+                                                                            "right": 526,
+                                                                            "bottom": 238
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 1080,
+                                                                            "top": 144,
+                                                                            "right": 1080,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 278,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 278,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/reward_info_epoxy_recyclerview",
+                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 278,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 278,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 319
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.widget.LinearLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 278,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 319
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Acceptance rate",
+                                                                                                "id": "com.doordash.driverapp:id/first_rating_value",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 226,
+                                                                                                    "top": 278,
+                                                                                                    "right": 435,
+                                                                                                    "bottom": 301
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Completion rate",
+                                                                                                "id": "com.doordash.driverapp:id/second_rating_value",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 435,
+                                                                                                    "top": 278,
+                                                                                                    "right": 644,
+                                                                                                    "bottom": 301
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Customer rating",
+                                                                                                "id": "com.doordash.driverapp:id/third_rating_value",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 644,
+                                                                                                    "top": 278,
+                                                                                                    "right": 853,
+                                                                                                    "bottom": 284
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Deliveries last 30d",
+                                                                                                "id": "com.doordash.driverapp:id/fourth_rating_value",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 853,
+                                                                                                    "top": 278,
+                                                                                                    "right": 1062,
+                                                                                                    "bottom": 284
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 302,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 464
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 302,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 464
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/container",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 18,
+                                                                                                    "top": 311,
+                                                                                                    "right": 1062,
+                                                                                                    "bottom": 455
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/chart",
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 18,
+                                                                                                            "top": 311,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 455
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 18,
+                                                                                                                    "top": 329,
+                                                                                                                    "right": 226,
+                                                                                                                    "bottom": 437
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/tier_icon",
+                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 86,
+                                                                                                                            "top": 329,
+                                                                                                                            "right": 157,
+                                                                                                                            "bottom": 400
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Silver",
+                                                                                                                        "id": "com.doordash.driverapp:id/tier_name",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 83,
+                                                                                                                            "top": 400,
+                                                                                                                            "right": 161,
+                                                                                                                            "bottom": 437
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "50%",
+                                                                                                                "id": "com.doordash.driverapp:id/first_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 226,
+                                                                                                                    "top": 315,
+                                                                                                                    "right": 435,
+                                                                                                                    "bottom": 423
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "90%",
+                                                                                                                "id": "com.doordash.driverapp:id/second_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 435,
+                                                                                                                    "top": 315,
+                                                                                                                    "right": 644,
+                                                                                                                    "bottom": 423
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "4.5",
+                                                                                                                "id": "com.doordash.driverapp:id/third_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 644,
+                                                                                                                    "top": 315,
+                                                                                                                    "right": 853,
+                                                                                                                    "bottom": 423
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "--",
+                                                                                                                "id": "com.doordash.driverapp:id/fourth_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 853,
+                                                                                                                    "top": 315,
+                                                                                                                    "right": 1062,
+                                                                                                                    "bottom": 423
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 450,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 612
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 450,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 612
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/container",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 18,
+                                                                                                    "top": 446,
+                                                                                                    "right": 1062,
+                                                                                                    "bottom": 590
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/chart",
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 18,
+                                                                                                            "top": 446,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 590
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 18,
+                                                                                                                    "top": 464,
+                                                                                                                    "right": 226,
+                                                                                                                    "bottom": 572
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/tier_icon",
+                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 86,
+                                                                                                                            "top": 464,
+                                                                                                                            "right": 157,
+                                                                                                                            "bottom": 535
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Gold",
+                                                                                                                        "id": "com.doordash.driverapp:id/tier_name",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 87,
+                                                                                                                            "top": 535,
+                                                                                                                            "right": 156,
+                                                                                                                            "bottom": 572
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "70%",
+                                                                                                                "id": "com.doordash.driverapp:id/first_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 226,
+                                                                                                                    "top": 464,
+                                                                                                                    "right": 435,
+                                                                                                                    "bottom": 572
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "95%",
+                                                                                                                "id": "com.doordash.driverapp:id/second_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 435,
+                                                                                                                    "top": 464,
+                                                                                                                    "right": 644,
+                                                                                                                    "bottom": 572
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "4.5",
+                                                                                                                "id": "com.doordash.driverapp:id/third_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 644,
+                                                                                                                    "top": 464,
+                                                                                                                    "right": 853,
+                                                                                                                    "bottom": 572
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "--",
+                                                                                                                "id": "com.doordash.driverapp:id/fourth_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 853,
+                                                                                                                    "top": 464,
+                                                                                                                    "right": 1062,
+                                                                                                                    "bottom": 572
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 587,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 749
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 587,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 749
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/container",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 18,
+                                                                                                    "top": 596,
+                                                                                                    "right": 1062,
+                                                                                                    "bottom": 740
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/chart",
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 18,
+                                                                                                            "top": 596,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 740
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 18,
+                                                                                                                    "top": 614,
+                                                                                                                    "right": 226,
+                                                                                                                    "bottom": 722
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/tier_icon",
+                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 86,
+                                                                                                                            "top": 614,
+                                                                                                                            "right": 157,
+                                                                                                                            "bottom": 685
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Platinum",
+                                                                                                                        "id": "com.doordash.driverapp:id/tier_name",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 58,
+                                                                                                                            "top": 685,
+                                                                                                                            "right": 185,
+                                                                                                                            "bottom": 722
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "70%",
+                                                                                                                "id": "com.doordash.driverapp:id/first_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 226,
+                                                                                                                    "top": 604,
+                                                                                                                    "right": 435,
+                                                                                                                    "bottom": 712
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "95%",
+                                                                                                                "id": "com.doordash.driverapp:id/second_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 435,
+                                                                                                                    "top": 604,
+                                                                                                                    "right": 644,
+                                                                                                                    "bottom": 712
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "4.7",
+                                                                                                                "id": "com.doordash.driverapp:id/third_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 644,
+                                                                                                                    "top": 604,
+                                                                                                                    "right": 853,
+                                                                                                                    "bottom": 712
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "100",
+                                                                                                                "id": "com.doordash.driverapp:id/fourth_rating_value",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 853,
+                                                                                                                    "top": 604,
+                                                                                                                    "right": 1062,
+                                                                                                                    "bottom": 712
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 739,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 792
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/container",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 739,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 792
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 792,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 814
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 792,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 814
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/top_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 792,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 794
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/middle_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 794,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 812
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/bottom_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 812,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 814
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 814,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 980
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 814,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 980
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "How to unlock Silver level",
+                                                                                                "id": "com.doordash.driverapp:id/title_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 841,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 893
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Based on your current ratings",
+                                                                                                "id": "com.doordash.driverapp:id/subtitle_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 893,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 935
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 963,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1110
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 963,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1110
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Acceptance rate",
+                                                                                                "id": "com.doordash.driverapp:id/rating_name_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 990,
+                                                                                                    "right": 734,
+                                                                                                    "bottom": 1037
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Raise to 50%",
+                                                                                                "id": "com.doordash.driverapp:id/rating_description_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1037,
+                                                                                                    "right": 734,
+                                                                                                    "bottom": 1079
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "47%",
+                                                                                                "id": "com.doordash.driverapp:id/current_rating_value_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 752,
+                                                                                                    "top": 1016,
+                                                                                                    "right": 823,
+                                                                                                    "bottom": 1058
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/rating_status_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 841,
+                                                                                                    "top": 1003,
+                                                                                                    "right": 895,
+                                                                                                    "bottom": 1057
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "50%",
+                                                                                                "id": "com.doordash.driverapp:id/expected_rating_value_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 913,
+                                                                                                    "top": 1009,
+                                                                                                    "right": 990,
+                                                                                                    "bottom": 1051
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/end_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 990,
+                                                                                                    "top": 1003,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1057
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/rating_info_divider_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1099,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1103
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1103,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1208
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1103,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1208
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Completion rate",
+                                                                                                "id": "com.doordash.driverapp:id/rating_name_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1130,
+                                                                                                    "right": 826,
+                                                                                                    "bottom": 1177
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "99%",
+                                                                                                "id": "com.doordash.driverapp:id/expected_rating_value_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 916,
+                                                                                                    "top": 1135,
+                                                                                                    "right": 990,
+                                                                                                    "bottom": 1177
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/rating_status_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 844,
+                                                                                                    "top": 1123,
+                                                                                                    "right": 898,
+                                                                                                    "bottom": 1177
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/end_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 990,
+                                                                                                    "top": 1123,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1177
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/rating_info_divider_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1198,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1202
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1202,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1307
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1202,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1307
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Customer rating",
+                                                                                                "id": "com.doordash.driverapp:id/rating_name_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1229,
+                                                                                                    "right": 828,
+                                                                                                    "bottom": 1276
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "4.97",
+                                                                                                "id": "com.doordash.driverapp:id/expected_rating_value_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 918,
+                                                                                                    "top": 1234,
+                                                                                                    "right": 990,
+                                                                                                    "bottom": 1276
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/rating_status_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 846,
+                                                                                                    "top": 1228,
+                                                                                                    "right": 900,
+                                                                                                    "bottom": 1282
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/end_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 990,
+                                                                                                    "top": 1228,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1282
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1307,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1360
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/container",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1307,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1360
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1354,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1376
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1354,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1376
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/top_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1354,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1356
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/middle_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1356,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1374
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/bottom_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1374,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1376
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1376,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1500
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1376,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1500
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Available rewards",
+                                                                                                "id": "com.doordash.driverapp:id/title_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1412,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1464
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1500,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1642
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1495,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1637
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/tier_icon",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1531,
+                                                                                                    "right": 107,
+                                                                                                    "bottom": 1602
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Silver",
+                                                                                                "id": "com.doordash.driverapp:id/tier_name",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 134,
+                                                                                                    "top": 1540,
+                                                                                                    "right": 250,
+                                                                                                    "bottom": 1592
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/locked_icon",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 990,
+                                                                                                    "top": 1544,
+                                                                                                    "right": 1035,
+                                                                                                    "bottom": 1589
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1637,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1742
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1637,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1742
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/reward_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1663,
+                                                                                                    "right": 89,
+                                                                                                    "bottom": 1716
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Priority for high paying offers",
+                                                                                                "id": "com.doordash.driverapp:id/reward_name_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 116,
+                                                                                                    "top": 1664,
+                                                                                                    "right": 954,
+                                                                                                    "bottom": 1711
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/end_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 990,
+                                                                                                    "top": 1663,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1717
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/reward_info_divider_view",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 116,
+                                                                                                    "top": 1738,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1742
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1742,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1847
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1742,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1847
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/reward_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1768,
+                                                                                                    "right": 89,
+                                                                                                    "bottom": 1821
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Early access to scheduling",
+                                                                                                "id": "com.doordash.driverapp:id/reward_name_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 116,
+                                                                                                    "top": 1765,
+                                                                                                    "right": 954,
+                                                                                                    "bottom": 1812
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/end_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 990,
+                                                                                                    "top": 1764,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1818
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1843,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1896
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/container",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1843,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1896
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1896,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2038
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1896,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2038
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/tier_icon",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1932,
+                                                                                                    "right": 107,
+                                                                                                    "bottom": 2003
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Gold",
+                                                                                                "id": "com.doordash.driverapp:id/tier_name",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 134,
+                                                                                                    "top": 1941,
+                                                                                                    "right": 234,
+                                                                                                    "bottom": 1993
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/locked_icon",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 990,
+                                                                                                    "top": 1945,
+                                                                                                    "right": 1035,
+                                                                                                    "bottom": 1990
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 2034,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2139
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2034,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2139
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/reward_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 2060,
+                                                                                                    "right": 89,
+                                                                                                    "bottom": 2113
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Increased priority for high paying offers",
+                                                                                                "id": "com.doordash.driverapp:id/reward_name_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 116,
+                                                                                                    "top": 2061,
+                                                                                                    "right": 954,
+                                                                                                    "bottom": 2108
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/end_image_view",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 990,
+                                                                                                    "top": 2060,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 2114
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 2139,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2253
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2139,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2253
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Also includes all silver rewards",
+                                                                                                "id": "com.doordash.driverapp:id/note_text_view",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 2175,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 2217
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/dropoff_issue_menu/dropoff_issue_menu.json
+++ b/app/src/test/resources/snapshots/dropoff_issue_menu/dropoff_issue_menu.json
@@ -1,0 +1,288 @@
+{
+    "captureId": "af399a9b-6f73-45e3-8c68-61ab83d04296",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784339226795,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2311
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2311
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2311
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2311
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2311
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.widget.ScrollView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 225,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 624
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "Drop-off issues",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 270,
+                                                                                                                    "right": 441,
+                                                                                                                    "bottom": 336
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 381,
+                                                                                                                    "right": 1035,
+                                                                                                                    "bottom": 488
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Reached drop-off location",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 45,
+                                                                                                                            "top": 411,
+                                                                                                                            "right": 520,
+                                                                                                                            "bottom": 458
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "desc": "",
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 982,
+                                                                                                                            "top": 408,
+                                                                                                                            "right": 1035,
+                                                                                                                            "bottom": 461
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 445,
+                                                                                                                    "right": 1035,
+                                                                                                                    "bottom": 508
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 508,
+                                                                                                                    "right": 1035,
+                                                                                                                    "bottom": 615
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Have not reached drop-off location",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 45,
+                                                                                                                            "top": 538,
+                                                                                                                            "right": 678,
+                                                                                                                            "bottom": 585
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "desc": "",
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 982,
+                                                                                                                            "top": 535,
+                                                                                                                            "right": 1035,
+                                                                                                                            "bottom": 588
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "desc": "",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 9,
+                                                                                                            "top": 145,
+                                                                                                            "right": 116,
+                                                                                                            "bottom": 252
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/dropoff_issue_resolution/dropoff_issue_resolution.json
+++ b/app/src/test/resources/snapshots/dropoff_issue_resolution/dropoff_issue_resolution.json
@@ -1,0 +1,494 @@
+{
+    "captureId": "6a2a3895-5a4c-44ce-9486-1acf636c17c2",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784339229199,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2311
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2311
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2311
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2311
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2311
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.widget.ScrollView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 246,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 1256
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "Reached drop-off location",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 291,
+                                                                                                                    "right": 728,
+                                                                                                                    "bottom": 357
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "If you delivered this order but didn’t complete it at the drop-off location, let us know why.",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 393,
+                                                                                                                    "right": 1035,
+                                                                                                                    "bottom": 496
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 568,
+                                                                                                                    "right": 1035,
+                                                                                                                    "bottom": 675
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "state": "Not selected",
+                                                                                                                        "class": "android.widget.RadioButton",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 74,
+                                                                                                                            "top": 597,
+                                                                                                                            "right": 123,
+                                                                                                                            "bottom": 646
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Provided address or map pin is wrong",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 188,
+                                                                                                                            "top": 598,
+                                                                                                                            "right": 860,
+                                                                                                                            "bottom": 645
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 659,
+                                                                                                                    "right": 1035,
+                                                                                                                    "bottom": 749
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 749,
+                                                                                                                    "right": 1035,
+                                                                                                                    "bottom": 856
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "state": "Not selected",
+                                                                                                                        "class": "android.widget.RadioButton",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 74,
+                                                                                                                            "top": 778,
+                                                                                                                            "right": 123,
+                                                                                                                            "bottom": 827
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Customer changed delivery location",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 188,
+                                                                                                                            "top": 779,
+                                                                                                                            "right": 841,
+                                                                                                                            "bottom": 826
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 840,
+                                                                                                                    "right": 1035,
+                                                                                                                    "bottom": 930
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 930,
+                                                                                                                    "right": 1035,
+                                                                                                                    "bottom": 1037
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "state": "Not selected",
+                                                                                                                        "class": "android.widget.RadioButton",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 74,
+                                                                                                                            "top": 959,
+                                                                                                                            "right": 123,
+                                                                                                                            "bottom": 1008
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Poor phone signal or app issues",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 188,
+                                                                                                                            "top": 960,
+                                                                                                                            "right": 754,
+                                                                                                                            "bottom": 1007
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 1021,
+                                                                                                                    "right": 1035,
+                                                                                                                    "bottom": 1111
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 1111,
+                                                                                                                    "right": 1035,
+                                                                                                                    "bottom": 1218
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "state": "Not selected",
+                                                                                                                        "class": "android.widget.RadioButton",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 74,
+                                                                                                                            "top": 1140,
+                                                                                                                            "right": 123,
+                                                                                                                            "bottom": 1189
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "I forgot to mark the order as complete",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 188,
+                                                                                                                            "top": 1141,
+                                                                                                                            "right": 871,
+                                                                                                                            "bottom": 1188
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 1202,
+                                                                                                                    "right": 1035,
+                                                                                                                    "bottom": 1308
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "desc": "",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 9,
+                                                                                                            "top": 156,
+                                                                                                            "right": 116,
+                                                                                                            "bottom": 263
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "For Jordan P • Pei Wei",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 334,
+                                                                                                            "top": 181,
+                                                                                                            "right": 745,
+                                                                                                            "bottom": 228
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1953,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2059
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 45,
+                                                                                                            "top": 2043,
+                                                                                                            "right": 1035,
+                                                                                                            "bottom": 2150
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.widget.Button",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 2043,
+                                                                                                                    "right": 1035,
+                                                                                                                    "bottom": 2150
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Continue",
+                                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 445,
+                                                                                                                            "top": 2064,
+                                                                                                                            "right": 635,
+                                                                                                                            "bottom": 2130
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 45,
+                                                                                                            "top": 2204,
+                                                                                                            "right": 1035,
+                                                                                                            "bottom": 2311
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.widget.Button",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 45,
+                                                                                                                    "top": 2204,
+                                                                                                                    "right": 1035,
+                                                                                                                    "bottom": 2311
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Contact Support",
+                                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 370,
+                                                                                                                            "top": 2225,
+                                                                                                                            "right": 711,
+                                                                                                                            "bottom": 2291
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/performance_orders_list/performance_orders_list.json
+++ b/app/src/test/resources/snapshots/performance_orders_list/performance_orders_list.json
@@ -1,0 +1,784 @@
+{
+    "captureId": "dc12d8c4-f4b7-45fa-a27f-05d31666b985",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1783988680396,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/dasher_workflow_host_fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/dasher_workflow_host_fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 403,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 403,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 403,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 433
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 403,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 433
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 158,
+                                                                                                                                    "right": 347,
+                                                                                                                                    "bottom": 213
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Jul 12 • Completed",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 136,
+                                                                                                                                            "right": 347,
+                                                                                                                                            "bottom": 117
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 385,
+                                                                                                                                    "right": 973,
+                                                                                                                                    "bottom": 485
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 433,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 611
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 611,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 789
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 403,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 411
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 403,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 425
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 403,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 451
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 403,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 486
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 403,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 423
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 403,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 477
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 403,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 422
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 403,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 492
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 403,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 445
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 313,
+                                                                                                                                    "right": 332,
+                                                                                                                                    "bottom": 368
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Jul 7 • Completed",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 271,
+                                                                                                                                            "right": 332,
+                                                                                                                                            "bottom": 326
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 403,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 448
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 403,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 448
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 364,
+                                                                                                                                    "right": 334,
+                                                                                                                                    "bottom": 419
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Jul 5 • Completed",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 364,
+                                                                                                                                            "right": 334,
+                                                                                                                                            "bottom": 419
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 394,
+                                                                                                                                    "right": 973,
+                                                                                                                                    "bottom": 500
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 448,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 626
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 448,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 626
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 475,
+                                                                                                                                    "right": 151,
+                                                                                                                                    "bottom": 533
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "H-E-B",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 475,
+                                                                                                                                            "right": 151,
+                                                                                                                                            "bottom": 533
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 542,
+                                                                                                                                    "right": 334,
+                                                                                                                                    "bottom": 597
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Jul 5 • Completed",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 542,
+                                                                                                                                            "right": 334,
+                                                                                                                                            "bottom": 597
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 572,
+                                                                                                                                    "right": 973,
+                                                                                                                                    "bottom": 678
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 626,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 804
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 600,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 778
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 527,
+                                                                                                                                    "right": 151,
+                                                                                                                                    "bottom": 585
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "H-E-B",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 400,
+                                                                                                                                            "right": 151,
+                                                                                                                                            "bottom": 458
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 328,
+                                                                                                                                    "right": 334,
+                                                                                                                                    "bottom": 383
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Jul 5 • Completed",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 308,
+                                                                                                                                            "right": 334,
+                                                                                                                                            "bottom": 363
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 278
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 278
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 9,
+                                                                                                                    "top": 153,
+                                                                                                                    "right": 116,
+                                                                                                                    "bottom": 260
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "desc": "Close",
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 180,
+                                                                                                                            "right": 89,
+                                                                                                                            "bottom": 233
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.Button",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 18,
+                                                                                                                            "top": 162,
+                                                                                                                            "right": 107,
+                                                                                                                            "bottom": 251
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 382,
+                                                                                                                    "top": 154,
+                                                                                                                    "right": 699,
+                                                                                                                    "bottom": 260
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Last 100 orders",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 382,
+                                                                                                                            "top": 181,
+                                                                                                                            "right": 699,
+                                                                                                                            "bottom": 233
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 296,
+                                                                                                    "right": 1007,
+                                                                                                    "bottom": 385
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "state": "Selected",
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "isChecked": 1,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 287,
+                                                                                                            "right": 142,
+                                                                                                            "bottom": 394
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "All",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 63,
+                                                                                                                    "top": 317,
+                                                                                                                    "right": 115,
+                                                                                                                    "bottom": 364
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "state": "Not selected",
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 160,
+                                                                                                            "top": 287,
+                                                                                                            "right": 427,
+                                                                                                            "bottom": 394
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "Completed",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 187,
+                                                                                                                    "top": 317,
+                                                                                                                    "right": 400,
+                                                                                                                    "bottom": 364
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "state": "Not selected",
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 445,
+                                                                                                            "top": 287,
+                                                                                                            "right": 721,
+                                                                                                            "bottom": 394
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "Unassigned",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 472,
+                                                                                                                    "top": 317,
+                                                                                                                    "right": 694,
+                                                                                                                    "bottom": 364
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "state": "Not selected",
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 739,
+                                                                                                            "top": 287,
+                                                                                                            "right": 971,
+                                                                                                            "bottom": 394
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "Excluded",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 766,
+                                                                                                                    "top": 317,
+                                                                                                                    "right": 944,
+                                                                                                                    "bottom": 364
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/performance_rate_detail/performance_rate_completion.json
+++ b/app/src/test/resources/snapshots/performance_rate_detail/performance_rate_completion.json
@@ -1,0 +1,472 @@
+{
+    "captureId": "f99b02d3-5957-482a-abd9-2b5f99cf102d",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1783988639390,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 2,
+            "top": 0,
+            "right": 1082,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 2,
+                    "top": 0,
+                    "right": 1082,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 2,
+                            "top": 136,
+                            "right": 1082,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 2,
+                                    "top": 136,
+                                    "right": 1082,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 2,
+                                            "top": 136,
+                                            "right": 1082,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/main_content",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 2,
+                                                    "top": 136,
+                                                    "right": 1082,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 2,
+                                                            "top": 136,
+                                                            "right": 1082,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 2,
+                                                                    "top": 136,
+                                                                    "right": 1082,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Navigate up",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 2,
+                                                                            "top": 144,
+                                                                            "right": 127,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "text": "Completion rate",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 135,
+                                                                            "top": 175,
+                                                                            "right": 532,
+                                                                            "bottom": 238
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 1082,
+                                                                            "top": 144,
+                                                                            "right": 1082,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 2,
+                                                            "top": 278,
+                                                            "right": 1082,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 2,
+                                                                    "top": 278,
+                                                                    "right": 1082,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 2,
+                                                                            "top": 278,
+                                                                            "right": 1082,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.widget.ScrollView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 2,
+                                                                                    "top": 278,
+                                                                                    "right": 1082,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "99%",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 469,
+                                                                                            "top": 367,
+                                                                                            "right": 615,
+                                                                                            "bottom": 451
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Good",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 480,
+                                                                                            "top": 451,
+                                                                                            "right": 605,
+                                                                                            "bottom": 508
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 2,
+                                                                                            "top": 563,
+                                                                                            "right": 1082,
+                                                                                            "bottom": 669
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Last 100 orders",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 38,
+                                                                                            "top": 689,
+                                                                                            "right": 384,
+                                                                                            "bottom": 746
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 38,
+                                                                                            "top": 768,
+                                                                                            "right": 1046,
+                                                                                            "bottom": 874
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Completed",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 38,
+                                                                                                    "top": 782,
+                                                                                                    "right": 251,
+                                                                                                    "bottom": 829
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "99",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 952,
+                                                                                                    "top": 782,
+                                                                                                    "right": 1001,
+                                                                                                    "bottom": 829
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "state": "99 percent.",
+                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 38,
+                                                                                                    "top": 847,
+                                                                                                    "right": 1046,
+                                                                                                    "bottom": 860
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 38,
+                                                                                            "top": 882,
+                                                                                            "right": 1046,
+                                                                                            "bottom": 988
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Unassigned",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 38,
+                                                                                                    "top": 896,
+                                                                                                    "right": 260,
+                                                                                                    "bottom": 943
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "1",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 984,
+                                                                                                    "top": 896,
+                                                                                                    "right": 1001,
+                                                                                                    "bottom": 943
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "state": "1 percent.",
+                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 38,
+                                                                                                    "top": 961,
+                                                                                                    "right": 1046,
+                                                                                                    "bottom": 974
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 38,
+                                                                                            "top": 983,
+                                                                                            "right": 396,
+                                                                                            "bottom": 1090
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "0 orders excluded",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 38,
+                                                                                                    "top": 1015,
+                                                                                                    "right": 334,
+                                                                                                    "bottom": 1058
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 38,
+                                                                                            "top": 1117,
+                                                                                            "right": 368,
+                                                                                            "bottom": 1206
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.widget.Button",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 38,
+                                                                                                    "top": 1117,
+                                                                                                    "right": 368,
+                                                                                                    "bottom": 1206
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "View all orders",
+                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 65,
+                                                                                                            "top": 1132,
+                                                                                                            "right": 341,
+                                                                                                            "bottom": 1192
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "About completion rate",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 38,
+                                                                                            "top": 1278,
+                                                                                            "right": 541,
+                                                                                            "bottom": 1335
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 38,
+                                                                                            "top": 1371,
+                                                                                            "right": 1046,
+                                                                                            "bottom": 1745
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "The number of orders you deliver without unassigning determines your completion rate. Your rating is calculated based on your past 100 deliveries and updates as you accept new orders.\n\nKeep your rating at 90% or above to avoid risking deactivation.",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 38,
+                                                                                                    "top": 1371,
+                                                                                                    "right": 1046,
+                                                                                                    "bottom": 1745
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 74,
+                                                                                            "top": 1817,
+                                                                                            "right": 1010,
+                                                                                            "bottom": 2297
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Example Completion Rate",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 74,
+                                                                                                    "top": 1817,
+                                                                                                    "right": 921,
+                                                                                                    "bottom": 1860
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "No longer in calculation",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 74,
+                                                                                                    "top": 2200,
+                                                                                                    "right": 471,
+                                                                                                    "bottom": 2243
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/performance_rate_detail/performance_rate_quality.json
+++ b/app/src/test/resources/snapshots/performance_rate_detail/performance_rate_quality.json
@@ -1,0 +1,592 @@
+{
+    "captureId": "ce015454-823b-47dd-8bce-4ccf6355c6e5",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784406907176,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/main_content",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Navigate up",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 144,
+                                                                            "right": 125,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "text": "Quality rate",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 133,
+                                                                            "top": 175,
+                                                                            "right": 421,
+                                                                            "bottom": 238
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 1080,
+                                                                            "top": 144,
+                                                                            "right": 1080,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 278,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 278,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 278,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.widget.ScrollView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 278,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "100%",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 447,
+                                                                                            "top": 367,
+                                                                                            "right": 634,
+                                                                                            "bottom": 451
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 437,
+                                                                                            "top": 451,
+                                                                                            "right": 644,
+                                                                                            "bottom": 510
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Very high",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 437,
+                                                                                                    "top": 451,
+                                                                                                    "right": 644,
+                                                                                                    "bottom": 510
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 565,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 671
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Last 100 orders",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 691,
+                                                                                            "right": 382,
+                                                                                            "bottom": 748
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 770,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 876
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Orders without issues",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 784,
+                                                                                                    "right": 447,
+                                                                                                    "bottom": 831
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "70",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 949,
+                                                                                                    "top": 784,
+                                                                                                    "right": 999,
+                                                                                                    "bottom": 831
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "state": "70 percent.",
+                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 849,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 862
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 898,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 1031
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Orders with major issues",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 898,
+                                                                                                    "right": 498,
+                                                                                                    "bottom": 945
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "-3% per order",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 949,
+                                                                                                    "right": 282,
+                                                                                                    "bottom": 996
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "0",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 970,
+                                                                                                    "top": 926,
+                                                                                                    "right": 999,
+                                                                                                    "bottom": 973
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "state": "0 percent.",
+                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1018,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1031
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 1067,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 1200
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Orders with minor issues",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1067,
+                                                                                                    "right": 501,
+                                                                                                    "bottom": 1114
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "-1% per order",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1118,
+                                                                                                    "right": 273,
+                                                                                                    "bottom": 1165
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "0",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 970,
+                                                                                                    "top": 1095,
+                                                                                                    "right": 999,
+                                                                                                    "bottom": 1142
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "state": "0 percent.",
+                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1187,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1200
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 1204,
+                                                                                            "right": 765,
+                                                                                            "bottom": 1311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "DoorDash reviews all customer reports",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 90,
+                                                                                                    "top": 1236,
+                                                                                                    "right": 720,
+                                                                                                    "bottom": 1279
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 1333,
+                                                                                            "right": 366,
+                                                                                            "bottom": 1422
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.widget.Button",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1333,
+                                                                                                    "right": 366,
+                                                                                                    "bottom": 1422
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "View all orders",
+                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 63,
+                                                                                                            "top": 1348,
+                                                                                                            "right": 339,
+                                                                                                            "bottom": 1408
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "About quality rate",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 1494,
+                                                                                            "right": 441,
+                                                                                            "bottom": 1551
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 1587,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 1799
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Quality rate measures how many of your last 100 orders you completed without any reported issues. Completed orders can take up to 12 hours to be reflected in your quality rate while we review customer reports.",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1587,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1799
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Tips to increase your rating",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 1871,
+                                                                                            "right": 638,
+                                                                                            "bottom": 1928
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 1,
+                                                                                            "top": 1938,
+                                                                                            "right": 107,
+                                                                                            "bottom": 2044
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Always deliver the correct order to the correct customer",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 90,
+                                                                                            "top": 1973,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2076
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 1,
+                                                                                            "top": 2077,
+                                                                                            "right": 107,
+                                                                                            "bottom": 2183
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Handle orders carefully and with the proper equipment, like a hot bag or pizza bag",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 90,
+                                                                                            "top": 2112,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2215
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 1,
+                                                                                            "top": 2216,
+                                                                                            "right": 107,
+                                                                                            "bottom": 2322
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Focus on accuracy by remembering drinks and desserts, and by picking the right items while shopping",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 90,
+                                                                                            "top": 2251,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2347
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/pickup_barcode_confirm/pickup_barcode_confirm.json
+++ b/app/src/test/resources/snapshots/pickup_barcode_confirm/pickup_barcode_confirm.json
@@ -1,0 +1,419 @@
+{
+    "captureId": "713484f2-dc6f-42af-85f1-4254c9ee15aa",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784342600134,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2400,
+                    "right": 1080,
+                    "bottom": 4747
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 2536,
+                            "right": 1080,
+                            "bottom": 4747
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 2536,
+                                    "right": 1080,
+                                    "bottom": 4747
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2536,
+                                            "right": 1080,
+                                            "bottom": 4747
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/layout_bottom_sheet",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 2536,
+                                                    "right": 1080,
+                                                    "bottom": 4747
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/overlay_view",
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2536,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4168,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4168,
+                                                                    "right": 1080,
+                                                                    "bottom": 4204
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/handle_overlay",
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 4168,
+                                                                            "right": 1080,
+                                                                            "bottom": 4204
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/handle_overlay_image",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 4186,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4195
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4276,
+                                                                    "right": 1080,
+                                                                    "bottom": 4711
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 4276,
+                                                                            "right": 1080,
+                                                                            "bottom": 4711
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 4276,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4443
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 4276,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 4443
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 4276,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 4443
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/epoxyRecyclerView",
+                                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 4276,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 4443
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 4276,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 4369
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 4276,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 4369
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Confirm barcode scanned",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 27,
+                                                                                                                                    "top": 4303,
+                                                                                                                                    "right": 1053,
+                                                                                                                                    "bottom": 4369
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 4369,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 4443
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 4369,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 4443
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "CVS requires scanning of the barcode",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 27,
+                                                                                                                                    "top": 4396,
+                                                                                                                                    "right": 1053,
+                                                                                                                                    "bottom": 4443
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_header_divider",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4276,
+                                                                    "right": 1080,
+                                                                    "bottom": 4285
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4439,
+                                                            "right": 1080,
+                                                            "bottom": 4443
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4443,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_actions_container",
+                                                                "class": "android.widget.LinearLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4443,
+                                                                    "right": 1080,
+                                                                    "bottom": 4747
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.Button",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 4479,
+                                                                            "right": 1044,
+                                                                            "bottom": 4586
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "text": "Confirm",
+                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 456,
+                                                                                    "top": 4500,
+                                                                                    "right": 624,
+                                                                                    "bottom": 4566
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "class": "android.widget.Button",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 4604,
+                                                                            "right": 1044,
+                                                                            "bottom": 4711
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "text": "Scan again",
+                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 431,
+                                                                                    "top": 4625,
+                                                                                    "right": 650,
+                                                                                    "bottom": 4691
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 4747,
+                    "right": 1080,
+                    "bottom": 4800
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/pickup_barcode_scan_failed/pickup_barcode_not_recognized.json
+++ b/app/src/test/resources/snapshots/pickup_barcode_scan_failed/pickup_barcode_not_recognized.json
@@ -1,0 +1,423 @@
+{
+    "captureId": "c2eba7ca-a657-430b-bb0a-1b9c86a08422",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1783459527064,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/layout_bottom_sheet",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/overlay_view",
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2388,
+                                                            "right": 1080,
+                                                            "bottom": 4599
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 3874,
+                                                            "right": 1080,
+                                                            "bottom": 4599
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 3874,
+                                                                    "right": 1080,
+                                                                    "bottom": 3874
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 3910,
+                                                                    "right": 1080,
+                                                                    "bottom": 4563
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 3910,
+                                                                            "right": 1080,
+                                                                            "bottom": 4563
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 3910,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4563
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 3910,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 4563
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 3910,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 4563
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/layout_header",
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 3910,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 3910
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/cardView_navigationBar",
+                                                                                                        "class": "androidx.cardview.widget.CardView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 3910,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 3910
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/layout_navigationBar",
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3910,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3910
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/layout_scrollable_body",
+                                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 3910,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 4402
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 3910,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 4003
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 3910,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 4003
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Item barcode not recognized",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 63,
+                                                                                                                                    "top": 3937,
+                                                                                                                                    "right": 1017,
+                                                                                                                                    "bottom": 4003
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 4003,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 4357
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 4003,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 4357
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "You can’t buy items with barcodes that are not recognized in our database.\n\nHowever, if the barcode is damaged, you can try scanning the item again or scan one with a better barcode.",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 63,
+                                                                                                                                    "top": 4030,
+                                                                                                                                    "right": 1017,
+                                                                                                                                    "bottom": 4357
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/layout_footer",
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 4402,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 4563
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 4402,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 4563
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 4402,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 4563
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isClickable": true,
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 27,
+                                                                                                                                    "top": 4429,
+                                                                                                                                    "right": 1053,
+                                                                                                                                    "bottom": 4536
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Scan again",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 429,
+                                                                                                                                            "top": 4457,
+                                                                                                                                            "right": 649,
+                                                                                                                                            "bottom": 4509
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.Button",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 27,
+                                                                                                                                            "top": 4429,
+                                                                                                                                            "right": 1053,
+                                                                                                                                            "bottom": 4536
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4595,
+                                                            "right": 1080,
+                                                            "bottom": 4599
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4599,
+                                                            "right": 1080,
+                                                            "bottom": 4599
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 4599,
+                    "right": 1080,
+                    "bottom": 4652
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/pickup_barcode_scan_failed/pickup_barcode_scan_failed_sheet.json
+++ b/app/src/test/resources/snapshots/pickup_barcode_scan_failed/pickup_barcode_scan_failed_sheet.json
@@ -1,0 +1,335 @@
+{
+    "captureId": "62179ec1-6ae9-48b6-8d70-a1543e267e60",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1783895862468,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 2400,
+            "right": 1080,
+            "bottom": 4800
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2400,
+                    "right": 1080,
+                    "bottom": 4747
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 2536,
+                            "right": 1080,
+                            "bottom": 4747
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 2536,
+                                    "right": 1080,
+                                    "bottom": 4747
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2536,
+                                            "right": 1080,
+                                            "bottom": 4747
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/layout_bottom_sheet",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 2536,
+                                                    "right": 1080,
+                                                    "bottom": 4747
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/overlay_view",
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2536,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 3891,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 3891,
+                                                                    "right": 1080,
+                                                                    "bottom": 3927
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/handle_overlay",
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 3891,
+                                                                            "right": 1080,
+                                                                            "bottom": 3927
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/handle_overlay_image",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 3909,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 3918
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "text": "Scan Failed",
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_title",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 36,
+                                                                    "top": 3963,
+                                                                    "right": 1044,
+                                                                    "bottom": 4047
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4083,
+                                                                    "right": 1080,
+                                                                    "bottom": 4711
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 4083,
+                                                                            "right": 1080,
+                                                                            "bottom": 4711
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 4083,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4443
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "You can’t buy items with barcodes that are not recognized in our database.\n\nHowever, if the barcode is damaged, you can try scanning the item again or scan one with a better barcode.",
+                                                                                        "id": "com.doordash.driverapp:id/prism_sheet_message",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 4083,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 4443
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_header_divider",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4083,
+                                                                    "right": 1080,
+                                                                    "bottom": 4092
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4439,
+                                                            "right": 1080,
+                                                            "bottom": 4443
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4443,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_actions_container",
+                                                                "class": "android.widget.LinearLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4443,
+                                                                    "right": 1080,
+                                                                    "bottom": 4747
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.Button",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 4479,
+                                                                            "right": 1044,
+                                                                            "bottom": 4586
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "text": "Enter PLU instead",
+                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 355,
+                                                                                    "top": 4500,
+                                                                                    "right": 725,
+                                                                                    "bottom": 4566
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "class": "android.widget.Button",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 4604,
+                                                                            "right": 1044,
+                                                                            "bottom": 4711
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "text": "Scan Again",
+                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 426,
+                                                                                    "top": 4625,
+                                                                                    "right": 654,
+                                                                                    "bottom": 4691
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 4747,
+                    "right": 1080,
+                    "bottom": 4800
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/pickup_receipt_photo/pickup_receipt_photo_confirm.json
+++ b/app/src/test/resources/snapshots/pickup_receipt_photo/pickup_receipt_photo_confirm.json
@@ -1,0 +1,316 @@
+{
+    "captureId": "1d4f9a82-690f-4ffa-a9fe-13080aedd716",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784338500094,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": -213,
+            "top": 0,
+            "right": 866,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": -213,
+                    "top": 0,
+                    "right": 866,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "id": "android:id/content",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": -213,
+                            "top": 136,
+                            "right": 866,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/education_photo_receipt_screen",
+                                "class": "android.view.ViewGroup",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": -213,
+                                    "top": 136,
+                                    "right": 866,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "com.doordash.driverapp:id/navBar",
+                                        "class": "android.widget.LinearLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": -213,
+                                            "top": 136,
+                                            "right": 866,
+                                            "bottom": 261
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/collapsingToolbar_navBar",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": -213,
+                                                    "top": 136,
+                                                    "right": 866,
+                                                    "bottom": 261
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/imageview_nav_bar_background",
+                                                        "class": "android.widget.ImageView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": -213,
+                                                            "top": 136,
+                                                            "right": 866,
+                                                            "bottom": 136
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_navBar",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": -213,
+                                                            "top": 136,
+                                                            "right": 866,
+                                                            "bottom": 261
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.ImageButton",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": -213,
+                                                                    "top": 136,
+                                                                    "right": -88,
+                                                                    "bottom": 261
+                                                                }
+                                                            },
+                                                            {
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": -88,
+                                                                    "top": 136,
+                                                                    "right": 866,
+                                                                    "bottom": 261
+                                                                }
+                                                            },
+                                                            {
+                                                                "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 866,
+                                                                    "top": 136,
+                                                                    "right": 866,
+                                                                    "bottom": 261
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "com.doordash.driverapp:id/scroll_view",
+                                        "class": "android.widget.ScrollView",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": -213,
+                                            "top": 261,
+                                            "right": 866,
+                                            "bottom": 2168
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": -213,
+                                                    "top": 261,
+                                                    "right": 866,
+                                                    "bottom": 1242
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/image_capture_result_group_view",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": -213,
+                                                            "top": 261,
+                                                            "right": -213,
+                                                            "bottom": 261
+                                                        }
+                                                    },
+                                                    {
+                                                        "text": "Receipt photo",
+                                                        "id": "com.doordash.driverapp:id/title",
+                                                        "class": "android.widget.TextView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": -177,
+                                                            "top": 314,
+                                                            "right": 830,
+                                                            "bottom": 380
+                                                        }
+                                                    },
+                                                    {
+                                                        "text": "We’ll share this photo with the customer to confirm you picked up the correct order.",
+                                                        "id": "com.doordash.driverapp:id/subtitle",
+                                                        "class": "android.widget.TextView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": -177,
+                                                            "top": 416,
+                                                            "right": 866,
+                                                            "bottom": 518
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/image_capture_result",
+                                                        "class": "android.widget.ImageView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": -177,
+                                                            "top": 554,
+                                                            "right": 245,
+                                                            "bottom": 1117
+                                                        }
+                                                    },
+                                                    {
+                                                        "desc": "Retake",
+                                                        "id": "com.doordash.driverapp:id/btn_retake_photo",
+                                                        "class": "android.widget.Button",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": -177,
+                                                            "top": 1153,
+                                                            "right": 8,
+                                                            "bottom": 1242
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "text": "Retake",
+                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": -150,
+                                                                    "top": 1168,
+                                                                    "right": -18,
+                                                                    "bottom": 1228
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "com.doordash.driverapp:id/btn_container",
+                                        "class": "android.view.ViewGroup",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": -213,
+                                            "top": 2168,
+                                            "right": 866,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "desc": "Continue",
+                                                "id": "com.doordash.driverapp:id/btn_primary_action",
+                                                "class": "android.widget.Button",
+                                                "isClickable": true,
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": -177,
+                                                    "top": 2204,
+                                                    "right": 830,
+                                                    "bottom": 2311
+                                                },
+                                                "children": [
+                                                    {
+                                                        "text": "Confirm pickup",
+                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                        "class": "android.widget.TextView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 168,
+                                                            "top": 2225,
+                                                            "right": 485,
+                                                            "bottom": 2291
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/statusBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": -213,
+                    "top": 0,
+                    "right": 866,
+                    "bottom": 136
+                }
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": -213,
+                    "top": 2347,
+                    "right": 866,
+                    "bottom": 2400
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/pickup_receipt_photo/pickup_receipt_photo_intro.json
+++ b/app/src/test/resources/snapshots/pickup_receipt_photo/pickup_receipt_photo_intro.json
@@ -1,0 +1,351 @@
+{
+    "captureId": "47891837-4548-4db9-a2f1-cf2233b8941e",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784338483645,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "id": "android:id/content",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/education_photo_receipt_screen",
+                                "class": "android.view.ViewGroup",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "com.doordash.driverapp:id/navBar",
+                                        "class": "android.widget.LinearLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 261
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/collapsingToolbar_navBar",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 261
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/imageview_nav_bar_background",
+                                                        "class": "android.widget.ImageView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 136
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_navBar",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 261
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.ImageButton",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 125,
+                                                                    "bottom": 261
+                                                                }
+                                                            },
+                                                            {
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 125,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 261
+                                                                }
+                                                            },
+                                                            {
+                                                                "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 1080,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 261
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "com.doordash.driverapp:id/scroll_view",
+                                        "class": "android.widget.ScrollView",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 261,
+                                            "right": 1080,
+                                            "bottom": 2043
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 261,
+                                                    "right": 1080,
+                                                    "bottom": 1519
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/instructions_group_view",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 261,
+                                                            "right": 0,
+                                                            "bottom": 261
+                                                        }
+                                                    },
+                                                    {
+                                                        "text": "Receipt photo",
+                                                        "id": "com.doordash.driverapp:id/title",
+                                                        "class": "android.widget.TextView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 36,
+                                                            "top": 314,
+                                                            "right": 1044,
+                                                            "bottom": 380
+                                                        }
+                                                    },
+                                                    {
+                                                        "text": "We’ll share this photo with the customer to confirm you picked up the correct order.",
+                                                        "id": "com.doordash.driverapp:id/subtitle",
+                                                        "class": "android.widget.TextView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 36,
+                                                            "top": 416,
+                                                            "right": 1080,
+                                                            "bottom": 518
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/example_image1",
+                                                        "class": "android.widget.ImageView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 36,
+                                                            "top": 554,
+                                                            "right": 522,
+                                                            "bottom": 1326
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/example_image2",
+                                                        "class": "android.widget.ImageView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 558,
+                                                            "top": 554,
+                                                            "right": 1044,
+                                                            "bottom": 1326
+                                                        }
+                                                    },
+                                                    {
+                                                        "text": "Receipt \nInclude the customer and merchant name",
+                                                        "id": "com.doordash.driverapp:id/example_image1_subtitle",
+                                                        "class": "android.widget.TextView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 36,
+                                                            "top": 1362,
+                                                            "right": 522,
+                                                            "bottom": 1519
+                                                        }
+                                                    },
+                                                    {
+                                                        "text": "No receipt \nIf there’s no receipt, just include the order",
+                                                        "id": "com.doordash.driverapp:id/example_image2_subtitle",
+                                                        "class": "android.widget.TextView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 558,
+                                                            "top": 1362,
+                                                            "right": 1044,
+                                                            "bottom": 1519
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "com.doordash.driverapp:id/btn_container",
+                                        "class": "android.view.ViewGroup",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2043,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "desc": "Continue",
+                                                "id": "com.doordash.driverapp:id/btn_primary_action",
+                                                "class": "android.widget.Button",
+                                                "isClickable": true,
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 36,
+                                                    "top": 2079,
+                                                    "right": 1044,
+                                                    "bottom": 2186
+                                                },
+                                                "children": [
+                                                    {
+                                                        "text": "Continue",
+                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                        "class": "android.widget.TextView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 445,
+                                                            "top": 2100,
+                                                            "right": 635,
+                                                            "bottom": 2166
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "desc": "No receipt",
+                                                "id": "com.doordash.driverapp:id/btn_secondary_action",
+                                                "class": "android.widget.Button",
+                                                "isClickable": true,
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 36,
+                                                    "top": 2204,
+                                                    "right": 1044,
+                                                    "bottom": 2311
+                                                },
+                                                "children": [
+                                                    {
+                                                        "text": "No receipt",
+                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                        "class": "android.widget.TextView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 432,
+                                                            "top": 2225,
+                                                            "right": 648,
+                                                            "bottom": 2291
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/statusBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 136
+                }
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2347,
+                    "right": 1080,
+                    "bottom": 2400
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/quality_rate_intro/quality_rate_intro.json
+++ b/app/src/test/resources/snapshots/quality_rate_intro/quality_rate_intro.json
@@ -1,0 +1,321 @@
+{
+    "captureId": "d66e62b8-762d-4944-b6ec-0e512bbde55d",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784406884770,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/fragment",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 278
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 278
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 9,
+                                                                                                    "top": 153,
+                                                                                                    "right": 116,
+                                                                                                    "bottom": 260
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.widget.Button",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 9,
+                                                                                                            "top": 153,
+                                                                                                            "right": 116,
+                                                                                                            "bottom": 260
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/imageView_prism_button_icon",
+                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 180,
+                                                                                                                    "right": 89,
+                                                                                                                    "bottom": 233
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 72,
+                                                                                                    "top": 154,
+                                                                                                    "right": 178,
+                                                                                                    "bottom": 260
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 278,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 278,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2204
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "desc": "",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 232,
+                                                                                                    "top": 278,
+                                                                                                    "right": 849,
+                                                                                                    "bottom": 741
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Introducing Quality Rate",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 777,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 843
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 879,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1578
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "You can now see your Quality Rate in the app. It shows how often your deliveries are completed without customer reported issues, based on your last 100 deliveries.\n\nOnce the new Overall Dasher Rating goes live in a couple of weeks, your Quality Rate will start to impact your Dasher Rewards status. For now, it’s here to help you understand and track your performance.\n\nYou have time to dash and build up your score before it impacts your Rewards status.",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 897,
+                                                                                                            "right": 1044,
+                                                                                                            "bottom": 1560
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 2204,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 2204,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 2311
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "Got it",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 480,
+                                                                                                            "top": 2232,
+                                                                                                            "right": 598,
+                                                                                                            "bottom": 2284
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.widget.Button",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 2204,
+                                                                                                            "right": 1044,
+                                                                                                            "bottom": 2311
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/task_feedback/task_feedback_categories.json
+++ b/app/src/test/resources/snapshots/task_feedback/task_feedback_categories.json
@@ -1,0 +1,640 @@
+{
+    "captureId": "5efb1e15-1d92-4de3-9367-2c6695d47917",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1783901959792,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/layout_bottom_sheet",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/overlay_view",
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 1042,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 1042,
+                                                                    "right": 1080,
+                                                                    "bottom": 1078
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/handle_overlay",
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 1042,
+                                                                            "right": 1080,
+                                                                            "bottom": 1078
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/handle_overlay_image",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1060,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1069
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 1078,
+                                                                    "right": 1080,
+                                                                    "bottom": 2311
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 1078,
+                                                                            "right": 1080,
+                                                                            "bottom": 2311
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1078,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2150
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1078,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2150
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1078,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2150
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1078,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2150
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1078,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 1409
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "How was this task?",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 1114,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1176
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 1248,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1373
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "state": "Selected",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isClickable": true,
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "isChecked": 1,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 397,
+                                                                                                                                    "top": 1248,
+                                                                                                                                    "right": 522,
+                                                                                                                                    "bottom": 1373
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "desc": "Thumbs Down",
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 433,
+                                                                                                                                            "top": 1284,
+                                                                                                                                            "right": 486,
+                                                                                                                                            "bottom": 1337
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "state": "Not selected",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isClickable": true,
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 558,
+                                                                                                                                    "top": 1248,
+                                                                                                                                    "right": 683,
+                                                                                                                                    "bottom": 1373
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "desc": "Thumbs Up",
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 594,
+                                                                                                                                            "top": 1284,
+                                                                                                                                            "right": 647,
+                                                                                                                                            "bottom": 1337
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "Not selected",
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 196,
+                                                                                                                    "top": 1480,
+                                                                                                                    "right": 462,
+                                                                                                                    "bottom": 1587
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "App issues",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 223,
+                                                                                                                            "top": 1508,
+                                                                                                                            "right": 435,
+                                                                                                                            "bottom": 1560
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "Not selected",
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 489,
+                                                                                                                    "top": 1480,
+                                                                                                                    "right": 884,
+                                                                                                                    "bottom": 1587
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Navigation issues",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 516,
+                                                                                                                            "top": 1508,
+                                                                                                                            "right": 857,
+                                                                                                                            "bottom": 1560
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "Not selected",
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 64,
+                                                                                                                    "top": 1614,
+                                                                                                                    "right": 392,
+                                                                                                                    "bottom": 1721
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Pick up issues",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 91,
+                                                                                                                            "top": 1642,
+                                                                                                                            "right": 365,
+                                                                                                                            "bottom": 1694
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "Not selected",
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 419,
+                                                                                                                    "top": 1614,
+                                                                                                                    "right": 763,
+                                                                                                                    "bottom": 1721
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Drop off issues",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 446,
+                                                                                                                            "top": 1642,
+                                                                                                                            "right": 736,
+                                                                                                                            "bottom": 1694
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "Not selected",
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 790,
+                                                                                                                    "top": 1614,
+                                                                                                                    "right": 1017,
+                                                                                                                    "bottom": 1721
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Earnings",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 817,
+                                                                                                                            "top": 1642,
+                                                                                                                            "right": 990,
+                                                                                                                            "bottom": 1694
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "Not selected",
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 286,
+                                                                                                                    "top": 1748,
+                                                                                                                    "right": 593,
+                                                                                                                    "bottom": 1855
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Safety issues",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 313,
+                                                                                                                            "top": 1776,
+                                                                                                                            "right": 566,
+                                                                                                                            "bottom": 1828
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "Not selected",
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 620,
+                                                                                                                    "top": 1748,
+                                                                                                                    "right": 795,
+                                                                                                                    "bottom": 1855
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Other",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 647,
+                                                                                                                            "top": 1776,
+                                                                                                                            "right": 768,
+                                                                                                                            "bottom": 1828
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 72,
+                                                                                                                    "top": 1953,
+                                                                                                                    "right": 1008,
+                                                                                                                    "bottom": 2123
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "",
+                                                                                                                        "class": "android.widget.EditText",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 72,
+                                                                                                                            "top": 1953,
+                                                                                                                            "right": 1008,
+                                                                                                                            "bottom": 2123
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 72,
+                                                                                                                                    "top": 2005,
+                                                                                                                                    "right": 404,
+                                                                                                                                    "bottom": 2123
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "Tell us anything we missed.",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 72,
+                                                                                                                                    "top": 1953,
+                                                                                                                                    "right": 584,
+                                                                                                                                    "bottom": 2005
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2146,
+                                                            "right": 1080,
+                                                            "bottom": 2150
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2150,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 2150,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2150,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 36,
+                                                                                    "top": 2186,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 2311
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Submit",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 453,
+                                                                                            "top": 2218,
+                                                                                            "right": 626,
+                                                                                            "bottom": 2280
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.widget.Button",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 2186,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2311
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2347,
+                    "right": 1080,
+                    "bottom": 2400
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/task_feedback/task_feedback_thumbs.json
+++ b/app/src/test/resources/snapshots/task_feedback/task_feedback_thumbs.json
@@ -1,0 +1,381 @@
+{
+    "captureId": "69e60051-38cc-4da6-a455-b4611ed54e5c",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1783289232427,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 2400,
+            "right": 1080,
+            "bottom": 4800
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2400,
+                    "right": 1080,
+                    "bottom": 4747
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 2536,
+                            "right": 1080,
+                            "bottom": 4747
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 2536,
+                                    "right": 1080,
+                                    "bottom": 4747
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2536,
+                                            "right": 1080,
+                                            "bottom": 4747
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/layout_bottom_sheet",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 2536,
+                                                    "right": 1080,
+                                                    "bottom": 4747
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/overlay_view",
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2536,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4344,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4344,
+                                                                    "right": 1080,
+                                                                    "bottom": 4380
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/handle_overlay",
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 4344,
+                                                                            "right": 1080,
+                                                                            "bottom": 4380
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/handle_overlay_image",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 4362,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4371
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4380,
+                                                                    "right": 1080,
+                                                                    "bottom": 4711
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 4380,
+                                                                            "right": 1080,
+                                                                            "bottom": 4711
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 4380,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4711
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 4380,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 4711
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 4380,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 4711
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 4380,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 4711
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 4380,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 4711
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "How was this task?",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 4416,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 4478
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 4550,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 4675
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "state": "Not selected",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isClickable": true,
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 397,
+                                                                                                                                    "top": 4550,
+                                                                                                                                    "right": 522,
+                                                                                                                                    "bottom": 4675
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "desc": "Thumbs Down",
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 433,
+                                                                                                                                            "top": 4586,
+                                                                                                                                            "right": 486,
+                                                                                                                                            "bottom": 4639
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "state": "Not selected",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isClickable": true,
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 558,
+                                                                                                                                    "top": 4550,
+                                                                                                                                    "right": 683,
+                                                                                                                                    "bottom": 4675
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "desc": "Thumbs Up",
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 594,
+                                                                                                                                            "top": 4586,
+                                                                                                                                            "right": 647,
+                                                                                                                                            "bottom": 4639
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4743,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4747,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4747,
+                                                                    "right": 1080,
+                                                                    "bottom": 4747
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 4747,
+                                                                            "right": 0,
+                                                                            "bottom": 4747
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 4747,
+                    "right": 1080,
+                    "bottom": 4800
+                }
+            }
+        ]
+    }
+}

--- a/matchers/rules/doordash/dash-lifecycle.json5
+++ b/matchers/rules/doordash/dash-lifecycle.json5
@@ -948,6 +948,48 @@
           "throttleMs": 60000
         }
       ]
+    },
+    {
+      "comment": "#796 — the transient 'Navigate to zone' map/loading overlay: a 'Navigate to zone' banner + a '<STATE>: <zone name>' label + the Safety/Help actions, usually over a `loading_view`, shown while the app is routing the dasher toward a zone. RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse — this is a mid-transition loading overlay, not a lifecycle anchor. This is DISTINCT from doordash.screen.dash_along_the_way (111), the idle order-less repositioning card, which additionally carries 'We'll look for orders along the way' / 'Spot saved until' / the navigate_button+bottom_view_info_title id-form — guards these frames legitimately lack. Priority 125 evaluates AFTER dash_along_the_way (111), so any frame dash_along_the_way matches is claimed by it first (all 11 'Navigate to zone' corpus frames live in dash_along_the_way and are claimed there); this rule only catches the leftover loading overlay, changing NO existing corpus classification. The rejects are load-bearing for PRIVACY: a variant of this overlay that also carries a pickup order card (user_name / user_name_label 'Delivery for <customer>' + 'Order includes') carries a customer name in an id-less/marker-less split-node shape and is DELIBERATELY left UNKNOWN (rejected here) rather than recognized without a redact — that pickup-card-over-zone compound is a separate pickup-recognition gap flagged for follow-up, out of scope for this recognize-only batch. The idle-card rejects ('We'll look for orders along the way' / 'Spot saved until') are belt-and-suspenders on top of the priority ordering. Alternative considered and deferred: folding this into dash_along_the_way's idle/online state — plausible (it is a repositioning-to-zone moment) but the loading overlay lacks the order-less-repositioning confirmation this batch treats as recognize-only.",
+      "id": "doordash.screen.dash_navigate_to_zone_loading",
+      "priority": 125,
+      "reject": [
+        {
+          "exists": {
+            "hasIdSuffix": "user_name"
+          }
+        },
+        {
+          "exists": {
+            "hasIdSuffix": "user_name_label"
+          }
+        },
+        {
+          "exists": {
+            "hasIdSuffix": "customer_name_label"
+          }
+        },
+        {
+          "exists": {
+            "hasTextContaining": "Order includes"
+          }
+        },
+        {
+          "exists": {
+            "hasTextContaining": "We'll look for orders along the way"
+          }
+        },
+        {
+          "exists": {
+            "hasTextContaining": "Spot saved until"
+          }
+        }
+      ],
+      "require": {
+        "exists": {
+          "hasTextContaining": "Navigate to zone"
+        }
+      }
     }
   ],
   "clicks": [

--- a/matchers/rules/doordash/dropoff.json5
+++ b/matchers/rules/doordash/dropoff.json5
@@ -1526,6 +1526,47 @@
           }
         ]
       }
+    },
+    {
+      "comment": "#796 — DoorDash 'Drop-off issues' help/resolution MENU (opened from the in-dropoff Help action: a 'Drop-off issues' title over two options, 'Reached drop-off location' and 'Have not reached drop-off location'). RECOGNIZE-ONLY (dev decision 2026-07-17, recognition-gap batch #796): no state.flow, no parse — a transient help overlay opened over an already-established task:dropoff flow, not a lifecycle anchor, so recognizing it only graduates the recurring UNKNOWN capture with no risk of perturbing task lineage. Anchors are corpus-unique (grep of app/src/test/resources/snapshots shows 0 other frames carry 'Drop-off issues' or 'Have not reached drop-off location'), so priority is behaviorally inert. PRIVACY: the menu frames carry no customer PII (option labels only); the sibling resolution screen that DOES carry a name is doordash.screen.dropoff_issue_resolution, which redacts it.",
+      "id": "doordash.screen.dropoff_issue_menu",
+      "priority": 113,
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasTextContaining": "Drop-off issues"
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "Have not reached drop-off location"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "comment": "#796 — the 'Reached drop-off location' RESOLUTION screen (reached from the Drop-off issues menu when the dasher marks they reached the location but could not complete: intro 'If you delivered this order but didn't complete it at the drop-off location, let us know why.' over a reason list — 'Provided address or map pin is wrong', 'Customer changed delivery location', … — plus a 'For <customer> • <store>' attribution line and Continue / Contact Support). RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse. Anchor 'complete it at the drop-off location' is corpus-unique (0 other snapshots) and distinct from the menu rule's 'Have not reached drop-off location', so the two never collide. PRIVACY: the 'For <FirstName L> • <store>' line is a FUSED id-less node carrying a customer first-name + last-initial (no viewId, no 'Deliver to '/'Message from ' marker prefix — the documented split-node residual that both the by-id redact and CustomerTextMarkers miss). The redact below masks the whole tail after the 'For ' prefix; the fused store name is lost from THIS node (acceptable — privacy-first governs the fused case where no control can isolate the store, #598/#803). keepPrefix 'For ' preserves replay recognition; normalize customerName derives the stable mask key.",
+      "id": "doordash.screen.dropoff_issue_resolution",
+      "priority": 114,
+      "redact": [
+        {
+          "comment": "The id-less fused 'For <FirstName L> • <store>' attribution line. hasTextStartsWith 'For ' targets only this node on this screen (no reason label or button starts with 'For '); keepPrefix keeps the literal 'For ' so replay recognition is unchanged, and everything after it (name + store) is masked to a single [redacted:<4hex>] token.",
+          "find": {
+            "hasTextStartsWith": "For "
+          },
+          "keepPrefix": [
+            "For "
+          ],
+          "normalize": "customerName"
+        }
+      ],
+      "require": {
+        "exists": {
+          "hasTextContaining": "complete it at the drop-off location"
+        }
+      }
     }
   ],
   "clicks": [

--- a/matchers/rules/doordash/pickup.json5
+++ b/matchers/rules/doordash/pickup.json5
@@ -979,6 +979,45 @@
           }
         ]
       }
+    },
+    {
+      "comment": "#796 — the pickup RECEIPT-PHOTO instruction screen ('Receipt photo' title over 'We'll share this photo with the customer to confirm you picked up the correct order.', with either the two example cards + Continue/No receipt, or the Retake/Confirm pickup post-capture variant). RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse — the task:pickup flow is already established; this is a confirmation affordance, not a lifecycle anchor. Anchors 'Receipt photo' + 'share this photo with the customer' are corpus-unique (0 other snapshots), so priority is behaviorally inert. PRIVACY: the frames carry no customer PII (the copy names 'the customer' / 'merchant name' generically; no receipt image text is in the tree). NOTE — this is the RECEIPT-photo instruction/confirmation surface, distinct from the dasher's document-image capture surfaces (license scan / signature pad) that are blocked as sensitive; a receipt photo is a merchant artifact, not an identity document.",
+      "id": "doordash.screen.pickup_receipt_photo",
+      "priority": 119,
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasTextContaining": "Receipt photo"
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "share this photo with the customer"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "comment": "#796 (#550-class) — the barcode-scan FAILURE screen of the shopping sub-flow. Two shapes share one body: the full-screen 'Item barcode not recognized' + 'Scan again' variant AND the 'Scan Failed' prism bottom-sheet (prism_sheet_title/prism_sheet_message + 'Enter PLU instead'/'Scan Again'); both carry the body 'You can't buy items with barcodes that are not recognized in our database…'. RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse. Anchored on the body substring 'not recognized in our database' (corpus-unique, 0 other snapshots) so ONE rule covers both title shapes; per the #796 no-merchant-anchor constraint the anchor is generic DoorDash copy, not a store literal. PRIVACY: no customer PII (scan-error copy only).",
+      "id": "doordash.screen.pickup_barcode_scan_failed",
+      "priority": 123,
+      "require": {
+        "exists": {
+          "hasTextContaining": "not recognized in our database"
+        }
+      }
+    },
+    {
+      "comment": "#796 (#550-class) — the 'Confirm barcode scanned' confirmation of the shopping sub-flow (a '<merchant> requires scanning of the barcode' sub-line over Confirm / Scan again). RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse. Anchored on the GENERIC 'Confirm barcode scanned' title (corpus-unique, 0 other snapshots) — the only merchant-literal on this screen is the '<merchant> requires scanning…' sub-line, which is DELIBERATELY NOT used as an anchor per the #796 no-store-anchor constraint (store names are kept in the capture but never matched on). Distinct from doordash.screen.pickup_qr_confirm ('Confirm that the code was scanned' / 'Scan code again'). PRIVACY: no customer PII (store name kept, driver-owned).",
+      "id": "doordash.screen.pickup_barcode_confirm",
+      "priority": 124,
+      "require": {
+        "exists": {
+          "hasTextContaining": "Confirm barcode scanned"
+        }
+      }
     }
   ],
   "clicks": [

--- a/matchers/rules/doordash/ratings-feedback.json5
+++ b/matchers/rules/doordash/ratings-feedback.json5
@@ -211,6 +211,79 @@
           "share your location"
         ]
       }
+    },
+    {
+      "comment": "#796 — the post-task 'How was this task?' feedback prompt (a thumbs-up/thumbs-down header, either bare or expanded into the issue-category picker: 'App issues'/'Navigation issues'/'Pick up issues'/'Drop off issues'/'Earnings'/'Safety issues'/'Other' + a free-text field + Submit). RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse. Anchor 'How was this task?' is corpus-unique (0 other snapshots) and covers both the bare and expanded shapes. PRIVACY: no customer PII (fixed feedback-category labels only; the free-text field is empty in the captured frames).",
+      "id": "doordash.screen.task_feedback",
+      "priority": 59,
+      "require": {
+        "exists": {
+          "hasTextContaining": "How was this task"
+        }
+      }
+    },
+    {
+      "comment": "#796 — the one-time 'Introducing Quality Rate' announcement card ('You can now see your Quality Rate in the app…' + Got it). Part of the Dasher Rewards / Quality Rate program surface. RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse. Anchor 'Introducing Quality Rate' is corpus-unique (0 other snapshots). PRIVACY: no PII (program copy only).",
+      "id": "doordash.screen.quality_rate_intro",
+      "priority": 115,
+      "require": {
+        "exists": {
+          "hasTextContaining": "Introducing Quality Rate"
+        }
+      }
+    },
+    {
+      "comment": "#796 — a performance-metric DETAIL screen (Completion rate / On-time rate / Quality rate): a metric header + score, a 'Last 100 orders' breakdown, a 'View all orders' button, and an 'About <metric> rate' explainer. RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse — the app already ships doordash.screen.ratings (the combined ratings hub); these are the single-metric drill-downs, which that rule's four-way 'ratings'+'acceptance rate'+'completion rate'+'overall' conjunct legitimately does NOT match. Anchored on 'Last 100 orders' + 'View all orders' together (both corpus-unique, 0 other snapshots); the sibling list modal shares 'Last 100 orders' but has NO 'View all orders' button, so the two never collide. PRIVACY: no customer PII — merchant/store names + dates only, both driver-owned and kept.",
+      "id": "doordash.screen.performance_rate_detail",
+      "priority": 116,
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasTextContaining": "Last 100 orders"
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "View all orders"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "comment": "#796 — the 'Last 100 orders' LIST modal reached from a metric detail's 'View all orders' (a tab row All / Completed / Unassigned / Excluded over a store+date order list, with a Close affordance). RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse. Anchored on 'Last 100 orders' + the exact-text tabs 'All' and 'Excluded' (both corpus-unique). The metric-detail screen also renders 'Last 100 orders' but has no exact 'All'/'Excluded' tab nodes (its 'excluded' appears only fused as '0 orders excluded'), so the exact-text tab conjunct keeps the two apart; hasText (exact) not hasTextContaining is load-bearing here. PRIVACY: no customer PII — merchant/store names + dates only, driver-owned and kept.",
+      "id": "doordash.screen.performance_orders_list",
+      "priority": 117,
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasTextContaining": "Last 100 orders"
+            }
+          },
+          {
+            "exists": {
+              "hasText": "All"
+            }
+          },
+          {
+            "exists": {
+              "hasText": "Excluded"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "comment": "#796 — the 'Dasher Rewards' program screens ('What are Dasher Rewards?' explainer AND the tier/rewards board — 'Available rewards' / 'How to unlock Silver level' + the reward-row recycler). RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse. Anchored on the viewId `reward_info_epoxy_recyclerview` — corpus-unique (0 other snapshots) and present on BOTH sub-screens, so one rule covers them. This id is deliberately used INSTEAD of the 'Dasher Rewards' text (which also appears in the existing ratings/ hub snapshots, 9 corpus frames) and INSTEAD of `reward_name_text_view` (which also appears in ratings, 4 frames) — the recycler-container id is the clean generic anchor that isolates the standalone program screens. PRIVACY: no customer PII (program copy + the dasher's own aggregate rating figures, which are the dasher's own data).",
+      "id": "doordash.screen.dasher_rewards",
+      "priority": 118,
+      "require": {
+        "exists": {
+          "hasIdSuffix": "reward_info_epoxy_recyclerview"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Closes #796. Recognize-only rules for recurring DoorDash UNKNOWN window families from the 2026-07-17..18 pulls (`~/dashbuddy/logs/2026/07/{18,19}/captures/`). None affect state correctness — all are `recognize-only` (no `state.flow`, no `parse`), so they only graduate recurring UNKNOWN captures out of the noise floor.

**Hard constraint honored (dev-stated): no merchant/store-specific anchors.** Every rule anchors on generic DoorDash surface chrome (copy or viewId). Store names are kept in the captures (driver-owned) but never used as match keys. The `<merchant> requires scanning…` / issue-family "CVS…" labels are provenance only.

Anchor corpus-uniqueness was verified by grepping the entire committed corpus (`app/src/test/resources/snapshots`) for each anchor before use (#738 lesson).

### Families built (11 rules, 16 fixtures, 11 new intent folders)

| Family | Rule id (priority) | Anchor(s) | Corpus-unique? | Redact |
|---|---|---|---|---|
| 1a Drop-off issues menu | `doordash.screen.dropoff_issue_menu` (113) | `Drop-off issues` + `Have not reached drop-off location` | yes (0) | — |
| 1b Drop-off resolution | `doordash.screen.dropoff_issue_resolution` (114) | `complete it at the drop-off location` | yes (0) | **yes** — fused `For <name> • <store>` |
| 2 Task feedback | `doordash.screen.task_feedback` (59) | `How was this task` (covers bare + expanded) | yes (0) | — |
| 3 Receipt photo | `doordash.screen.pickup_receipt_photo` (119) | `Receipt photo` + `share this photo with the customer` | yes (0) | — |
| 4a Barcode scan failed | `doordash.screen.pickup_barcode_scan_failed` (123) | `not recognized in our database` (covers `Item barcode not recognized` + `Scan Failed` sheet) | yes (0) | — |
| 4b Confirm barcode | `doordash.screen.pickup_barcode_confirm` (124) | `Confirm barcode scanned` (generic; merchant sub-line NOT anchored) | yes (0) | — |
| 5 Zone nav loading | `doordash.screen.dash_navigate_to_zone_loading` (125) | `Navigate to zone` + guards | shared w/ `dash_along_the_way` (see below) | — |
| 6a Quality Rate intro | `doordash.screen.quality_rate_intro` (115) | `Introducing Quality Rate` | yes (0) | — |
| 6b Metric detail | `doordash.screen.performance_rate_detail` (116) | `Last 100 orders` + `View all orders` (Completion/On-time/Quality) | yes (0) | — |
| 6c Last-100 list | `doordash.screen.performance_orders_list` (117) | `Last 100 orders` + exact-text tabs `All` + `Excluded` | yes (0) | — |
| 6d Dasher Rewards | `doordash.screen.dasher_rewards` (118) | id `reward_info_epoxy_recyclerview` (both program sub-screens) | yes (0) | — |

Notes on tighter anchors chosen to avoid collisions found in the corpus grep:
- **Dasher Rewards**: `Dasher Rewards` text (9 corpus hits in `ratings/`) and `reward_name_text_view` id (4 hits in `ratings/`) were both rejected as anchors; the container id `reward_info_epoxy_recyclerview` (0 hits) is the clean generic anchor present on both the "What are Dasher Rewards?" explainer and the tier/rewards board.
- **Metric detail vs Last-100 list**: both render `Last 100 orders`; the detail adds a `View all orders` button (absent from the list modal) and the list adds exact-text tabs `All`/`Excluded` (the detail's only "excluded" is the fused `0 orders excluded`, so `hasText` exact — not `hasTextContaining` — keeps them apart).

### Family 5 (zone) decision — variant vs guard-rejected near-miss

The `Navigate to zone` UNKNOWN frames split into two shapes:
1. **Pure loading overlay** (`Navigate to zone` + `<STATE>: <zone>` + Safety/Help + `loading_view`, no order card, no PII) — the recurring capture. **Built** as a recognize-only rule, priority **125 (after `dash_along_the_way` 111)** so any frame the idle repositioning card matches is claimed by it first; all 11 corpus `Navigate to zone` frames live in `dash_along_the_way` and are claimed there, so **this rule changes zero existing corpus classifications**. It is distinguished from the idle card, which additionally carries `We'll look for orders along the way` / `Spot saved until` / the `navigate_button`+`bottom_view_info_title` id-form — guards the loading overlay legitimately lacks. Those texts are also added as belt-and-suspenders `reject`s.
2. **Pickup-card-over-zone compound** (`Navigate to zone` banner + a live pickup card: `user_name`/`Delivery for <customer>` + `Order includes` + store address) — carries a customer name in an id-less/marker-less split-node shape. **Deliberately left UNKNOWN** (rejected by the new rule's `user_name`/`user_name_label`/`Order includes` guards) rather than recognized without a redact. This is really a *pickup*-recognition gap ("Delivery for" pickup variant during zone nav) plus a `#806`-residual (a customer name on an UNKNOWN frame with no `Deliver to `/`Pickup for ` marker prefix), out of scope for a recognize-only batch. **Flagged for the dev as a follow-up.**

Alternative considered for shape 1: folding it into `dash_along_the_way`'s `idle`/`online` state (plausible — it is a repositioning-to-zone moment). Deferred to keep this batch recognize-only per the issue.

### Families skipped / not built

- **Account-verification "Please stop and park"** — **skipped: no frames in hand.** Grep of all three pull dirs (`stop and park`) returned 0 frames; not built.
- **Transient partial-offer frames** (bare UUID + "$X Guaranteed") — **not built** per the issue's LOW/no-action note (no rule added).

### PII sweep attestation

Manual sweep run on **every** fixture (both raw and post-`SnapshotRedactor` sorted forms) walking `text`+`desc` generic keys against the desk-playbook recipe (two-cap-word names, `For [A-Z][a-z]+ [A-Z]\.`, `Pickup for `/`Deliver to `/`Delivery for `/`For ` fused nodes, `pin \d{3,}`+gate codes, street addresses, `Customer Notes:`).

- **One real customer-PII hit**: `dropoff_issue_resolution.json` carried a fused `For <FirstName L> • <store>` line. The customer name was **hand-anonymized in the fixture** to a consistent fake (`Jordan P`; the store `Pei Wei` is merchant data, kept) and is **masked at runtime** by the rule's `keepPrefix "For "` redact → `[redacted:<4hex>]` (#598/#803 architecture; same fused-node pattern as `dropoff_multi_order_confirm`). Fake values are described here, never the originals.
- All other 15 fixtures: **clean** — only store names (H-E-B, CVS, Pei Wei, Parry's Pizzeria, …) + dates + program/scan copy, all driver-owned/kept. The receipt-photo family is the *receipt* instruction surface (a merchant artifact), distinct from the blocked license-scan/signature document-image surfaces.
- `InboxProcessorTest`'s `SnapshotSecurityScanner` toxicity gate passed on all 16 (no sensitive/banking markers).

### Golden delta

Additions-only: `approved-parse-output.json` **+96 / −0**. All 16 added entries are the new intents; every one is `shape: null`, `fields: {}` (recognize-only). Regenerated with `-DupdateParseGolden=true` and diff-reviewed.

### Test plan

- `export JAVA_HOME=/usr/lib/jvm/java-25`
- `./gradlew :app:testDebugUnitTest --tests "*InboxProcessorTest*"` — canonicalized cleanly (JSON5 valid, no dup rule id, compiler-accepted), sorted all 16 into the 11 intent folders, INBOX empty.
- `./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` — 758/759 green pre-regen (only `ParseOutputGoldenTest` failed on the new corpus, expected); **green after golden regen**.
- `./gradlew :app:testDebugUnitTest` — **BUILD SUCCESSFUL** (full app unit suite).

### Design-goal review

- **6 Security & privacy first**: recognition-only change on the untrusted accessibility-tree boundary. Trusted: nothing new actuates or parses. Gated: n/a. Scrubbed: the one customer-name-bearing surface (`dropoff_issue_resolution`) declares a fail-closed `redact` (edge PII-hash); the pickup-card-over-zone PII compound is left UNKNOWN behind the existing `#806`/`NoOpCaptureBus` backstops rather than recognized without a redact. No rule stores raw customer PII; no sensitive/banking block is downgraded.
- **8 Platform-agnostic core**: rule JSON only — no `:core:*`/`:domain` edits, no new state vocabulary, no platform literal in logic. Anchors are DoorDash *data* under `matchers/rules/doordash/`; the no-merchant-anchor constraint is exactly the anti-coupling discipline (a rule keyed on "CVS" would be the drift this guards against). Adding these needed zero engine edits — the acceptance test.
- **5 SSOT**: the resolution redact reuses the established `keepPrefix`/`normalize: customerName` mechanism and the fused-`For `-name shape already fielded by `dropoff_multi_order_confirm`; no new duplicated matcher logic.
- **3 Single responsibility**: rules added to the correct existing surface sub-files (`dropoff`/`pickup`/`ratings-feedback`/`dash-lifecycle`); no file materially bloated.

### Adversarial review

Not yet run — opening for the fable adversarial pass (`/code-review` + `/security-review` on the untrusted-input boundary) per workflow. **Do not merge** until that is clean.

### Field-test follow-up

Add to the `Next field test` checklist on merge: confirm the 11 families now recognize on-dash (drop-off issue menu/resolution, task feedback, receipt photo, barcode confirm/scan-failed, navigate-to-zone loading, Quality Rate/Dasher Rewards screens) and that the pickup-card-over-zone compound is the only remaining `Navigate to zone` UNKNOWN.
