### PR TITLE
chore(build): #841 zero compiler warnings + allWarningsAsErrors gate

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
@@ -28,7 +28,7 @@ internal const val EMPTY_VALUE = "—"
  * `AnalyticsScreen.tabOptions()`. The [AppSegmented][cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented]
  * selection there is keyed off the enum itself, never the resolved label string.
  */
-enum class AnalyticsTab(@StringRes val labelRes: Int) {
+enum class AnalyticsTab(@param:StringRes val labelRes: Int) {
     Money(R.string.analytics_tab_money),
     Patterns(R.string.analytics_tab_patterns),
     Decisions(R.string.analytics_tab_decisions),

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardUiState.kt
@@ -31,7 +31,7 @@ data class DashboardUiState(
      * carries resolved copy. Not i18n: the app still ships English-only; this is a string-
      * ownership move (SSOT), not locale selection.
      */
-    @StringRes val statusText: Int = R.string.dashboard_status_offline,
+    @param:StringRes val statusText: Int = R.string.dashboard_status_offline,
     /**
      * True while a dash session is active (focused region present, mode != Offline),
      * registry-resolved (never a `== DoorDash` literal). Drives the bubble pointer only.

--- a/app/src/main/java/cloud/trotter/dashbuddy/util/PermissionUtils.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/util/PermissionUtils.kt
@@ -68,6 +68,10 @@ object PermissionUtils {
     }
 
     // Bubble Permissions
+    // DEPRECATION suppressed, not cleared: areBubblesAllowed() is the documented minSdk-30
+    // fallback (#122/#793) — bubblePreference exists only on API 31+, so the deprecated call
+    // IS the pre-31 path and must stay until minSdk >= 31.
+    @Suppress("DEPRECATION")
     fun hasFullBubblePreference(context: Context): Boolean {
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/OdometerPredicateEquivalenceTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/OdometerPredicateEquivalenceTest.kt
@@ -91,7 +91,7 @@ class OdometerPredicateEquivalenceTest {
         if (prevLive && !nextLive) add(Gps.OFF)  // StopOdometer (session end)
         if (!nextLive) return@buildList
         val pt = prev?.activeTask
-        val nt = next?.activeTask
+        val nt = next.activeTask
         // Emission ORDER is faithful to master's diffTask (adversarial-review MED): the task-change
         // Resumes fire BEFORE the arrival Pause, so a mint+arrive-in-one-frame step (teardown_ghost's
         // offer → pickup_shopping) folds to OFF — Resume then Pause — exactly as real master did.
@@ -99,7 +99,7 @@ class OdometerPredicateEquivalenceTest {
         if (nt != null && nt.phase == TaskPhase.PICKUP && pt?.taskId != nt.taskId) add(Gps.ON)    // Resume (new pickup nav)
         if (nt?.phase == TaskPhase.DROPOFF && nt.taskId != pt?.taskId) add(Gps.ON)                // Resume (new dropoff leg)
         if (nt?.arrivedAt != null && pt?.arrivedAt == null) add(Gps.OFF)                          // PauseOdometer (arrival)
-        if (next?.lastActedFlow == Flow.PostTask && prev?.lastActedFlow != Flow.PostTask) add(Gps.ON) // Resume (PostTask entry)
+        if (next.lastActedFlow == Flow.PostTask && prev?.lastActedFlow != Flow.PostTask) add(Gps.ON) // Resume (PostTask entry)
     }
 
     /** The GPS ground truth per step, straight from the arbiter (property 2's SSOT). */

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,3 +8,29 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.jvm) apply false
     alias(libs.plugins.android.library) apply false
 }
+
+// Warnings-as-errors gate (#841): every Kotlin compilation in every module fails on ANY
+// warning — hand-written or KSP-generated. A deliberate exception (e.g. the minSdk-30
+// areBubblesAllowed fallback) gets a site-local @Suppress with a justifying comment, never
+// a global opt-out. (The matchers included build has no Kotlin compilation tasks — its
+// canonicalizer is build-script logic on the `base` plugin — so nothing to gate there.)
+subprojects {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask<*>>().configureEach {
+        compilerOptions.allWarningsAsErrors.set(true)
+    }
+
+    // JDK-25 test-worker noise (#841): third-party jars (robolectric, conscrypt, the
+    // datastore protobuf) trip the native-access / sun.misc.Unsafe JVM notices on modern
+    // JDKs. Not our code and not compiler-gateable — silenced at the test JVM. Version-
+    // gated: CI runs JDK 21, where --sun-misc-unsafe-memory-access doesn't exist (23+)
+    // and the notices don't fire anyway.
+    tasks.withType<Test>().configureEach {
+        if (JavaVersion.current() >= JavaVersion.VERSION_24) {
+            jvmArgs("--enable-native-access=ALL-UNNAMED", "--sun-misc-unsafe-memory-access=allow")
+        }
+        // Robolectric appends the bootstrap classpath, which trips a harmless CDS
+        // "Sharing is only supported for boot loader classes" notice — turn CDS off
+        // for test workers rather than ship a permanent noise line.
+        jvmArgs("-Xshare:off")
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
@@ -69,8 +69,8 @@ class CaptureRedactionTest {
         ),
     )
 
-    private fun sourceFor(ruleId: String, redact: CompiledRedact) = object : ScreenRedactionSource {
-        override fun redactFor(id: String): CompiledRedact? = redact.takeIf { id == ruleId }
+    private fun sourceFor(forRuleId: String, redact: CompiledRedact) = object : ScreenRedactionSource {
+        override fun redactFor(ruleId: String): CompiledRedact? = redact.takeIf { ruleId == forRuleId }
     }
 
     private fun writer(source: ScreenRedactionSource) = CaptureWriter(captureBus, stats, source)

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/NotificationRedactionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/NotificationRedactionTest.kt
@@ -40,9 +40,9 @@ class NotificationRedactionTest {
             Json.parseToJsonElement(json).jsonArray, RuleContext.NOTIFICATION,
         ).single().notifRedact
 
-    private fun sourceFor(ruleId: String, redact: CompiledNotifRedact) = object : ScreenRedactionSource {
-        override fun redactFor(id: String): CompiledRedact? = null
-        override fun notifRedactFor(id: String): CompiledNotifRedact? = redact.takeIf { id == ruleId }
+    private fun sourceFor(forRuleId: String, redact: CompiledNotifRedact) = object : ScreenRedactionSource {
+        override fun redactFor(ruleId: String): CompiledRedact? = null
+        override fun notifRedactFor(ruleId: String): CompiledNotifRedact? = redact.takeIf { ruleId == forRuleId }
     }
 
     private fun writer(source: ScreenRedactionSource) = CaptureWriter(captureBus, stats, source)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/DeliveryFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/DeliveryFolds.kt
@@ -104,8 +104,8 @@ internal object DeliveryFolds {
         val receipt = p.parsedPay
         val soleDrop = !suspectFullReceipt && receipt != null &&
             (p.dropRealizedPay == null || kotlin.math.abs(p.dropRealizedPay - receipt.total) < 0.005)
-        val tip = if (soleDrop) receipt?.totalTip else null
-        val basePay = if (soleDrop) receipt?.totalBasePay else null
+        val tip = if (soleDrop) receipt.totalTip else null
+        val basePay = if (soleDrop) receipt.totalBasePay else null
 
         // Partition deltas. Anchor = the previous completion (or DASH_START) in the same session.
         // Floor the per-row delta at 0 like the session-level SUM (MAX(…,0)): a mid-session odometer

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -370,7 +370,6 @@ object RecordFolds {
         val p = e.payload as? SessionStartPayload
             ?: return FoldOutcome(context = context, skip = "DASH_START: missing/malformed payload")
         val sid = e.sessionId ?: p.sessionId
-            ?: return FoldOutcome(context = context, skip = "DASH_START: no sessionId")
         val platform = Platform.fromName(p.platform) ?: Platform.Unknown
         val odo = event.metadata?.odometer
         // A RECOVERY (or any duplicate) re-start of a session that was ALREADY STARTED WITH A REAL

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -335,7 +335,7 @@ class RecordFoldsTest {
         assertEquals(0.10, d.frozenFuelPerMile!!, 1e-9)
         assertEquals(0.15, d.frozenNonFuelPerMile!!, 1e-9)
         // The invariant the 4-step waterfall relies on: fuel + non-fuel ≈ frozenCostPerMile.
-        assertEquals(d.frozenCostPerMile!!, d.frozenFuelPerMile!! + d.frozenNonFuelPerMile!!, 1e-9)
+        assertEquals(d.frozenCostPerMile!!, d.frozenFuelPerMile + d.frozenNonFuelPerMile, 1e-9)
     }
 
     @Test
@@ -630,7 +630,7 @@ class RecordFoldsTest {
             currentCostPerMile = null,
         )
         assertEquals(Platform.Unknown.wire, out.delivery!!.platform)
-        assertNull(out.delivery!!.sessionId)
+        assertNull(out.delivery.sessionId)
         assertNull("no session context is created for a session-less event", out.context)
     }
 
@@ -663,7 +663,7 @@ class RecordFoldsTest {
             currentCostPerMile = null,
         )
         assertEquals("DASH_STOP's platform stamp refines an _unknown session", Platform.DoorDash, stopOut.context!!.platform)
-        assertEquals("doordash", stopOut.context!!.platform.wire)
+        assertEquals("doordash", stopOut.context.platform.wire)
     }
 
     @Test
@@ -887,7 +887,7 @@ class RecordFoldsTest {
             currentCostPerMile = 0.25,
         )
         assertEquals(PayBasis.NONE, out.delivery!!.payBasis)
-        assertNull(out.delivery!!.realizedPay)
+        assertNull(out.delivery.realizedPay)
     }
 
     // ── User corrections (#650) ─────────────────────────────────────────
@@ -1226,7 +1226,7 @@ class RecordFoldsTest {
         assertEquals(2.4, d.milesToDropoff!!, 1e-9)
         assertEquals(2.9, d.realizedMiles!!, 1e-9)
         // Invariant: realizedMiles == milesToStore + milesToDropoff when milesToDropoff != null.
-        assertEquals(d.milesToStore!! + d.milesToDropoff!!, d.realizedMiles!!, 1e-9)
+        assertEquals(d.milesToStore + d.milesToDropoff, d.realizedMiles, 1e-9)
         // Net computed against the leg-sum miles, not the legacy delta.
         assertEquals(10.0 - 2.9 * 0.25, d.netProfit!!, 1e-9)
     }
@@ -1266,7 +1266,7 @@ class RecordFoldsTest {
         assertEquals(3.39, dB.milesToDropoff!!, 1e-6)
         assertEquals(0.16 + 3.39, dB.realizedMiles!!, 1e-6)
         // The collapsed 6.75/0.0 shape is gone; Σ ≈ the old single lump.
-        assertEquals(6.75, dA.realizedMiles!! + dB.realizedMiles!!, 1e-6)
+        assertEquals(6.75, dA.realizedMiles + dB.realizedMiles, 1e-6)
     }
 
     @Test
@@ -1470,8 +1470,8 @@ class RecordFoldsTest {
         val span = ctx!!.lastOdometer!! - ctx.startOdometer!! // 103.9 − 100.0 = 3.9
         assertEquals(3.9, span, 1e-9)
         assertTrue(
-            "Σ per-drop miles (${dA.realizedMiles!! + dB.realizedMiles!!}) must not exceed span ($span)",
-            dA.realizedMiles!! + dB.realizedMiles!! <= span + 1e-9,
+            "Σ per-drop miles (${dA.realizedMiles + dB.realizedMiles}) must not exceed span ($span)",
+            dA.realizedMiles + dB.realizedMiles <= span + 1e-9,
         )
     }
 
@@ -1563,8 +1563,8 @@ class RecordFoldsTest {
         val span = ctx!!.lastOdometer!! - ctx.startOdometer!! // 104.0 − 100.0 = 4.0
         assertEquals(4.0, span, 1e-9)
         assertTrue(
-            "Σ per-drop miles (${d1.realizedMiles!! + d2.realizedMiles!!}) must not exceed span ($span)",
-            d1.realizedMiles!! + d2.realizedMiles!! <= span + 1e-9,
+            "Σ per-drop miles (${d1.realizedMiles + d2.realizedMiles}) must not exceed span ($span)",
+            d1.realizedMiles + d2.realizedMiles <= span + 1e-9,
         )
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8 --enable-native-access=ALL-UNNAMED
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
Closes #841 (dev request: clear build warnings; add a build-process check).

## What was cleared (29 → 0 compiler warnings)

- **22 × unnecessary `!!` / `?.`** (RecordFoldsTest ×18, OdometerPredicateEquivalenceTest ×2, DeliveryFolds ×2) — removed at the compiler-reported exact positions only (never blanket), so a *necessary* assertion can't have been touched.
- **1 × dead elvis arm** (`RecordFolds.foldDashStart`): `SessionStartPayload.sessionId` is non-null by type, so the `?: return … "no sessionId"` arm was provably unreachable — removed, zero behavior change.
- **3 × override-parameter-name mismatch** vs `ScreenRedactionSource.ruleId` (two redaction tests): override params renamed to `ruleId`; the OUTER factory params renamed to `forRuleId` so the bodies (`ruleId == forRuleId`) don't become self-comparisons — callers are positional, unaffected.
- **2 × Kotlin 2.x annotation-target-default warnings**: `@StringRes` → `@param:StringRes` (explicit current semantics, no bytecode change).

## What was deliberately NOT cleared (the report-back)

- **`areBubblesAllowed()` deprecation (PermissionUtils)** — this call IS the documented minSdk-30 fallback (#122/#793): `bubblePreference` exists only on API 31+. Removing it would break API 30. Now `@Suppress("DEPRECATION")` with a justifying comment; revisit only when minSdk ≥ 31.
- **The Gradle *launcher* JVM's native-access notice** — printed by Gradle's own native-platform jar before the build script runs; no repo file can configure the launcher JVM. Workstation fix documented in CLAUDE.local.md (`GRADLE_OPTS=--enable-native-access=ALL-UNNAMED`); CI (JDK 21) doesn't emit it.

## The build-process check

- **`allWarningsAsErrors` on every Kotlin compilation** (root `subprojects` convention) — any future warning, including in KSP-generated code, fails the build loud. Deliberate exceptions must be site-local `@Suppress` with a justifying comment, never a global opt-out. Verified: clean `assembleDebug` + full unit suites compile green under the gate.
- **JDK-25 test-worker noise silenced** via version-gated `Test` jvmArgs (`--enable-native-access`, `--sun-misc-unsafe-memory-access=allow` — third-party robolectric/conscrypt/datastore-protobuf notices) + `-Xshare:off` (robolectric bootstrap-classpath CDS notice). Version gate keeps CI's JDK 21 untouched (the unsafe flag doesn't exist there).
- Daemon JVM native-access flag added to `org.gradle.jvmargs`.

## Verification

- Clean build (`clean` → `assembleDebug` + test-compile): **0** `w:` lines (was 29), gate active.
- `testDebugUnitTest :domain:test`: BUILD SUCCESSFUL; forced `--rerun` of AllMatchersSuite: zero warning lines of any kind.

### Design-goal review

- **Kotlin best practices (4):** the fixes remove dead null-handling the compiler proves unnecessary; the one kept deprecation is suppressed at the narrowest scope with the reason inline.
- **SSOT (5):** the warnings policy now has one owner (the root convention) instead of per-module drift; the minSdk-30 exception is documented at its single call site.
- **Security & privacy (6):** no recognition/capture/network/effect changes. `RecordFolds`/`DeliveryFolds` edits are compiler-proven no-ops (dead arm + redundant safe-calls on non-null receivers); the analytics fold behavior is unchanged (full suite green, incl. the fold characterization tests).
- **Platform-agnostic core (8):** no platform literals; build-config only.
