### PR TITLE
security(rules): #416 signature verification before compiling any remote ruleset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,7 +464,11 @@ Every new feature or refactor holds to these — they are forefront design input
      accessibility tree comes from another app; once the matchers split (#192) lands, rule JSON
      comes from a CDN. Both get bounded ingestion (size/depth/node/regex caps), fail-closed
      validation, and — for any remote rule source — **signature/integrity verification before
-     compile**, which does not exist yet and is a hard prerequisite for that path.
+     compile** (#416, in-tree): `RulesetVerifier` (ECDSA P-256/SHA-256, no new crypto dep) gates
+     `JsonRuleInterpreter.load`, which now accepts only a `VerifiedRulesetBytes` mintable solely by
+     a passing signature check — compile-from-remote-bytes is structurally unreachable without
+     verification against the *configured source's* pinned key; bundled assets are exempt (APK
+     signature covers them). Signing tooling: `matchers/tools/`.
    - **The dasher's sensitive screens are blocked, never parsed or stored** (the dasher's banking /
      DasherDirect / payment / own identity docs) — plus **document-image capture surfaces** (the
      license-scan camera, the signature pad), regardless of whose, since they're an image of an ID /

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
@@ -275,13 +275,23 @@ class JsonRuleInterpreter @Inject constructor(
     }
 
     /**
-     * Load a single ruleset and replace all current rules.
-     * Kept for backward compatibility with CDN hot-reload path.
+     * Load a single **signature-verified** ruleset and replace all current rules
+     * (the CDN hot-reload / side-load path, #192).
      *
-     * [source] is NOT asset-prefixed here, so nothing a remote caller loads
-     * is ever auto-granted (#417) — its capabilities reconcile as pending.
+     * Fail-closed BY CONSTRUCTION (#416): this path only accepts a
+     * [VerifiedRulesetBytes], which [RulesetVerifier] mints ONLY after a detached
+     * signature over the exact bundle bytes verifies against the configured source's
+     * pinned public key. There is no `load(String)` overload — an unverified remote
+     * bundle cannot reach compile. (Bundled asset rulesets skip this: they load via
+     * [loadDefaults], already covered by the APK signature.)
+     *
+     * The verified [VerifiedRulesetBytes.source] is NOT asset-prefixed, so nothing a
+     * remote caller loads is ever auto-granted (#417) — its capabilities reconcile
+     * as pending.
      */
-    suspend fun load(jsonString: String, source: String = "unknown") {
+    suspend fun load(verified: VerifiedRulesetBytes) {
+        val jsonString = verified.json
+        val source = verified.source
         val result = loadSingle(jsonString, source) ?: return
 
         // #419 (2a): a REPLACEMENT bundle must not silently drop sensitive-screen

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
@@ -189,9 +189,14 @@ class JsonRuleInterpreter @Inject constructor(
      * Parse and compile a single rules JSON string.
      * Used by [loadDefaults] and will be used by the CDN fetch path in Phase A3+.
      *
+     * `internal` (#416 review F4): compiling raw JSON is a module-internal step — the
+     * only public entry points are [loadDefaults] (bundled assets, APK-signature covered)
+     * and [load] (which takes a signature-verified [VerifiedRulesetBytes]). Reachable from
+     * `:core:pipeline` tests (same module).
+     *
      * @return compiled rule lists, or null if validation/compilation fails.
      */
-    fun loadSingle(jsonString: String, source: String = "unknown"): CompiledRuleBundle? {
+    internal fun loadSingle(jsonString: String, source: String = "unknown"): CompiledRuleBundle? {
         if (jsonString.length > MAX_FILE_BYTES) {
             Timber.e("JsonRuleInterpreter: $source exceeds size limit (${jsonString.length} bytes)")
             return null

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RulesetVerifier.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RulesetVerifier.kt
@@ -1,0 +1,203 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import timber.log.Timber
+import java.security.KeyFactory
+import java.security.PublicKey
+import java.security.Signature
+import java.security.spec.X509EncodedKeySpec
+import java.util.Base64
+
+/**
+ * Signature / integrity verification for a **remote / side-loaded** ruleset bundle
+ * (#416 — the hard prerequisite for the matchers CDN split, #192).
+ *
+ * ## Threat model
+ * Once recognition rules arrive from a forkable, network-delivered source, every
+ * rule bundle is **untrusted input**. A tampered / MITM'd / malicious-fork bundle
+ * that reached [JsonRuleInterpreter.load] unverified could silently drop the
+ * dasher's sensitive-screen rules (banking → captured) or redefine recognition
+ * wholesale. This verifier is the gate: a bundle compiles only after a detached
+ * signature over its **exact canonical bytes** verifies against the **configured
+ * source's** pinned public key.
+ *
+ * ## Scheme (no new crypto dependency)
+ * - Detached signature over the exact canonical ruleset JSON bytes.
+ * - **ECDSA P-256 with SHA-256** (`SHA256withECDSA`) — available via `java.security`
+ *   on every supported API level (min SDK 30), so no BouncyCastle / extra dependency.
+ * - Signature transported **base64** (standard alphabet); the underlying signature is
+ *   ASN.1 DER `SEQUENCE { r, s }` (what `openssl dgst -sha256 -sign` and Java's
+ *   `Signature` both produce/expect — see `matchers/tools/sign-ruleset.sh`).
+ * - Public key pinned as **base64 DER X.509 SubjectPublicKeyInfo** in configuration.
+ *
+ * ## Trust model — forkability without skipping verification
+ * Verification is ALWAYS against the *configured source's* key. Each non-bundled
+ * source id maps to exactly one pinned key ([keysBySource]); switching sources
+ * (the forkability story) switches keys — it never disables the check. A source
+ * with no configured key can never mint a [VerifiedRulesetBytes] (fail closed).
+ *
+ * **Bundled ASSET rulesets are exempt** and load unchanged via
+ * [JsonRuleInterpreter.loadDefaults]: the APK signature already covers `assets/`,
+ * so re-signing bytes the OS integrity-checks at install would be redundant. Every
+ * OTHER path — the [JsonRuleInterpreter.load] CDN hot-reload API and any file-based
+ * side-load — MUST pass this verifier, and the type system enforces it: [load] only
+ * accepts a [VerifiedRulesetBytes], which only [VerifiedRulesetBytes.verify] can mint.
+ *
+ * ## Fail direction
+ * Every branch fails CLOSED — an oversized bundle, an unconfigured source, an
+ * undecodable signature, a verification mismatch, or any crypto exception returns
+ * `null` (reject). The caller keeps the last-good ruleset. Logs at ERROR under the
+ * stable `Rules` tag (Principle 7); the untrusted bundle is treated as hostile — the
+ * log carries only sizes / the source id, **never** any bundle content.
+ *
+ * @param keysBySource source id → its pinned public key. Built by [fromConfig] from
+ *   base64-DER config; a source absent here has no key and is always rejected.
+ */
+class RulesetVerifier(private val keysBySource: Map<String, PublicKey>) {
+
+    /**
+     * Verify [signatureBase64] (a detached ECDSA-P256-SHA256 signature, base64) over
+     * [bundleBytes] (the exact canonical JSON bytes) against the pinned key configured
+     * for [source]. Returns a [VerifiedRulesetBytes] the loader will accept, or `null`
+     * on ANY failure (fail closed).
+     */
+    fun verify(source: String, bundleBytes: ByteArray, signatureBase64: String): VerifiedRulesetBytes? {
+        val key = keysBySource[source]
+        if (key == null) {
+            // No pinned key configured for this source => can never be trusted.
+            Timber.tag(RulesetCrypto.TAG).e(
+                "rejected remote bundle: no pinned public key configured for source '%s' (fail closed)",
+                source,
+            )
+            return null
+        }
+        // The single construction path for a VerifiedRulesetBytes runs the full
+        // bounded-ingestion + crypto check (see VerifiedRulesetBytes.verify).
+        return VerifiedRulesetBytes.verify(key, source, bundleBytes, signatureBase64)
+    }
+
+    companion object {
+        /**
+         * Build a verifier from configured [keys]. Each key's base64-DER X.509
+         * SubjectPublicKeyInfo is decoded once here; a malformed/undecodable key is
+         * DROPPED (logged) so its source has no usable key and always fails closed —
+         * a bad config entry can never weaken verification for another source.
+         */
+        fun fromConfig(keys: List<RuleSourceKey>): RulesetVerifier {
+            val factory = KeyFactory.getInstance("EC")
+            val decoded = HashMap<String, PublicKey>(keys.size)
+            for (entry in keys) {
+                try {
+                    val der = Base64.getDecoder().decode(entry.publicKeyBase64Der)
+                    decoded[entry.sourceId] = factory.generatePublic(X509EncodedKeySpec(der))
+                } catch (e: Exception) {
+                    Timber.tag(RulesetCrypto.TAG).e(
+                        e,
+                        "dropping unusable pinned key for source '%s' — that source will fail closed",
+                        entry.sourceId,
+                    )
+                }
+            }
+            return RulesetVerifier(decoded)
+        }
+    }
+}
+
+/** Shared crypto parameters + log tag for the ruleset-verification path (#416). */
+internal object RulesetCrypto {
+    const val TAG = "Rules"
+
+    /** ECDSA over the NIST P-256 curve with a SHA-256 digest. */
+    const val SIGNATURE_ALGORITHM = "SHA256withECDSA"
+
+    /**
+     * Max accepted remote bundle size, checked BEFORE hashing/verifying. Aligned with
+     * [JsonRuleInterpreter]'s post-decode 1 MB file cap so a bundle that would be
+     * rejected at compile can't burn crypto work first.
+     */
+    const val MAX_BUNDLE_BYTES = 1_000_000
+}
+
+/**
+ * A configured trust anchor: a remote/side-loaded rule [sourceId] paired with the
+ * base64-DER (X.509 SubjectPublicKeyInfo) EC-P256 public key that signs its bundles.
+ * Generate a keypair per `matchers/tools/README.md`; the private half is NEVER committed.
+ */
+data class RuleSourceKey(
+    val sourceId: String,
+    val publicKeyBase64Der: String,
+)
+
+/**
+ * Canonical ruleset bytes that have **passed signature verification** — the only
+ * token [JsonRuleInterpreter.load] accepts (#416). Fail-closed BY CONSTRUCTION: the
+ * constructor is private and the sole way to obtain an instance is
+ * [VerifiedRulesetBytes.verify], which does the full bounded-ingestion + crypto check.
+ * There is thus no way to reach compile-from-remote-bytes without a valid signature —
+ * the guarantee is structural, not call-site discipline.
+ */
+class VerifiedRulesetBytes private constructor(
+    /** The verified bundle as a UTF-8 string (== UTF-8 decode of the signed bytes). */
+    val json: String,
+    /** The configured source id whose pinned key verified these bytes. */
+    val source: String,
+) {
+    companion object {
+        /**
+         * The SINGLE construction site. Verify [signatureBase64] (detached
+         * ECDSA-P256-SHA256, base64) over [bundleBytes] against [key], and mint on
+         * success; return `null` on ANY failure (fail closed). Bounded ingestion is
+         * enforced here — even a direct caller can't feed an unbounded blob into crypto.
+         *
+         * Production code goes through [RulesetVerifier.verify], which binds the
+         * CONFIGURED key so app code can never present an arbitrary one; this overload
+         * exists for a caller that already resolved the pinned key (and for tests that
+         * generate their own keypair).
+         */
+        fun verify(
+            key: PublicKey,
+            source: String,
+            bundleBytes: ByteArray,
+            signatureBase64: String,
+        ): VerifiedRulesetBytes? {
+            // Bounded ingestion BEFORE any crypto: an attacker-supplied blob must not
+            // reach the (allocating) base64 decode / signature update.
+            if (bundleBytes.size > RulesetCrypto.MAX_BUNDLE_BYTES) {
+                Timber.tag(RulesetCrypto.TAG).e(
+                    "rejected remote bundle for source '%s': %d bytes exceeds cap %d (before verify)",
+                    source, bundleBytes.size, RulesetCrypto.MAX_BUNDLE_BYTES,
+                )
+                return null
+            }
+
+            return try {
+                val signature = Base64.getDecoder().decode(signatureBase64)
+                val verifier = Signature.getInstance(RulesetCrypto.SIGNATURE_ALGORITHM)
+                verifier.initVerify(key)
+                verifier.update(bundleBytes)
+                if (!verifier.verify(signature)) {
+                    Timber.tag(RulesetCrypto.TAG).e(
+                        "rejected remote bundle for source '%s': signature does not verify against the " +
+                            "pinned key (%d bytes)",
+                        source, bundleBytes.size,
+                    )
+                    return null
+                }
+                // Verified: decoding to a String is safe — the EXACT bytes were the
+                // signed payload; a non-UTF-8 bundle fails downstream JSON parse, not
+                // integrity.
+                VerifiedRulesetBytes(bundleBytes.toString(Charsets.UTF_8), source)
+            } catch (e: IllegalArgumentException) {
+                // Base64 decode failure (garbage / missing signature).
+                Timber.tag(RulesetCrypto.TAG).e(
+                    e, "rejected remote bundle for source '%s': malformed signature encoding", source,
+                )
+                null
+            } catch (e: java.security.GeneralSecurityException) {
+                Timber.tag(RulesetCrypto.TAG).e(
+                    e, "rejected remote bundle for source '%s': crypto failure during verify", source,
+                )
+                null
+            }
+        }
+    }
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RulesetVerifier.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RulesetVerifier.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.pipeline.rules
 
+import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
 import timber.log.Timber
 import java.security.KeyFactory
 import java.security.PublicKey
@@ -44,15 +45,26 @@ import java.util.Base64
  *
  * ## Fail direction
  * Every branch fails CLOSED — an oversized bundle, an unconfigured source, an
- * undecodable signature, a verification mismatch, or any crypto exception returns
- * `null` (reject). The caller keeps the last-good ruleset. Logs at ERROR under the
- * stable `Rules` tag (Principle 7); the untrusted bundle is treated as hostile — the
- * log carries only sizes / the source id, **never** any bundle content.
+ * `asset:`-prefixed (auto-grant) source id, an over-long or undecodable signature, a
+ * verification mismatch, or any exception during verify returns `null` (reject). The
+ * caller keeps the last-good ruleset. Logs at ERROR under the stable `Rules` tag
+ * (Principle 7); the untrusted bundle is treated as hostile — the log carries only
+ * sizes / the source id, **never** any bundle content.
  *
- * @param keysBySource source id → its pinned public key. Built by [fromConfig] from
- *   base64-DER config; a source absent here has no key and is always rejected.
+ * ## Known residual — no freshness / rollback protection (deferred to #192)
+ * This gate proves a bundle was signed by the pinned key; it does NOT prove the bundle
+ * is the *latest* one. An attacker who can serve bytes (a stale CDN cache, a MITM
+ * replaying an older signed bundle) could re-serve an OLD but validly-signed bundle,
+ * which verifies and swaps in — a downgrade to a superseded ruleset. There is no
+ * version/monotonicity/expiry field yet. Freshness pinning (a signed, monotonic
+ * `ruleset_version` or a corpus↔rules SHA pin, N5/#638) is tracked with the CDN wiring
+ * under #192; until then the swap is authenticity-verified but not rollback-protected.
+ *
+ * @param keysBySource source id → its pinned public key. Constructed only via
+ *   [fromConfig] (the primary constructor is private) from base64-DER config; a source
+ *   absent here has no key and is always rejected.
  */
-class RulesetVerifier(private val keysBySource: Map<String, PublicKey>) {
+class RulesetVerifier private constructor(private val keysBySource: Map<String, PublicKey>) {
 
     /**
      * Verify [signatureBase64] (a detached ECDSA-P256-SHA256 signature, base64) over
@@ -86,6 +98,19 @@ class RulesetVerifier(private val keysBySource: Map<String, PublicKey>) {
             val factory = KeyFactory.getInstance("EC")
             val decoded = HashMap<String, PublicKey>(keys.size)
             for (entry in keys) {
+                // A remote source must NEVER claim the `asset:` prefix: RuleCapabilityGrants
+                // AUTO-GRANTS capabilities for asset-prefixed sources (#417). A config entry
+                // that pinned a key for an `asset:`-prefixed id would let a remote bundle's
+                // taps auto-grant. Drop such entries so the id can never resolve a key
+                // (verify() re-checks this too — defense in depth).
+                if (entry.sourceId.startsWith(RuleCapabilityGrants.ASSET_SOURCE_PREFIX)) {
+                    Timber.tag(RulesetCrypto.TAG).e(
+                        "dropping pinned key for source '%s' — the '%s' prefix is reserved for bundled " +
+                            "assets (auto-grant); a remote source must not claim it (fail closed)",
+                        entry.sourceId, RuleCapabilityGrants.ASSET_SOURCE_PREFIX,
+                    )
+                    continue
+                }
                 try {
                     val der = Base64.getDecoder().decode(entry.publicKeyBase64Der)
                     decoded[entry.sourceId] = factory.generatePublic(X509EncodedKeySpec(der))
@@ -115,6 +140,14 @@ internal object RulesetCrypto {
      * rejected at compile can't burn crypto work first.
      */
     const val MAX_BUNDLE_BYTES = 1_000_000
+
+    /**
+     * Max accepted length of the base64 signature string, checked BEFORE decode. A real
+     * P-256 DER signature base64-encodes to ~100 chars (raw DER ≤ ~72 bytes); 512 is a
+     * generous ceiling that still rejects a hostile multi-MB "signature" before it
+     * allocates in the base64 decoder.
+     */
+    const val MAX_SIGNATURE_B64_CHARS = 512
 }
 
 /**
@@ -146,25 +179,47 @@ class VerifiedRulesetBytes private constructor(
          * The SINGLE construction site. Verify [signatureBase64] (detached
          * ECDSA-P256-SHA256, base64) over [bundleBytes] against [key], and mint on
          * success; return `null` on ANY failure (fail closed). Bounded ingestion is
-         * enforced here — even a direct caller can't feed an unbounded blob into crypto.
+         * enforced here — even the in-module caller can't feed an unbounded blob into
+         * crypto.
          *
-         * Production code goes through [RulesetVerifier.verify], which binds the
-         * CONFIGURED key so app code can never present an arbitrary one; this overload
-         * exists for a caller that already resolved the pinned key (and for tests that
-         * generate their own keypair).
+         * **`internal` on purpose:** the ONLY production caller is [RulesetVerifier.verify],
+         * which binds the CONFIGURED key so app code can never present an arbitrary key
+         * (self-signed key confusion — a key delivered alongside the bundle). Exposing a
+         * public `verify(key, …)` would make the key binding disciplinary rather than
+         * structural; keeping this internal + [RulesetVerifier]'s constructor private forces
+         * every path through [fromConfig]'s pinned keys. Reachable from `:core:pipeline`
+         * tests (same module) which generate their own keypair.
          */
-        fun verify(
+        internal fun verify(
             key: PublicKey,
             source: String,
             bundleBytes: ByteArray,
             signatureBase64: String,
         ): VerifiedRulesetBytes? {
+            // Defense in depth (fromConfig also drops these): a remote source must never
+            // claim the `asset:` prefix, which RuleCapabilityGrants auto-grants (#417).
+            if (source.startsWith(RuleCapabilityGrants.ASSET_SOURCE_PREFIX)) {
+                Timber.tag(RulesetCrypto.TAG).e(
+                    "rejected remote bundle: source '%s' uses the reserved '%s' auto-grant prefix",
+                    source, RuleCapabilityGrants.ASSET_SOURCE_PREFIX,
+                )
+                return null
+            }
             // Bounded ingestion BEFORE any crypto: an attacker-supplied blob must not
             // reach the (allocating) base64 decode / signature update.
             if (bundleBytes.size > RulesetCrypto.MAX_BUNDLE_BYTES) {
                 Timber.tag(RulesetCrypto.TAG).e(
                     "rejected remote bundle for source '%s': %d bytes exceeds cap %d (before verify)",
                     source, bundleBytes.size, RulesetCrypto.MAX_BUNDLE_BYTES,
+                )
+                return null
+            }
+            // Cap the signature string BEFORE base64-decode — a real P-256 DER sig is
+            // ~100 chars; a multi-MB "signature" must not allocate in the decoder.
+            if (signatureBase64.length > RulesetCrypto.MAX_SIGNATURE_B64_CHARS) {
+                Timber.tag(RulesetCrypto.TAG).e(
+                    "rejected remote bundle for source '%s': signature length %d exceeds cap %d (before decode)",
+                    source, signatureBase64.length, RulesetCrypto.MAX_SIGNATURE_B64_CHARS,
                 )
                 return null
             }
@@ -186,15 +241,15 @@ class VerifiedRulesetBytes private constructor(
                 // signed payload; a non-UTF-8 bundle fails downstream JSON parse, not
                 // integrity.
                 VerifiedRulesetBytes(bundleBytes.toString(Charsets.UTF_8), source)
-            } catch (e: IllegalArgumentException) {
-                // Base64 decode failure (garbage / missing signature).
+            } catch (e: Exception) {
+                // Broad catch on PURPOSE (still fail-closed + logged): the input is a
+                // HOSTILE, attacker-shaped signature/DER. Beyond the expected
+                // IllegalArgumentException (bad base64) and GeneralSecurityException, some
+                // JCE providers throw unchecked (ArrayIndexOutOfBounds / NegativeArraySize /
+                // provider-internal RuntimeExceptions) on malformed ASN.1 DER — a narrower
+                // catch would let one of those escape and fail OPEN into the loader's caller.
                 Timber.tag(RulesetCrypto.TAG).e(
-                    e, "rejected remote bundle for source '%s': malformed signature encoding", source,
-                )
-                null
-            } catch (e: java.security.GeneralSecurityException) {
-                Timber.tag(RulesetCrypto.TAG).e(
-                    e, "rejected remote bundle for source '%s': crypto failure during verify", source,
+                    e, "rejected remote bundle for source '%s': verify failed (%s)", source, e.javaClass.simpleName,
                 )
                 null
             }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreterReplaceSurvivalTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreterReplaceSurvivalTest.kt
@@ -22,6 +22,13 @@ class JsonRuleInterpreterReplaceSurvivalTest {
 
     private val interpreter = JsonRuleInterpreter(mock<Context>(), mock<RuleCapabilityGrants>())
 
+    // #416: load() now only accepts signature-verified bytes. Tests sign their own
+    // bundles with a runtime keypair (no committed private key) and mint through the
+    // real RulesetVerifier — exercising the whole gate.
+    private val signingKey = TestRulesetSigning.keyPair()
+    private fun load(json: String, source: String) =
+        TestRulesetSigning.verified(json, source, signingKey)
+
     /** A single-child tree carrying [text] (exists/hasText searches the subtree). */
     private fun screen(text: String) = UiNode(children = listOf(UiNode(text = text)))
 
@@ -60,7 +67,7 @@ class JsonRuleInterpreterReplaceSurvivalTest {
 
     @Test
     fun `a replacement that omits sensitive rules is rejected and the previous block survives`() = runTest {
-        interpreter.load(goodBundle, "good")
+        interpreter.load(load(goodBundle, "good"))
         assertTrue("good bundle should be live", interpreter.isLoaded)
         assertEquals(
             "sensitive",
@@ -68,7 +75,7 @@ class JsonRuleInterpreterReplaceSurvivalTest {
         )
 
         // A sensitive-omitting replacement must NOT go live.
-        interpreter.load(replacementWithoutSensitive, "evil-replacement")
+        interpreter.load(load(replacementWithoutSensitive, "evil-replacement"))
 
         // The previous bundle's sensitive block is still in force.
         assertEquals(
@@ -80,9 +87,9 @@ class JsonRuleInterpreterReplaceSurvivalTest {
 
     @Test
     fun `a replacement that keeps sensitive rules loads normally`() = runTest {
-        interpreter.load(goodBundle, "good")
+        interpreter.load(load(goodBundle, "good"))
         // Same platform, still ships the sensitive rule → allowed to swap.
-        interpreter.load(goodBundle, "good-again")
+        interpreter.load(load(goodBundle, "good-again"))
         assertEquals(
             "sensitive",
             interpreter.screenRuleset?.matchFirst(bankingScreen)?.shape,

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreterVerifiedLoadTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreterVerifiedLoadTest.kt
@@ -1,0 +1,94 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import android.content.Context
+import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+/**
+ * #416 — end-to-end: the remote-replace path ([JsonRuleInterpreter.load]) is
+ * unreachable without signature verification, and a rejected bundle keeps the
+ * last-good ruleset live.
+ *
+ * The gate is STRUCTURAL: `load()` only accepts a [VerifiedRulesetBytes], which the
+ * [RulesetVerifier] mints solely after a valid signature. A tampered / wrong-key /
+ * garbage bundle produces `null` at verify time, so `load()` is simply never called
+ * — the previous good bundle stays in force with no explicit "keep last good" branch
+ * needed. This test drives that contract the way a real CDN caller would:
+ * `verifier.verify(...)?.let { interpreter.load(it) }`.
+ */
+class JsonRuleInterpreterVerifiedLoadTest {
+
+    private val interpreter = JsonRuleInterpreter(mock<Context>(), mock<RuleCapabilityGrants>())
+
+    private val source = "cdn:matchers/doordash"
+    private val signingKey = TestRulesetSigning.keyPair()
+    private val verifier = RulesetVerifier.fromConfig(
+        listOf(RuleSourceKey(source, TestRulesetSigning.publicKeyBase64Der(signingKey))),
+    )
+
+    private fun screen(text: String) = UiNode(children = listOf(UiNode(text = text)))
+    private val bankingScreen = screen("Available Balance")
+
+    private val goodBundle = """
+        {
+          "format_version": 2,
+          "platform_id": "doordash.driver",
+          "screens": [
+            {
+              "id": "doordash.screen.sensitive.known", "priority": 0, "overrideable": false,
+              "parse": { "as": "sensitive" },
+              "require": { "exists": { "hasText": "Available Balance" } }
+            },
+            {
+              "id": "doordash.screen.idle_map", "priority": 10,
+              "require": { "exists": { "hasText": "MapView" } }
+            }
+          ]
+        }
+    """.trimIndent()
+
+    /** The real CDN-shaped call site: verify, and only load on success. */
+    private suspend fun tryLoad(json: String, signatureBase64: String) {
+        verifier.verify(source, json.toByteArray(Charsets.UTF_8), signatureBase64)
+            ?.let { interpreter.load(it) }
+    }
+
+    @Test
+    fun `a validly-signed remote bundle compiles and goes live`() = runTest {
+        val sig = TestRulesetSigning.signBase64(goodBundle.toByteArray(Charsets.UTF_8), signingKey.private)
+        tryLoad(goodBundle, sig)
+
+        assertTrue("a verified bundle must go live", interpreter.isLoaded)
+        assertEquals("sensitive", interpreter.screenRuleset?.matchFirst(bankingScreen)?.shape)
+    }
+
+    @Test
+    fun `a tampered remote bundle never compiles and the last-good ruleset is retained`() = runTest {
+        // First a good load establishes last-good.
+        val sig = TestRulesetSigning.signBase64(goodBundle.toByteArray(Charsets.UTF_8), signingKey.private)
+        tryLoad(goodBundle, sig)
+        val liveRuleset = interpreter.screenRuleset
+
+        // A single-byte flip of the payload, keeping the original (now-stale) signature.
+        val tampered = goodBundle.replaceFirst("Available Balance", "Available BalancX")
+        tryLoad(tampered, sig)
+
+        assertTrue("previous good bundle must remain live", interpreter.isLoaded)
+        assertEquals("live ruleset must be unchanged by a rejected tampered bundle", liveRuleset, interpreter.screenRuleset)
+        // And the sensitive rule (which the tampered bundle mangled) is still enforced.
+        assertEquals("sensitive", interpreter.screenRuleset?.matchFirst(bankingScreen)?.shape)
+    }
+
+    @Test
+    fun `verification of a tampered bundle returns null (never reaches load)`() {
+        val sig = TestRulesetSigning.signBase64(goodBundle.toByteArray(Charsets.UTF_8), signingKey.private)
+        val tampered = (goodBundle + " ").toByteArray(Charsets.UTF_8)
+        assertNull("a byte-changed bundle must not verify", verifier.verify(source, tampered, sig))
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/LoadAtomicityTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/LoadAtomicityTest.kt
@@ -101,7 +101,7 @@ class LoadAtomicityTest {
     fun `a dup-id whole-file reject reconciles NO capabilities and loads no rules`() = runTest {
         val grants = RecordingGrants()
         val interp = interpreter(grants)
-        interp.load(verified(dupIdFile, "asset:rules/doordash.json"))
+        interp.load(verified(dupIdFile, "cdn:rules/doordash"))
 
         assertFalse("a rejected file must not go live", interp.isLoaded)
         assertTrue(
@@ -114,7 +114,7 @@ class LoadAtomicityTest {
     fun `a sensitive-coverage reject reconciles NO capabilities and loads no rules`() = runTest {
         val grants = RecordingGrants()
         val interp = interpreter(grants)
-        interp.load(verified(noSensitiveFile, "asset:rules/doordash.json"))
+        interp.load(verified(noSensitiveFile, "cdn:rules/doordash"))
 
         assertFalse("a coverage-rejected file must not go live", interp.isLoaded)
         assertTrue(
@@ -127,7 +127,7 @@ class LoadAtomicityTest {
     fun `a valid file goes live and reconciles exactly once (positive control)`() = runTest {
         val grants = RecordingGrants()
         val interp = interpreter(grants)
-        interp.load(verified(validFile, "asset:rules/doordash.json"))
+        interp.load(verified(validFile, "cdn:rules/doordash"))
 
         assertTrue("a valid bundle must go live", interp.isLoaded)
         assertNotNull(interp.screenRuleset)
@@ -139,12 +139,12 @@ class LoadAtomicityTest {
         val grants = RecordingGrants()
         val interp = interpreter(grants)
 
-        interp.load(verified(validFile, "asset:rules/doordash.json"))
+        interp.load(verified(validFile, "cdn:rules/doordash"))
         val goodRuleset = interp.screenRuleset
         assertEquals(1, grants.reconcileCalls.size)
 
         // The failing load must be a no-op on the live state.
-        interp.load(verified(dupIdFile, "asset:rules/doordash.json"))
+        interp.load(verified(dupIdFile, "cdn:rules/doordash"))
 
         assertTrue("previous good bundle must remain live", interp.isLoaded)
         assertEquals("live ruleset must be unchanged by the rejected load", goodRuleset, interp.screenRuleset)

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/LoadAtomicityTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/LoadAtomicityTest.kt
@@ -49,6 +49,12 @@ class LoadAtomicityTest {
     private fun interpreter(grants: RuleCapabilityGrants) =
         JsonRuleInterpreter(context = mock<Context>(), capabilityGrants = grants)
 
+    // #416: load() only accepts signature-verified bytes. Sign with a runtime keypair
+    // (no committed private key) and mint through the real RulesetVerifier.
+    private val signingKey = TestRulesetSigning.keyPair()
+    private fun verified(json: String, source: String) =
+        TestRulesetSigning.verified(json, source, signingKey)
+
     // --- Rule-file builders (minimal valid doordash bundles) ---------------------
 
     private val sensitiveRule = """
@@ -95,7 +101,7 @@ class LoadAtomicityTest {
     fun `a dup-id whole-file reject reconciles NO capabilities and loads no rules`() = runTest {
         val grants = RecordingGrants()
         val interp = interpreter(grants)
-        interp.load(dupIdFile, source = "asset:rules/doordash.json")
+        interp.load(verified(dupIdFile, "asset:rules/doordash.json"))
 
         assertFalse("a rejected file must not go live", interp.isLoaded)
         assertTrue(
@@ -108,7 +114,7 @@ class LoadAtomicityTest {
     fun `a sensitive-coverage reject reconciles NO capabilities and loads no rules`() = runTest {
         val grants = RecordingGrants()
         val interp = interpreter(grants)
-        interp.load(noSensitiveFile, source = "asset:rules/doordash.json")
+        interp.load(verified(noSensitiveFile, "asset:rules/doordash.json"))
 
         assertFalse("a coverage-rejected file must not go live", interp.isLoaded)
         assertTrue(
@@ -121,7 +127,7 @@ class LoadAtomicityTest {
     fun `a valid file goes live and reconciles exactly once (positive control)`() = runTest {
         val grants = RecordingGrants()
         val interp = interpreter(grants)
-        interp.load(validFile, source = "asset:rules/doordash.json")
+        interp.load(verified(validFile, "asset:rules/doordash.json"))
 
         assertTrue("a valid bundle must go live", interp.isLoaded)
         assertNotNull(interp.screenRuleset)
@@ -133,12 +139,12 @@ class LoadAtomicityTest {
         val grants = RecordingGrants()
         val interp = interpreter(grants)
 
-        interp.load(validFile, source = "asset:rules/doordash.json")
+        interp.load(verified(validFile, "asset:rules/doordash.json"))
         val goodRuleset = interp.screenRuleset
         assertEquals(1, grants.reconcileCalls.size)
 
         // The failing load must be a no-op on the live state.
-        interp.load(dupIdFile, source = "asset:rules/doordash.json")
+        interp.load(verified(dupIdFile, "asset:rules/doordash.json"))
 
         assertTrue("previous good bundle must remain live", interp.isLoaded)
         assertEquals("live ruleset must be unchanged by the rejected load", goodRuleset, interp.screenRuleset)

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RulesetVerifierTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RulesetVerifierTest.kt
@@ -90,6 +90,31 @@ class RulesetVerifierTest {
     }
 
     @Test
+    fun `an asset-prefixed source id is rejected (auto-grant seam, #417)`() {
+        val pair = TestRulesetSigning.keyPair()
+        val assetSource = "asset:rules/doordash.json"
+        // Even if a config entry tried to pin a key for an asset-prefixed id, fromConfig
+        // drops it — so the source resolves no key AND the verify() re-check would fire.
+        val verifier = verifierFor(RuleSourceKey(assetSource, TestRulesetSigning.publicKeyBase64Der(pair)))
+        val assetBytes = bundle.toByteArray(Charsets.UTF_8)
+        val sig = TestRulesetSigning.signBase64(assetBytes, pair.private)
+
+        assertNull(
+            "a remote bundle must never verify under the reserved 'asset:' auto-grant prefix",
+            verifier.verify(assetSource, assetBytes, sig),
+        )
+    }
+
+    @Test
+    fun `an over-long signature string is rejected before decode`() {
+        val pair = TestRulesetSigning.keyPair()
+        val verifier = verifierFor(RuleSourceKey(source, TestRulesetSigning.publicKeyBase64Der(pair)))
+        val huge = "A".repeat(RulesetCrypto.MAX_SIGNATURE_B64_CHARS + 1)
+
+        assertNull("an over-cap signature must be rejected before base64 decode", verifier.verify(source, bytes, huge))
+    }
+
+    @Test
     fun `a malformed pinned key drops that source to fail-closed`() {
         // fromConfig cannot decode the key => the source has no usable key.
         val verifier = verifierFor(RuleSourceKey(source, "not-a-real-der-key"))

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RulesetVerifierTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RulesetVerifierTest.kt
@@ -1,0 +1,101 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #416 — signature verification for a remote / side-loaded ruleset bundle.
+ *
+ * Exercises the [RulesetVerifier] gate directly (no interpreter): a valid signature
+ * verifies; a tampered payload, wrong key, missing/garbage signature, unconfigured
+ * source, and an oversized bundle all fail CLOSED (return null). All keypairs are
+ * generated at runtime — no committed private key.
+ */
+class RulesetVerifierTest {
+
+    private val source = "cdn:matchers/doordash"
+    private val bundle = """{"format_version":2,"platform_id":"doordash.driver","screens":[]}"""
+    private val bytes = bundle.toByteArray(Charsets.UTF_8)
+
+    private fun verifierFor(vararg keys: RuleSourceKey) = RulesetVerifier.fromConfig(keys.toList())
+
+    @Test
+    fun `valid signature verifies and carries the exact bytes and source`() {
+        val pair = TestRulesetSigning.keyPair()
+        val verifier = verifierFor(RuleSourceKey(source, TestRulesetSigning.publicKeyBase64Der(pair)))
+
+        val verified = verifier.verify(source, bytes, TestRulesetSigning.signBase64(bytes, pair.private))
+
+        assertNotNull("a valid signature must verify", verified)
+        assertEquals(bundle, verified!!.json)
+        assertEquals(source, verified.source)
+    }
+
+    @Test
+    fun `a single-byte-flipped payload is rejected`() {
+        val pair = TestRulesetSigning.keyPair()
+        val verifier = verifierFor(RuleSourceKey(source, TestRulesetSigning.publicKeyBase64Der(pair)))
+        val sig = TestRulesetSigning.signBase64(bytes, pair.private)
+
+        val tampered = bytes.copyOf()
+        tampered[tampered.size / 2] = (tampered[tampered.size / 2] + 1).toByte()
+
+        assertNull("a tampered payload must not verify", verifier.verify(source, tampered, sig))
+    }
+
+    @Test
+    fun `a signature from a different key is rejected`() {
+        val pinned = TestRulesetSigning.keyPair()
+        val attacker = TestRulesetSigning.keyPair()
+        // The verifier is configured with the PINNED key; the bundle is signed by the ATTACKER.
+        val verifier = verifierFor(RuleSourceKey(source, TestRulesetSigning.publicKeyBase64Der(pinned)))
+        val sig = TestRulesetSigning.signBase64(bytes, attacker.private)
+
+        assertNull("a wrong-key signature must not verify", verifier.verify(source, bytes, sig))
+    }
+
+    @Test
+    fun `garbage and empty signatures are rejected`() {
+        val pair = TestRulesetSigning.keyPair()
+        val verifier = verifierFor(RuleSourceKey(source, TestRulesetSigning.publicKeyBase64Der(pair)))
+
+        assertNull("non-base64 garbage must not verify", verifier.verify(source, bytes, "!!!not base64!!!"))
+        assertNull("empty signature must not verify", verifier.verify(source, bytes, ""))
+        // Well-formed base64 that decodes to non-DER bytes.
+        assertNull("valid-base64 non-signature must not verify", verifier.verify(source, bytes, "AAAA"))
+    }
+
+    @Test
+    fun `an unconfigured source is rejected even with a valid signature`() {
+        val pair = TestRulesetSigning.keyPair()
+        // Key pinned for a DIFFERENT source id than the one being loaded.
+        val verifier = verifierFor(RuleSourceKey("cdn:other", TestRulesetSigning.publicKeyBase64Der(pair)))
+        val sig = TestRulesetSigning.signBase64(bytes, pair.private)
+
+        assertNull("no pinned key for this source => reject", verifier.verify(source, bytes, sig))
+    }
+
+    @Test
+    fun `an oversized bundle is rejected before crypto`() {
+        val pair = TestRulesetSigning.keyPair()
+        val verifier = verifierFor(RuleSourceKey(source, TestRulesetSigning.publicKeyBase64Der(pair)))
+        val huge = ByteArray(RulesetCrypto.MAX_BUNDLE_BYTES + 1)
+        // A signature that WOULD verify the oversized bytes — proves the size cap
+        // trips first (fail closed before the crypto path runs).
+        val sig = TestRulesetSigning.signBase64(huge, pair.private)
+
+        assertNull("over-cap bundle must be rejected before verify", verifier.verify(source, huge, sig))
+    }
+
+    @Test
+    fun `a malformed pinned key drops that source to fail-closed`() {
+        // fromConfig cannot decode the key => the source has no usable key.
+        val verifier = verifierFor(RuleSourceKey(source, "not-a-real-der-key"))
+        val pair = TestRulesetSigning.keyPair()
+        val sig = TestRulesetSigning.signBase64(bytes, pair.private)
+
+        assertNull("a source whose configured key failed to decode must fail closed", verifier.verify(source, bytes, sig))
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TestRulesetSigning.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TestRulesetSigning.kt
@@ -1,0 +1,50 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.Signature
+import java.security.spec.ECGenParameterSpec
+import java.util.Base64
+
+/**
+ * Test-only signing helpers for the #416 ruleset-verification path. Every keypair is
+ * generated at runtime — NO private key is ever committed. Mirrors the production
+ * `SHA256withECDSA` P-256 scheme (the same one `matchers/tools/sign-ruleset.sh` uses),
+ * so tests exercise the real verifier end to end.
+ */
+object TestRulesetSigning {
+
+    /** A fresh EC P-256 keypair. */
+    fun keyPair(): KeyPair =
+        KeyPairGenerator.getInstance("EC").apply {
+            initialize(ECGenParameterSpec("secp256r1"))
+        }.generateKeyPair()
+
+    /** Detached ECDSA-P256-SHA256 signature over [bytes], base64-encoded. */
+    fun signBase64(bytes: ByteArray, privateKey: PrivateKey): String {
+        val signer = Signature.getInstance(RulesetCrypto.SIGNATURE_ALGORITHM)
+        signer.initSign(privateKey)
+        signer.update(bytes)
+        return Base64.getEncoder().encodeToString(signer.sign())
+    }
+
+    /** The public key as base64-DER X.509 SubjectPublicKeyInfo (the pinned-config form). */
+    fun publicKeyBase64Der(pair: KeyPair): String =
+        Base64.getEncoder().encodeToString(pair.public.encoded)
+
+    /**
+     * Sign [json] with [pair]'s private key and verify through the real
+     * [RulesetVerifier], returning the [VerifiedRulesetBytes] a `load()` call needs.
+     * Fails the test (non-null assumption) if verification unexpectedly rejects.
+     */
+    fun verified(json: String, source: String, pair: KeyPair): VerifiedRulesetBytes {
+        val bytes = json.toByteArray(Charsets.UTF_8)
+        val verifier = RulesetVerifier.fromConfig(
+            listOf(RuleSourceKey(source, publicKeyBase64Der(pair))),
+        )
+        return requireNotNull(verifier.verify(source, bytes, signBase64(bytes, pair.private))) {
+            "test fixture failed to verify for source '$source'"
+        }
+    }
+}

--- a/docs/audits/2026-06-11-rule-engine-security.md
+++ b/docs/audits/2026-06-11-rule-engine-security.md
@@ -52,6 +52,17 @@ or mismatched bundles and keep the last-good ruleset. The "switch sources via
 configuration" forkability must verify against the *configured* source's key,
 not skip verification.
 
+**RESOLVED 2026-07-23 (#416, in-tree build).** `RulesetVerifier` (ECDSA P-256 /
+SHA-256, no new crypto dependency) gates the remote-replace path:
+`JsonRuleInterpreter.load` now accepts only a `VerifiedRulesetBytes`, a value type
+that can be minted *solely* by a successful signature check, so
+compile-from-remote-bytes is **structurally unreachable** without verification —
+fail-closed by construction, not call-site discipline. Verification is always
+against the *configured source's* pinned key (base64-DER SPKI); an unconfigured
+source, tampered payload, wrong key, garbage/oversized bundle all reject and keep
+last-good. Bundled asset rulesets are exempt (already covered by the APK
+signature). Signing tooling: `matchers/tools/sign-ruleset.sh` + README.
+
 ### S2 — `isPermissionGranted` is a hardcoded `true` (HIGH, gates #192 / multi-user)
 `SideEffectEngine.isPermissionGranted(tier)` returns `true` for every
 `PermissionTier`. The tier system is fully built (verbs carry tiers; the engine

--- a/docs/audits/2026-06-11-rule-engine-security.md
+++ b/docs/audits/2026-06-11-rule-engine-security.md
@@ -60,8 +60,16 @@ compile-from-remote-bytes is **structurally unreachable** without verification �
 fail-closed by construction, not call-site discipline. Verification is always
 against the *configured source's* pinned key (base64-DER SPKI); an unconfigured
 source, tampered payload, wrong key, garbage/oversized bundle all reject and keep
-last-good. Bundled asset rulesets are exempt (already covered by the APK
-signature). Signing tooling: `matchers/tools/sign-ruleset.sh` + README.
+last-good. An `asset:`-prefixed source id is rejected on the verified path (it would
+otherwise inherit the #417 auto-grant). Bundled asset rulesets are exempt (already
+covered by the APK signature). Signing tooling: `matchers/tools/sign-ruleset.sh` +
+README.
+
+**Residual (deferred to #192):** the gate proves *authenticity* but not *freshness* —
+there is no version/monotonicity/expiry field, so an OLD but validly-signed bundle
+that is re-served (stale cache / MITM replay) verifies and swaps in (a downgrade to a
+superseded ruleset). Freshness pinning (signed monotonic `ruleset_version`, or the
+corpus↔rules SHA pin N5/#638) ships with the CDN wiring under #192.
 
 ### S2 — `isPermissionGranted` is a hardcoded `true` (HIGH, gates #192 / multi-user)
 `SideEffectEngine.isPermissionGranted(tier)` returns `true` for every

--- a/matchers/tools/README.md
+++ b/matchers/tools/README.md
@@ -1,0 +1,51 @@
+# matchers/tools — ruleset signing (#416)
+
+Dev-side helpers for signing a canonical ruleset bundle so a running app instance
+can verify it before compiling (the hard prerequisite for the CDN matchers split,
+#192). The on-device gate is `RulesetVerifier` in `:core:pipeline`.
+
+## Scheme
+
+- **ECDSA P-256 (secp256r1 / prime256v1) with SHA-256** — Java `SHA256withECDSA`,
+  available on every supported API level, no extra crypto dependency.
+- **Detached** signature over the **exact canonical JSON bytes** (no reformatting).
+- Signature transported **base64** (standard alphabet); it is an ASN.1 DER
+  `SEQUENCE { r, s }` — exactly what `openssl dgst -sign` emits and what the Java
+  verifier expects.
+- Public key pinned in app config as **base64 DER X.509 SubjectPublicKeyInfo**.
+
+## One-time key generation (private key is NEVER committed)
+
+```bash
+# Generate the signing keypair. Keep ruleset-signing-key.pem OFF the repo / in a secret store.
+openssl ecparam -name prime256v1 -genkey -noout -out ruleset-signing-key.pem
+
+# Derive the PINNED public key for app config (base64 DER SubjectPublicKeyInfo):
+openssl ec -in ruleset-signing-key.pem -pubout -outform DER | base64 -w0
+```
+
+Pin that public-key string against the rule source id in `RuleSourceKey` config. To
+rotate or fork, generate a new keypair and switch the pinned key for that source —
+verification is always against the *configured source's* key; it is never skipped.
+
+> `keytool -genkeypair -keyalg EC -groupname secp256r1 ...` into a keystore works
+> too if you prefer a keystore-managed private key; export the public key as DER and
+> base64-encode it the same way.
+
+## Signing a bundle
+
+```bash
+matchers/tools/sign-ruleset.sh ruleset-signing-key.pem path/to/doordash.json
+# → prints the base64 signature; ship it alongside the bundle for the CDN path.
+```
+
+## Verifying locally (sanity check, mirrors the app)
+
+```bash
+openssl ec -in ruleset-signing-key.pem -pubout -out pub.pem
+matchers/tools/sign-ruleset.sh ruleset-signing-key.pem doordash.json | base64 -d > sig.der
+openssl dgst -sha256 -verify pub.pem -signature sig.der doordash.json   # → "Verified OK"
+```
+
+Bundled `assets/rules/*` are **exempt** — the APK signature already covers them; only
+remote / side-loaded bundles are signed and verified here.

--- a/matchers/tools/sign-ruleset.sh
+++ b/matchers/tools/sign-ruleset.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# sign-ruleset.sh — detached signature over a canonical ruleset bundle (#416).
+#
+# Produces the exact scheme the on-device RulesetVerifier checks:
+#   - ECDSA P-256 with SHA-256  (Java "SHA256withECDSA")
+#   - detached signature, base64-encoded (ASN.1 DER SEQUENCE { r, s })
+#   - over the EXACT canonical JSON bytes (no re-formatting)
+#
+# The signing PRIVATE KEY is never committed. Generate one (once) with:
+#   openssl ecparam -name prime256v1 -genkey -noout -out ruleset-signing-key.pem
+# and pin the matching PUBLIC key (base64 DER SubjectPublicKeyInfo) in app config:
+#   openssl ec -in ruleset-signing-key.pem -pubout -outform DER | base64 -w0
+#
+# Usage:
+#   matchers/tools/sign-ruleset.sh <private-key.pem> <bundle.json>
+# Prints the base64 signature to stdout (transport it alongside the bundle).
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <private-key.pem> <bundle.json>" >&2
+  exit 2
+fi
+
+KEY="$1"
+BUNDLE="$2"
+
+for f in "$KEY" "$BUNDLE"; do
+  [[ -f "$f" ]] || { echo "error: no such file: $f" >&2; exit 2; }
+done
+
+# -sha256 + an EC key => SHA256withECDSA, DER-encoded signature (Java-compatible).
+# base64 -w0 keeps it single-line for transport; the verifier uses the standard alphabet.
+openssl dgst -sha256 -sign "$KEY" "$BUNDLE" | base64 -w0
+echo


### PR DESCRIPTION
Closes #416. Adds signature/integrity verification before compiling any **remote / side-loaded** ruleset bundle — the hard prerequisite for the matchers CDN split (#192, audit S1). In-tree build authorized 2026-07-23; the repo split stays deferred.

## What changed
- **`RulesetVerifier` (`:core:pipeline`)** — detached signature over the exact canonical ruleset JSON bytes. **ECDSA P-256 / SHA-256** (`SHA256withECDSA` via `java.security` — no new crypto dependency, works on min SDK 30). Signature transported base64; public key pinned as **base64-DER X.509 SubjectPublicKeyInfo**, keyed per rule source (`RuleSourceKey`). `fromConfig` decodes pinned keys once; a bad config key is dropped so its source fails closed.
- **`JsonRuleInterpreter.load`** now takes a `VerifiedRulesetBytes` instead of a raw `String`. Bundled assets are untouched (`loadDefaults`).
- **Signing tooling** — `matchers/tools/sign-ruleset.sh` + `README.md` (openssl keygen; private key never committed; verify-locally recipe).
- **Tests** — `RulesetVerifierTest`, `JsonRuleInterpreterVerifiedLoadTest`; existing `load()` tests (`ReplaceSurvivalTest`, `LoadAtomicityTest`) re-routed through the real verifier via `TestRulesetSigning` (runtime keypairs, no committed key).

## Structural-unreachability mechanism
`load()` accepts **only** a `VerifiedRulesetBytes`. That type has a **private constructor** whose sole caller is `VerifiedRulesetBytes.verify(...)` — the one function that performs the bounded-ingestion + crypto check. There is no other mint path (no `internal` escape hatch, no `String` overload), so **compile-from-remote-bytes is unreachable without a passing signature**. Fail-closed *by construction*, not by call-site discipline. `RulesetVerifier` is the app-facing seam that binds the *configured* pinned key, so app code can never present an arbitrary key.

## Security posture (required)
- **Trusted:** only the pinned public key(s) in config (the root of trust). Bundled `assets/rules/*` (covered by the APK signature — documented exemption).
- **Untrusted:** every remote/side-loaded bundle's bytes and signature. The bundle is treated as hostile; ERROR logs carry only byte sizes + source id, **never bundle content** (Principle 7).
- **Gated:** the entire `load()` (replace) path — verification is mandatory and against the *configured source's* key (forkability switches keys, never skips).
- **Fail direction — CLOSED at every branch:** oversized bundle (capped *before* crypto) → reject; source with no/undecodable pinned key → reject; malformed/garbage/empty signature → reject; wrong-key or single-byte-tampered payload → reject; any `GeneralSecurityException` → reject. On reject `load()` is never called, so the **last-good ruleset is retained** (sensitive-screen rules stay in force). No crash on any path.
- **Bounded ingestion:** `MAX_BUNDLE_BYTES` (1 MB, aligned with the loader's `MAX_FILE_BYTES`) checked before base64-decode/verify.

## Design deviations
None material. The design specified "a small `RulesetVerifier` … `load()` requires a `VerifiedRulesetBytes` value type only the verifier can mint." Implemented exactly: the crypto+mint live in `VerifiedRulesetBytes.verify` (the private-constructor's only caller), `RulesetVerifier`'s constructor is private (all paths go through `fromConfig`'s pinned keys), and the companion `verify` is `internal` — so the key binding is **structural**, app code cannot present an arbitrary key. Signing tooling shipped as the script option (`matchers/tools/`) rather than a Gradle task (no build wiring needed, openssl DER output is byte-compatible with `SHA256withECDSA`).

## Test evidence
`export JAVA_HOME=/usr/lib/jvm/java-25; ./gradlew testDebugUnitTest :domain:test` → **BUILD SUCCESSFUL** (allWarningsAsErrors on). Acceptance cases covered: valid→compiles/live; tampered (single byte flip)→rejected + last-good retained; wrong key→rejected; missing/garbage/empty signature→rejected; unconfigured source→rejected; oversized→rejected before crypto; asset path unchanged (existing loader tests green). openssl→openssl round-trip of the signing script verified locally (`Verified OK`); the on-device scheme is exercised end-to-end by the JVM `Signature` tests.

## Residuals
- No CDN fetch is wired yet, so nothing constructs a `RulesetVerifier` in production DI — that (plus loading the pinned-key config) is #192's job. This PR only makes the compile seam impossible to reach unverified.
- **No freshness / rollback protection (deferred to #192).** The gate proves *authenticity* (signed by the pinned key), not *freshness* — there is no version/monotonicity/expiry field, so an OLD but validly-signed bundle that is re-served (stale cache / MITM replay) verifies and swaps in (a downgrade to a superseded ruleset). Freshness pinning (signed monotonic `ruleset_version`, or the corpus↔rules SHA pin N5/#638) ships with the CDN wiring under #192. Documented in the verifier KDoc + audit S1.

### Design-goal review
- **P6 (security & privacy):** the whole point — untrusted remote bundle, bounded ingestion before crypto, fail-closed at every branch, no bundle content in logs, structural (not disciplinary) gate. Bundled-asset exemption documented (APK signature).
- **P7 (logging):** all new log sites are ERROR (a rejected untrusted subsystem input = lost/hostile input) under the stable `Rules` tag; PII-safe by construction (sizes + source id only). Tagged calls, so the Timber-tag ratchet is unaffected.
- **P8 (platform-agnostic):** zero platform literals — verification is keyed by opaque `source` id + pinned key; no `Platform` branch, no wire-string gating. Nothing platform-specific.
- **P3 (single responsibility):** `RulesetVerifier` is small and single-purpose next to the loader; `RulesetCrypto` holds the shared params.
- **P5 (SSOT):** `MAX_BUNDLE_BYTES` documented as aligned with the loader cap; crypto params in one `RulesetCrypto` object; the test signer mirrors the production scheme via the same constant.

### Adversarial review
Fable security review: **APPROVE-WITH-FIXES** — all six findings applied in commit `b1f46ecf`:
- **F1 (MED, structural key binding):** made `RulesetVerifier`'s primary constructor private (force `fromConfig`) and the companion `VerifiedRulesetBytes.verify(key,…)` `internal` — closes the self-signed key-confusion seam (a caller minting against a key delivered alongside the bundle). KDoc/PR-body corrected.
- **F2 (MED, #417 auto-grant seam):** reject an `asset:`-prefixed sourceId on the verified path — in `fromConfig` (drop the entry) and in `verify()` (defense in depth); test added; `LoadAtomicityTest` sources renamed off `asset:`.
- **F3 (docs):** freshness/rollback residual documented (verifier KDoc + audit S1 + Residuals above).
- **F4:** `loadSingle(String)` is now `internal`.
- **F5:** base64 signature length capped (512 chars) before decode.
- **F6:** final verify catch broadened to `Exception` (hostile ASN.1 DER can trip unchecked provider exceptions) — still fail-closed + logged, comment names why.
