### PR TITLE
feat(tts): #428 Half B — multi-language offer reading (system locale + settings override)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
@@ -14,6 +14,7 @@ import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.Locale
@@ -96,8 +97,12 @@ class TtsEffectHandler @Inject constructor(
         }
         // Observe the override reactively so a settings change re-languages the live engine AND the
         // spoken copy with no restart (Reactive UI / UDF: the pref is the single source of truth).
+        // distinctUntilChanged() is load-bearing: the app-prefs DataStore emits on EVERY write to the
+        // store (theme, glance, economy edits, the EIA gas-price writer), so without it an unrelated
+        // write would re-run applyLanguage() and issue a redundant engine setLanguage() — possibly
+        // mid-utterance (same-value re-set is engine-dependent, not guaranteed inert).
         appScope.launch {
-            appPreferencesRepository.ttsLanguageTag.collect { tag ->
+            appPreferencesRepository.ttsLanguageTag.distinctUntilChanged().collect { tag ->
                 overrideTag = tag
                 applyLanguage()
             }

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
@@ -1,15 +1,20 @@
 package cloud.trotter.dashbuddy.state.effects
 
 import android.content.Context
+import android.content.res.Configuration
 import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
 import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
+import cloud.trotter.dashbuddy.domain.di.ApplicationScope
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicLong
@@ -20,6 +25,8 @@ import cloud.trotter.dashbuddy.domain.format.Formats
 @Singleton
 class TtsEffectHandler @Inject constructor(
     @param:ApplicationContext private val context: Context,
+    private val appPreferencesRepository: AppPreferencesRepository,
+    @param:ApplicationScope private val appScope: CoroutineScope,
 ) {
     private var tts: TextToSpeech? = null
 
@@ -29,6 +36,26 @@ class TtsEffectHandler @Inject constructor(
 
     @Volatile
     private var isReady = false
+
+    /**
+     * #428 Half B — the settings language override (BCP-47 tag; null ⇒ follow system locale),
+     * kept current by the reactive [AppPreferencesRepository.ttsLanguageTag] collector below.
+     */
+    @Volatile
+    private var overrideTag: String? = null
+
+    /**
+     * The locale actually installed on the engine (== the effective locale, or English if that was
+     * unavailable). The SPOKEN COPY is resolved through this exact locale so the words and the voice
+     * always match — a Spanish override changes both, and a fallback to an English voice also falls
+     * the words back to English.
+     */
+    @Volatile
+    private var spokenLocale: Locale = Locale.getDefault()
+
+    /** Edge-gate for the fallback WARN: only log when the unavailable target changes (never per
+     *  utterance). Guarded by [applyLanguage]'s lock. */
+    private var lastFallbackTag: String? = null
 
     private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
@@ -44,7 +71,6 @@ class TtsEffectHandler @Inject constructor(
     init {
         tts = TextToSpeech(context) { status ->
             if (status == TextToSpeech.SUCCESS) {
-                tts?.language = Locale.US
                 tts?.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
                     override fun onStart(utteranceId: String?) {}
                     override fun onDone(utteranceId: String?) {
@@ -60,10 +86,47 @@ class TtsEffectHandler @Inject constructor(
                     }
                 })
                 isReady = true
+                // #428 Half B: install the effective language now the engine is up (replaces the
+                // former unconditional Locale.US).
+                applyLanguage()
                 Timber.tag("Tts").i("engine initialized")
             } else {
                 Timber.tag("Tts").w("init failed with status %d", status)
             }
+        }
+        // Observe the override reactively so a settings change re-languages the live engine AND the
+        // spoken copy with no restart (Reactive UI / UDF: the pref is the single source of truth).
+        appScope.launch {
+            appPreferencesRepository.ttsLanguageTag.collect { tag ->
+                overrideTag = tag
+                applyLanguage()
+            }
+        }
+    }
+
+    /**
+     * Resolves the effective locale (override > system) and installs it on the engine, falling back
+     * to English (with ONE edge-gated WARN) if the requested language is unavailable / missing voice
+     * data — never a silent drop. No-ops until the engine is ready; the init callback re-runs it.
+     * Synchronized so the init callback and the pref collector can't interleave.
+     */
+    @Synchronized
+    private fun applyLanguage() {
+        val engine = tts ?: return
+        if (!isReady) return
+        val target = TtsLocale.effectiveLocale(overrideTag, Locale.getDefault())
+        val outcome = TtsLocale.applyLanguage(target) { engine.setLanguage(it) }
+        spokenLocale = outcome.applied
+        if (outcome.fellBack) {
+            val targetTag = target.toLanguageTag()
+            if (lastFallbackTag != targetTag) {
+                lastFallbackTag = targetTag
+                Timber.tag("Tts").w(
+                    "language %s unavailable — speaking English instead", targetTag
+                )
+            }
+        } else {
+            lastFallbackTag = null
         }
     }
 
@@ -91,11 +154,13 @@ class TtsEffectHandler @Inject constructor(
     }
 
     private fun formatEvaluation(eval: OfferEvaluation): String {
-        // #428 Half A: the verdict word + template connectives moved to strings.xml (string
-        // ownership, NOT locale-selected TTS — the engine still speaks Locale.US regardless of
-        // device locale; per-language reading is a separate, out-of-scope design issue).
-        // Formats.decimal(...) numeric formatting is unchanged — only the literal words moved.
-        val verdict = context.getString(
+        // #428 Half B: the verdict word + template connectives are resolved through the EFFECTIVE
+        // locale's resources (via a localized Context) so the settings override changes the words as
+        // well as the voice. Formats.decimal(...) numeric formatting is unchanged — the SSOT locale
+        // policy in :domain (#358/#456/#467) still owns number/money formatting; the es voice reads
+        // those digits.
+        val localized = localizedContext(spokenLocale)
+        val verdict = localized.getString(
             when (eval.action) {
                 OfferAction.ACCEPT -> R.string.tts_verdict_accept
                 OfferAction.DECLINE -> R.string.tts_verdict_decline
@@ -103,7 +168,7 @@ class TtsEffectHandler @Inject constructor(
                 else -> R.string.tts_verdict_offer
             }
         )
-        return context.getString(
+        return localized.getString(
             R.string.tts_offer_evaluation_template,
             verdict,
             eval.merchantName.trim(),
@@ -114,4 +179,11 @@ class TtsEffectHandler @Inject constructor(
         )
     }
 
+    /** A [Context] whose resources resolve against [locale] — so the spoken strings match the
+     *  engine voice regardless of the device default (#428 Half B). */
+    private fun localizedContext(locale: Locale): Context {
+        val config = Configuration(context.resources.configuration)
+        config.setLocale(locale)
+        return context.createConfigurationContext(config)
+    }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsLocale.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsLocale.kt
@@ -33,6 +33,15 @@ object TtsLocale {
      * (`LANG_MISSING_DATA` / `LANG_NOT_SUPPORTED`) means it is not, so we fall back to English
      * rather than silently dropping speech. If [target] is already English and even that fails,
      * there is nothing better to try — we report the fallback without a redundant second call.
+     *
+     * Two edges worth naming:
+     * - The English fallback's OWN [setLang] return is not checked: if English is also unavailable
+     *   (a doubly-broken engine) the engine keeps whatever language it last had, while the spoken
+     *   WORDS still switch to English via [ApplyOutcome.applied]. Rare, and the settings UI only
+     *   ever writes en/es/null, so a genuinely unresolvable target is not reachable from the UI.
+     * - A parseable-but-unavailable tag (valid BCP-47, no installed voice) falls back to ENGLISH
+     *   here — not to the system locale. Only an ill-formed/blank tag degrades to system, and that
+     *   happens earlier, in [effectiveLocale], before this function is reached.
      */
     fun applyLanguage(target: Locale, setLang: (Locale) -> Int): ApplyOutcome {
         if (setLang(target) >= TextToSpeech.LANG_AVAILABLE) {

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsLocale.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsLocale.kt
@@ -1,0 +1,47 @@
+package cloud.trotter.dashbuddy.state.effects
+
+import android.speech.tts.TextToSpeech
+import java.util.Locale
+
+/**
+ * Pure, engine-agnostic helpers for #428 Half B (multi-language offer reading). Kept out of
+ * [TtsEffectHandler] so the effective-locale resolution and the unavailable-language fallback
+ * are unit-testable without a live [TextToSpeech] instance (the engine is faked via a lambda).
+ */
+object TtsLocale {
+
+    /**
+     * Effective spoken-offer locale: the settings [overrideTag] (a BCP-47 tag such as `"es"`) wins
+     * when present and parseable, otherwise the [systemLocale]. A blank tag, or one
+     * [Locale.forLanguageTag] can't resolve to a real language, degrades to [systemLocale] — so a
+     * corrupt stored value never silences speech (fail-safe toward the system default).
+     */
+    fun effectiveLocale(overrideTag: String?, systemLocale: Locale): Locale {
+        val tag = overrideTag?.trim().orEmpty()
+        if (tag.isEmpty()) return systemLocale
+        val parsed = Locale.forLanguageTag(tag)
+        return if (parsed.language.isNullOrEmpty()) systemLocale else parsed
+    }
+
+    /** Outcome of applying a language to the engine — the locale actually installed, and whether we
+     *  had to fall back to English because the requested one was unavailable / missing voice data. */
+    data class ApplyOutcome(val applied: Locale, val fellBack: Boolean)
+
+    /**
+     * Applies [target] to the engine via [setLang] — the value of [TextToSpeech.setLanguage] for
+     * that locale. A code `>= LANG_AVAILABLE` (0) means the language is usable. A negative code
+     * (`LANG_MISSING_DATA` / `LANG_NOT_SUPPORTED`) means it is not, so we fall back to English
+     * rather than silently dropping speech. If [target] is already English and even that fails,
+     * there is nothing better to try — we report the fallback without a redundant second call.
+     */
+    fun applyLanguage(target: Locale, setLang: (Locale) -> Int): ApplyOutcome {
+        if (setLang(target) >= TextToSpeech.LANG_AVAILABLE) {
+            return ApplyOutcome(target, fellBack = false)
+        }
+        if (target.language.equals(Locale.ENGLISH.language, ignoreCase = true)) {
+            return ApplyOutcome(target, fellBack = true)
+        }
+        setLang(Locale.ENGLISH)
+        return ApplyOutcome(Locale.ENGLISH, fellBack = true)
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/GeneralSettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/GeneralSettingsScreen.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.ui.main.settings
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -19,10 +20,26 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented
 
 /**
- * General app settings. Currently just the driving / glance-mode toggle (#318); Theme and
- * Pro Mode land here later.
+ * The spoken-offer (TTS) language choices (#428 Half B). [tag] is the stored BCP-47 override
+ * (`null` ⇒ follow the system locale); [labelRes] is the row's option label. Kept here, not in
+ * `:domain`, because the tag↔label mapping is a UI concern.
+ */
+private enum class TtsLangOption(val tag: String?, val labelRes: Int) {
+    SYSTEM(null, R.string.tts_language_option_system),
+    ENGLISH("en", R.string.tts_language_option_english),
+    SPANISH("es", R.string.tts_language_option_spanish);
+
+    companion object {
+        fun fromTag(tag: String?): TtsLangOption = entries.firstOrNull { it.tag == tag } ?: SYSTEM
+    }
+}
+
+/**
+ * General app settings. The driving / glance-mode toggle (#318) and the spoken-offer language
+ * override (#428 Half B); Theme and Pro Mode land here later.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -31,6 +48,8 @@ fun GeneralSettingsScreen(
     viewModel: SettingsMenuViewModel = hiltViewModel()
 ) {
     val glanceMode by viewModel.glanceMode.collectAsStateWithLifecycle(initialValue = false)
+    // #428 Half B: reflect the persisted override reactively; null ⇒ System default.
+    val ttsLanguageTag by viewModel.ttsLanguageTag.collectAsStateWithLifecycle(initialValue = null)
 
     Scaffold(
         topBar = {
@@ -59,6 +78,37 @@ fun GeneralSettingsScreen(
                 subtitle = stringResource(R.string.general_settings_glance_mode_subtitle),
                 checked = glanceMode,
                 onCheckedChange = { viewModel.setGlanceMode(it) }
+            )
+
+            // --- Voice: spoken-offer language (#428 Half B) ---
+            Text(
+                stringResource(R.string.general_settings_section_voice),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(top = 24.dp, bottom = 4.dp)
+            )
+            Text(
+                stringResource(R.string.general_settings_tts_language_label),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                stringResource(R.string.general_settings_tts_language_subtitle),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            // Pair each option with its resolved label so selection maps back to the tag without
+            // re-matching localized text through a Context.
+            val labeledOptions = TtsLangOption.entries.map { it to stringResource(it.labelRes) }
+            val selectedOption = TtsLangOption.fromTag(ttsLanguageTag)
+            AppSegmented(
+                options = labeledOptions.map { it.second },
+                selected = labeledOptions.first { it.first == selectedOption }.second,
+                onSelect = { label ->
+                    val chosen = labeledOptions.first { it.second == label }.first
+                    viewModel.setTtsLanguage(chosen.tag)
+                },
+                modifier = Modifier.fillMaxWidth(),
             )
         }
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsMenuViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsMenuViewModel.kt
@@ -24,6 +24,8 @@ class SettingsMenuViewModel @Inject constructor(
     val isProMode = appPreferencesRepository.isProMode
     /** Driving / glance mode (#318) — surfaced on General settings. */
     val glanceMode = appPreferencesRepository.glanceMode
+    /** Spoken-offer language override (#428 Half B) — surfaced on General settings; null ⇒ system. */
+    val ttsLanguageTag = appPreferencesRepository.ttsLanguageTag
     /** Surfaced on Settings home so the Personal Economy nav row shows live $/mi. */
     val userEconomy = appPreferencesRepository.userEconomy
 
@@ -65,5 +67,10 @@ class SettingsMenuViewModel @Inject constructor(
 
     fun setGlanceMode(enabled: Boolean) = viewModelScope.launch {
         appPreferencesRepository.setGlanceMode(enabled)
+    }
+
+    /** #428 Half B — set (or clear, null ⇒ system) the spoken-offer language override. */
+    fun setTtsLanguage(tag: String?) = viewModelScope.launch {
+        appPreferencesRepository.setTtsLanguageTag(tag)
     }
 }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -13,5 +13,5 @@
     <string name="tts_verdict_review">Revisar</string>
     <string name="tts_verdict_offer">Oferta</string>
     <!-- %1$s verdict word, %2$s merchant name, %3$s $/hr, %4$s net pay, %5$s miles, %6$s score. -->
-    <string name="tts_offer_evaluation_template">%1$s. %2$s. %3$s dólares por hora neto. Neto %4$s, %5$s millas, puntuación %6$s.</string>
+    <string name="tts_offer_evaluation_template">%1$s. %2$s. %3$s dólares por hora netos. Neto %4$s, %5$s millas, puntuación %6$s.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  #428 Half B — Spanish spoken-offer (TTS) copy. Language-level (values-es) so every Spanish
+  region variant AND the "es" settings override resolve it (the existing values-es-rUS folder
+  keeps its own broader UI translations; Android merges per-string). Only the SPOKEN strings are
+  translated here — the app UI stays English-only by design (this feature localizes audio, not
+  the visual UI). The positional args (%1$s..%6$s) MUST match values/strings.xml exactly.
+-->
+<resources>
+    <!-- state/effects/TtsEffectHandler.kt — verdict words spoken before the economics. -->
+    <string name="tts_verdict_accept">Aceptar</string>
+    <string name="tts_verdict_decline">Rechazar</string>
+    <string name="tts_verdict_review">Revisar</string>
+    <string name="tts_verdict_offer">Oferta</string>
+    <!-- %1$s verdict word, %2$s merchant name, %3$s $/hr, %4$s net pay, %5$s miles, %6$s score. -->
+    <string name="tts_offer_evaluation_template">%1$s. %2$s. %3$s dólares por hora neto. Neto %4$s, %5$s millas, puntuación %6$s.</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,6 +173,15 @@
     <string name="general_settings_section_driving">Driving</string>
     <string name="general_settings_glance_mode_label">Driving glance mode</string>
     <string name="general_settings_glance_mode_subtitle">Larger HUD text while on a session</string>
+    <!-- Spoken-offer language (#428 Half B) — voice + words follow this. -->
+    <string name="general_settings_section_voice">Voice</string>
+    <string name="general_settings_tts_language_label">Spoken offer language</string>
+    <string name="general_settings_tts_language_subtitle">Language the offer read-aloud uses</string>
+    <!-- Language options. The option LABELS are translated; the endonym "Español" reads the same in
+         every locale. "System default" follows the phone's language. -->
+    <string name="tts_language_option_system">System default</string>
+    <string name="tts_language_option_english">English</string>
+    <string name="tts_language_option_spanish">Español</string>
 
     <!-- components/economy/EconomyAccordionRow.kt -->
     <string name="economy_accordion_content_desc_collapse">Collapse</string>
@@ -645,19 +654,22 @@
     <string name="evidence_settings_session_label">Save Session Summary</string>
     <string name="evidence_settings_session_subtitle">End of session earnings report</string>
 
-    <!-- #428 Half A: non-Compose copy routed through strings.xml (string ownership, NOT i18n —
-         the TTS engine still speaks the device-default voice; per-language reading is a
-         separate, out-of-scope design issue). -->
+    <!-- #428 Half A extracted the spoken copy to strings.xml; Half B makes it translatable —
+         the effective TTS locale (settings override > system) selects both the voice AND these
+         words via a localized Context (see TtsEffectHandler). See values-es for the Spanish set. -->
 
     <!-- state/effects/TtsEffectHandler.kt -->
-    <!-- Locale-locked by design: the TTS engine speaks Locale.US regardless of device locale
-         (see the in-code comment on TtsEffectHandler), so these are NOT translation candidates. -->
-    <string name="tts_verdict_accept" translatable="false">Accept</string>
-    <string name="tts_verdict_decline" translatable="false">Decline</string>
-    <string name="tts_verdict_review" translatable="false">Review</string>
-    <string name="tts_verdict_offer" translatable="false">Offer</string>
-    <!-- %1$s verdict word, %2$s merchant name, %3$s $/hr, %4$s net pay, %5$s miles, %6$s score -->
-    <string name="tts_offer_evaluation_template" translatable="false">%1$s. %2$s. %3$s dollars an hour net. Net %4$s, %5$s miles, score %6$s.</string>
+    <!-- Verdict words spoken before the economics. Translatable (#428 Half B). NOTE: these are the
+         SPOKEN verdict, unrelated to the RuleAction tap-label allowlists (button text) which stay
+         locale-anchored English by design. -->
+    <string name="tts_verdict_accept">Accept</string>
+    <string name="tts_verdict_decline">Decline</string>
+    <string name="tts_verdict_review">Review</string>
+    <string name="tts_verdict_offer">Offer</string>
+    <!-- %1$s verdict word, %2$s merchant name, %3$s $/hr, %4$s net pay, %5$s miles, %6$s score.
+         Translations MUST keep the same six positional args (a translated %-mismatch is the #719
+         HIGH-1 crash class). The merchant name and the numbers are runtime args — never translated. -->
+    <string name="tts_offer_evaluation_template">%1$s. %2$s. %3$s dollars an hour net. Net %4$s, %5$s miles, score %6$s.</string>
 
     <!-- state/effects/TipEffectHandler.kt -->
     <!-- %1$s tip amount, %2$s store name -->

--- a/app/src/test/java/cloud/trotter/dashbuddy/res/StringFormatArgConsistencyTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/res/StringFormatArgConsistencyTest.kt
@@ -40,10 +40,21 @@ class StringFormatArgConsistencyTest {
         val default = parse(File("src/main/res/values/strings.xml"))
         val es = parse(File("src/main/res/values-es/strings.xml"))
 
-        // The whole point of this PR's es file is the spoken-offer set — make sure it's actually here.
-        assertTrue(
-            "values-es should translate the spoken-offer template",
-            es.containsKey("tts_offer_evaluation_template"),
+        // Every spoken-offer string MUST be translated in values-es — a name present in default but
+        // MISSING from es would silently regress to the English word inside the Spanish voice, which
+        // the both-files positional-arg check below can't catch (it only compares shared names).
+        val requiredTtsNames = listOf(
+            "tts_verdict_accept",
+            "tts_verdict_decline",
+            "tts_verdict_review",
+            "tts_verdict_offer",
+            "tts_offer_evaluation_template",
+        )
+        val missing = requiredTtsNames.filter { it !in es }
+        assertEquals(
+            "values-es is missing spoken-offer translations (would speak English in the es voice): $missing",
+            emptyList<String>(),
+            missing,
         )
 
         val mismatches = es.keys

--- a/app/src/test/java/cloud/trotter/dashbuddy/res/StringFormatArgConsistencyTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/res/StringFormatArgConsistencyTest.kt
@@ -1,0 +1,70 @@
+package cloud.trotter.dashbuddy.res
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * #428 Half B — every localized string must carry the SAME positional format args as its default
+ * (`values/`) counterpart. A translated `%`-mismatch is the #719 HIGH-1 crash class
+ * (`getString(id, args)` throws at runtime when the arg indices don't line up), so this guards it
+ * at build time rather than on a device speaking Spanish. Focused on the spoken-offer (`tts_`)
+ * strings this PR translates, but it checks EVERY name present in both files.
+ *
+ * Runs as a plain JVM test — the module working dir is `app/`, so the res files are read directly.
+ */
+class StringFormatArgConsistencyTest {
+
+    // %1$s / %2$d / %3$f … — the positional format tokens Android's Resources.getString consumes.
+    private val positionalArg = Regex("""%(\d+)\$[a-zA-Z]""")
+
+    private data class Res(val name: String, val value: String)
+
+    private fun parse(file: File): Map<String, String> {
+        assertTrue("missing res file: ${file.absolutePath}", file.exists())
+        val text = file.readText()
+        // Grab <string name="x" ...>value</string>, tolerating extra attributes (translatable, etc).
+        val stringTag = Regex("""<string\s+name="([^"]+)"[^>]*>(.*?)</string>""", RegexOption.DOT_MATCHES_ALL)
+        return stringTag.findAll(text)
+            .map { Res(it.groupValues[1], it.groupValues[2]) }
+            .associate { it.name to it.value }
+    }
+
+    /** The multiset of positional arg indices in a value (e.g. "%1$s and %1$s, %2$d" → [1,1,2]). */
+    private fun argIndices(value: String): List<Int> =
+        positionalArg.findAll(value).map { it.groupValues[1].toInt() }.sorted().toList()
+
+    @Test
+    fun `es strings keep the default positional args`() {
+        val default = parse(File("src/main/res/values/strings.xml"))
+        val es = parse(File("src/main/res/values-es/strings.xml"))
+
+        // The whole point of this PR's es file is the spoken-offer set — make sure it's actually here.
+        assertTrue(
+            "values-es should translate the spoken-offer template",
+            es.containsKey("tts_offer_evaluation_template"),
+        )
+
+        val mismatches = es.keys
+            .filter { it in default }
+            .mapNotNull { name ->
+                val d = argIndices(default.getValue(name))
+                val t = argIndices(es.getValue(name))
+                if (d != t) "  $name: default=$d es=$t" else null
+            }
+        assertEquals(
+            "Positional format args drifted between values/ and values-es/ (crash risk, #719):\n" +
+                mismatches.joinToString("\n"),
+            emptyList<String>(),
+            mismatches,
+        )
+    }
+
+    @Test
+    fun `tts template still declares six args in the default locale`() {
+        val default = parse(File("src/main/res/values/strings.xml"))
+        val args = argIndices(default.getValue("tts_offer_evaluation_template"))
+        assertEquals(listOf(1, 2, 3, 4, 5, 6), args)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/TtsLocaleTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/TtsLocaleTest.kt
@@ -1,0 +1,99 @@
+package cloud.trotter.dashbuddy.state.effects
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * #428 Half B — the pure locale-resolution + unavailable-language fallback that drives the TTS
+ * engine. The engine is faked via a `(Locale) -> Int` lambda (the [android.speech.tts.TextToSpeech]
+ * setLanguage return code), so these run as plain JVM tests with no device.
+ */
+class TtsLocaleTest {
+
+    // --- effectiveLocale: override > system ---
+
+    @Test
+    fun `null override follows the system locale`() {
+        assertEquals(Locale.US, TtsLocale.effectiveLocale(overrideTag = null, systemLocale = Locale.US))
+    }
+
+    @Test
+    fun `blank override follows the system locale`() {
+        assertEquals(Locale.US, TtsLocale.effectiveLocale("   ", Locale.US))
+    }
+
+    @Test
+    fun `override wins over the system locale`() {
+        val eff = TtsLocale.effectiveLocale(overrideTag = "es", systemLocale = Locale.US)
+        assertEquals("es", eff.language)
+    }
+
+    @Test
+    fun `english override wins over a spanish system locale`() {
+        val eff = TtsLocale.effectiveLocale(overrideTag = "en", systemLocale = Locale.forLanguageTag("es"))
+        assertEquals("en", eff.language)
+    }
+
+    @Test
+    fun `ill-formed override degrades to the system locale`() {
+        // A tag Locale.forLanguageTag can't resolve to a real language must not silence speech.
+        assertEquals(Locale.US, TtsLocale.effectiveLocale("not a tag", Locale.US))
+    }
+
+    // --- applyLanguage: fallback to English on an unavailable language ---
+
+    @Test
+    fun `available language applies with no fallback`() {
+        val calls = mutableListOf<Locale>()
+        val target = Locale.forLanguageTag("es")
+        val outcome = TtsLocale.applyLanguage(target) { calls.add(it); 0 /* LANG_AVAILABLE */ }
+        assertEquals(target, outcome.applied)
+        assertFalse(outcome.fellBack)
+        assertEquals(listOf(target), calls)
+    }
+
+    @Test
+    fun `country-available code counts as usable`() {
+        val target = Locale.forLanguageTag("es")
+        val outcome = TtsLocale.applyLanguage(target) { 1 /* LANG_COUNTRY_AVAILABLE */ }
+        assertEquals(target, outcome.applied)
+        assertFalse(outcome.fellBack)
+    }
+
+    @Test
+    fun `missing voice data falls back to english`() {
+        val calls = mutableListOf<Locale>()
+        val target = Locale.forLanguageTag("es")
+        val outcome = TtsLocale.applyLanguage(target) { loc ->
+            calls.add(loc)
+            if (loc == target) -1 /* LANG_MISSING_DATA */ else 0
+        }
+        assertTrue(outcome.fellBack)
+        assertEquals(Locale.ENGLISH.language, outcome.applied.language)
+        // Tried the target first, then installed English.
+        assertEquals(target, calls.first())
+        assertTrue(calls.any { it == Locale.ENGLISH })
+    }
+
+    @Test
+    fun `unsupported language falls back to english`() {
+        val target = Locale.forLanguageTag("es")
+        val outcome = TtsLocale.applyLanguage(target) { loc ->
+            if (loc == target) -2 /* LANG_NOT_SUPPORTED */ else 0
+        }
+        assertTrue(outcome.fellBack)
+        assertEquals(Locale.ENGLISH.language, outcome.applied.language)
+    }
+
+    @Test
+    fun `english target that itself fails does not re-call the engine`() {
+        val calls = mutableListOf<Locale>()
+        val outcome = TtsLocale.applyLanguage(Locale.ENGLISH) { calls.add(it); -2 }
+        // Nothing better to fall back to — report the fallback, but only one attempt.
+        assertTrue(outcome.fellBack)
+        assertEquals(1, calls.size)
+    }
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
@@ -30,6 +30,8 @@ class AppPreferencesRepository @Inject constructor(
     val appTheme = dataSource.appTheme
     /** Driving / glance mode (#318) — the HUD honors this, the main app window never does. */
     val glanceMode = dataSource.glanceMode
+    /** Spoken-offer language override (#428 Half B); null ⇒ follow the system locale. */
+    val ttsLanguageTag = dataSource.ttsLanguageTag
 
     val fuelType: Flow<FuelType> = dataSource.fuelType.map { savedType ->
         try {
@@ -203,6 +205,13 @@ class AppPreferencesRepository @Inject constructor(
     suspend fun setProMode(enabled: Boolean) = dataSource.setProMode(enabled)
     suspend fun setTheme(theme: String) = dataSource.setTheme(theme)
     suspend fun setGlanceMode(enabled: Boolean) = dataSource.setGlanceMode(enabled)
+
+    /**
+     * #428 Half B — set (or clear, null) the spoken-offer language override (BCP-47 tag). Null
+     * follows the system locale. The [TtsEffectHandler] observes [ttsLanguageTag] reactively, so
+     * the change re-languages the live engine + spoken copy without a restart.
+     */
+    suspend fun setTtsLanguageTag(tag: String?) = dataSource.setTtsLanguageTag(tag)
 
     suspend fun updateEconomySettings(
         year: String, make: String, model: String, trim: String,

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSource.kt
@@ -33,6 +33,10 @@ class AppPreferencesDataSource @Inject constructor(
         val APP_THEME = stringPreferencesKey("app_theme")
         // Driving / glance mode (#318) — bumps the HUD's LocalGlance multiplier.
         val GLANCE_MODE = booleanPreferencesKey("glance_mode")
+        // Spoken-offer (TTS) language override (#428 Half B) — a BCP-47 tag (e.g. "es").
+        // Absent/null ⇒ follow the system locale; present ⇒ force that language for both the
+        // engine voice and the spoken word resolution.
+        val TTS_LANGUAGE_TAG = stringPreferencesKey("tts_language_tag")
         val FUEL_TYPE = stringPreferencesKey("fuel_type")
         // Legacy key (pre-v2 schema, "CAR"/"E_BIKE"). VEHICLE_CLASS supersedes it.
         val VEHICLE_TYPE = stringPreferencesKey("vehicle_type")
@@ -87,6 +91,8 @@ class AppPreferencesDataSource @Inject constructor(
     val isProMode: Flow<Boolean> = ds.data.map { it[Keys.IS_PRO_MODE] ?: false }
     val appTheme: Flow<String?> = ds.data.map { it[Keys.APP_THEME] }
     val glanceMode: Flow<Boolean> = ds.data.map { it[Keys.GLANCE_MODE] ?: false }
+    /** #428 Half B — spoken-offer language override (BCP-47 tag); null ⇒ follow system locale. */
+    val ttsLanguageTag: Flow<String?> = ds.data.map { it[Keys.TTS_LANGUAGE_TAG] }
     val fuelType: Flow<String?> = ds.data.map { it[Keys.FUEL_TYPE] }
     /**
      * Reads `vehicle_class` first; falls back to legacy `vehicle_type` (mapping
@@ -194,6 +200,16 @@ class AppPreferencesDataSource @Inject constructor(
 
     suspend fun setGlanceMode(enabled: Boolean) {
         ds.edit { it[Keys.GLANCE_MODE] = enabled }
+    }
+
+    /**
+     * #428 Half B — set (or clear) the spoken-offer language override. A non-null [tag] is a
+     * BCP-47 language tag (e.g. "es"); null clears the key so TTS falls back to the system locale.
+     */
+    suspend fun setTtsLanguageTag(tag: String?) {
+        ds.edit {
+            if (tag == null) it.remove(Keys.TTS_LANGUAGE_TAG) else it[Keys.TTS_LANGUAGE_TAG] = tag
+        }
     }
 
     suspend fun updateEconomySettings(

--- a/core/datastore/src/test/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSourceTest.kt
+++ b/core/datastore/src/test/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSourceTest.kt
@@ -84,4 +84,29 @@ class AppPreferencesDataSourceTest {
         assertEquals(3.61f, source.gasPrice.first())
         assertEquals(true, source.isGasPriceAuto.first())
     }
+
+    // #428 Half B — the spoken-offer language override.
+
+    @Test
+    fun `ttsLanguageTag defaults to null (follow system)`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val source = newSource(dispatcher, "prefs-tts1.preferences_pb")
+
+        assertEquals(null, source.ttsLanguageTag.first())
+    }
+
+    @Test
+    fun `setTtsLanguageTag round-trips and clears on null`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val source = newSource(dispatcher, "prefs-tts2.preferences_pb")
+
+        source.setTtsLanguageTag("es")
+        advanceUntilIdle()
+        assertEquals("es", source.ttsLanguageTag.first())
+
+        // null clears back to the system-locale default.
+        source.setTtsLanguageTag(null)
+        advanceUntilIdle()
+        assertEquals(null, source.ttsLanguageTag.first())
+    }
 }


### PR DESCRIPTION
Builds on Half A (PR #747, which moved the spoken copy into string resources). Closes the i18n half of #428.

## Scope

Spoken offer read-aloud (TTS) now speaks in the user's language. Default = the **system locale**; a **settings override** (System default / English / Español) forces a specific language for both the voice and the words. This is **spoken-audio localization only** — the visual Compose UI stays English-only by design (out of scope), as do the `RuleAction` tap-label allowlists (the D8 platform×locale table is separately tracked).

## Locale-resolution design

- **Preference:** `tts_language_tag: String?` in the single-concern **app-prefs** DataStore (`:core:datastore`, alongside theme/glance) — a BCP-47 tag; `null` ⇒ follow system. Repository passthrough + setter in `AppPreferencesRepository`.
- **Effective locale = override > system**, resolved by the pure `TtsLocale.effectiveLocale(overrideTag, systemLocale)`. A blank/ill-formed tag degrades to the system locale (fail-safe — a corrupt stored value never silences speech).
- **Reactive engine (UDF):** `TtsEffectHandler` collects the pref `Flow` on the app scope and re-applies the language to the live `TextToSpeech` engine on every change (and at engine init) — no read-once, no restart. The pref is the single source of truth.
- **Availability fail-safe:** `TtsLocale.applyLanguage` inspects `TextToSpeech.setLanguage`'s return code; a negative code (`LANG_MISSING_DATA`/`LANG_NOT_SUPPORTED`) falls back to English rather than dropping speech, and logs **one** edge-gated WARN per distinct unavailable target (not per utterance). The spoken **copy** falls back with the voice (English words for an English fallback voice — never Spanish words read by an English voice).
- **Words follow the voice:** the spoken strings are resolved through a **localized `Context`** (`createConfigurationContext` + `Configuration.setLocale(effectiveLocale)`), not the device default — so the override changes the words and the voice together.
- **`values-es`** carries the Spanish `tts_` set (verdict words + evaluation template) at **language level**, so every Spanish region variant and the `es` override resolve it (merging per-string with the pre-existing `values-es-rUS` UI translations). Positional args (`%1$s`..`%6$s`) kept byte-for-byte aligned with the default.

## Settings UI

Settings → General → **Voice → Spoken offer language**, an `AppSegmented` (System default / English / Español) that reflects the persisted pref reactively (`collectAsStateWithLifecycle`). A UI-layer `TtsLangOption` enum owns the tag↔label mapping.

## Translation-quality note

Verdict words: Accept→Aceptar, Decline→Rechazar, Review→Revisar, Offer→Oferta. Template: "%1$s. %2$s. %3$s dólares por hora netos. Neto %4$s, %5$s millas, puntuación %6$s." (plural agreement with *dólares*). Merchant name + all numbers are runtime args (never translated).

## Residuals

- **Voice-locale ≠ number-locale (not a Formats fork):** numbers stay on the `Formats` SSOT (`:domain`, #358/#456/#467). `Formats.locale` is `Locale.getDefault()`, so on a Spanish-*system* device the numbers already render `12,50` — the digits are locale-correct. The real residual is a **mismatch** case: system = es but override = **en** (or vice-versa) means the voice locale and the number-formatting locale disagree — e.g. an English voice reading a comma-decimal `12,50` may misvoice the comma as a thousands grouping. Aligning number formatting to the *effective TTS* locale (rather than the device default) would mean threading the effective locale into `Formats`, which is deliberately deferred — the SSOT is intentionally **not** forked.
- **Live system-locale change mid-process:** the effective locale re-reads `Locale.getDefault()` on each pref emission and at speak time via the applied locale, but a system-locale change while the process is alive (no config-driven recreation of the singleton) is not separately observed. Edge; a process restart picks it up.
- **`es`-only resource fallback:** `values-es` is language-level; a device on a Spanish variant with no override gets translated TTS via language matching (standard Android resolution).
- **Doubly-broken engine:** if even the English fallback voice is unavailable, the engine keeps its prior language while the words switch to English. Not reachable from the settings UI (only en/es/null are writable). Documented on `TtsLocale.applyLanguage`.

## Test plan

- `./gradlew testDebugUnitTest :domain:test` — green.
- `./gradlew :app:assembleDebug` — green (resource merge with `values-es` + format-string sanity).
- New: `TtsLocaleTest` (override>system, blank/ill-formed→system, available→no-fallback, missing-data/unsupported→English fallback, English-target-fails no double-call), `StringFormatArgConsistencyTest` (es args == default per name, #719 guard; template declares 6 args), `AppPreferencesDataSource` tts round-trip + null-clears-to-default.

## Security / privacy posture

No change to the trust boundary. No new PII surface — spoken text already named merchants (INFO logs carry counts only, unchanged). The new WARN is metadata-only (a BCP-47 tag + English fallback). No network. Formats SSOT untouched.

### Design-goal review

- **UDF (1):** engine language + spoken copy are driven by the pref `Flow` (state down); the settings row dispatches an intent up. No read-once.
- **MAD (2):** Kotlin/Compose/Flow/Hilt/DataStore; version catalog unaffected.
- **Single responsibility (3):** pure resolution/fallback extracted to `TtsLocale`; `TtsEffectHandler` keeps the engine edge. No file grew unreasonably.
- **SSOT (5):** the pref is the one owner of the choice; **`Formats` not forked** for numbers; the tts_ strings have one owner (default) + one translation (es), args guarded by a test.
- **Security/privacy (6):** stated above — no downgrade, no new PII, metadata-only WARN.
- **Semantic logging (7):** the fallback WARN is a defended-invariant edge (unavailable language), edge-gated, tagged `Tts`, PII-safe (tag string only). No bare `Timber` — tag-guard unaffected.
- **Platform-agnostic (8):** no platform literals; `Platform.sessionVerb`/merchant stay runtime args, never hardcoded into resources. Diff does not touch `:core:state`/`:core:pipeline`; no new rule↔state vocabulary.
- **Reactive UI:** the language row reflects the pref reactively; the value can't go stale under the dasher.

### Adversarial review

Fable adversarial pass: APPROVE-WITH-FIXES. Applied on `82992643`:
- **F1 (required):** `distinctUntilChanged()` on the pref collector — the shared app-prefs DataStore emits on every write, so unrelated writes no longer re-run `applyLanguage()`/`setLanguage()`.
- **F2 (required, doc):** residual note corrected — the real issue is voice-locale ≠ number-locale on a system/override mismatch, not ASCII pinning (`Formats.locale` is `Locale.getDefault()`). SSOT still not forked.
- **F3 (doc):** English-fallback edges documented on `TtsLocale.applyLanguage` (unchecked fallback return; parseable-but-unavailable → English, not system).
- **F4 (test):** `StringFormatArgConsistencyTest` now asserts all five `tts_` names exist in `values-es`.
- **F6 (polish):** `dólares por hora neto` → `netos`.
