### PR TITLE
feat(consent): #843 prompted per-capability automation consent — no auto-grant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,7 +300,8 @@ state into `AppEffect`s.
 runs the evaluation loopback (offer eval → `OfferEvaluationEvent` back into the machine), and owns
 the fail-closed action gates (#417): live `PermissionTierChecker` + the capability consent gate on
 automation-triggered `RuleAction`s (grant store: `RuleCapabilityRepository` over the
-`rule_capability_grants` DataStore; asset rules auto-grant at load).
+`rule_capability_grants` DataStore; **no auto-grant (#843)** — `reconcile` only publishes the
+enumeration, every capability lands *undecided* until the user opts in via the consent prompt).
 Handlers: `OdometerEffectHandler`, `ScreenShotHandler`, `TipEffectHandler`, `TtsEffectHandler`,
 `UiInteractionHandler` (package-scoped, label-verified `RuleAction` taps — the only path that ever
 clicks a third-party app, #425), `OfferActionReceiver` (notification Accept/Decline actions).
@@ -495,15 +496,21 @@ Every new feature or refactor holds to these — they are forefront design input
      taps are app-owned `RuleAction`s aimed by ruleset target bindings and verified at fire
      time (package scope + label allowlist + strict click); any failed check aborts to manual.
      Automation-initiated taps must additionally be covered by a granted, content-pinned
-     capability key (#417): rule loads enumerate capabilities and reconcile them into the
-     grant store *before* rules go live; bundled (asset) sources auto-grant, remote sources
-     never will. A dasher-pressed Accept/Decline is its own consent (integrity checks still
-     apply). The consent surface (#422 PR 3) — Settings → Data & Privacy → **Automation &
-     Consent** — lists each enumerated capability per ruleset source with Play-consistent
-     disclosure copy and a grant/revoke switch (`CapabilityConsentScreen`/`ViewModel`, writing
-     through `RuleCapabilityGrants.setGranted`); it is a consent *record*, never a second gate —
-     enforcement stays at the `PerformRuleAction` seam, and a revoke persists an explicit denial
-     so the next asset load can't silently re-grant it (fail-closed).
+     capability key (#417): rule loads enumerate capabilities and publish them to the grant
+     store *before* rules go live, but **grant NOTHING — there is no auto-grant (#843)**. Every
+     capability, bundled (asset) OR remote, lands *undecided* (three states: granted / denied /
+     undecided; only an explicit user act grants; the gate fires only on granted). Per Google
+     Play policy the user opts into EACH automation individually. A dasher-pressed Accept/Decline
+     is its own consent (integrity checks still apply). Consent is collected by a **prompt**
+     (`ConsentPromptSheet`, #843 — the app's front door, joining the a11y/notification permission
+     chain: fires on app foreground whenever `capabilities − granted − denied ≠ ∅`, one Allow /
+     Don't-allow row per undecided capability, no "allow all"; "Not now" defers, a denial is
+     durable) and reviewed/revoked in Settings → Data & Privacy → **Automation & Consent**
+     (`CapabilityConsentScreen`/`ViewModel`, writing through `RuleCapabilityGrants.setGranted`);
+     the settings screen is a consent *record*, never a second gate — enforcement stays at the
+     `PerformRuleAction` seam, and a denial persists so a later load can't silently re-grant it
+     (fail-closed). A one-shot schema migration (`RuleCapabilityDataSource`, #843) clears any
+     pre-#843 auto-granted keys on upgrade (denials preserved) so the prompt re-collects consent.
    When a change touches recognition, capture, network, or effects, state its security/privacy
    posture in the PR — what's trusted, what's gated, what's scrubbed.
 7. **Semantic, PII-safe logging.** Log levels carry *meaning*, not volume convenience, and the log is

--- a/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
@@ -53,6 +53,9 @@ class DashBuddyApplication : Application(), Configuration.Provider {
     lateinit var jsonRuleInterpreter: JsonRuleInterpreter
 
     @Inject
+    lateinit var ruleCapabilityRepository: cloud.trotter.dashbuddy.core.data.capability.RuleCapabilityRepository
+
+    @Inject
     lateinit var shadowStoreChainLogger: cloud.trotter.dashbuddy.state.shadow.ShadowStoreChainLogger
 
     @Inject
@@ -117,7 +120,17 @@ class DashBuddyApplication : Application(), Configuration.Provider {
         // 2. Compile the JSON rulesets off the main thread (#361): ~95KB of
         // parse+regex-compile work. The classifier tolerates a null ruleset
         // (classifies UNKNOWN) for the instants before the swap lands.
-        applicationScope.launch { jsonRuleInterpreter.loadDefaults() }
+        //
+        // First run the one-shot consent-schema migration (#843): clear any
+        // pre-#843 auto-granted capabilities (keep explicit denials) so nothing
+        // fires against a stale grant, THEN load the rules. Ordering it before
+        // loadDefaults means the reconcile publishes the enumeration into a
+        // store that already reflects the no-auto-grant policy; the consent
+        // prompt then collects fresh, explicit consent.
+        applicationScope.launch {
+            ruleCapabilityRepository.migrateConsentSchemaIfNeeded()
+            jsonRuleInterpreter.loadDefaults()
+        }
 
         // 3. Initialize State
         stateManagerV2.initialize()

--- a/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
@@ -127,6 +127,14 @@ class DashBuddyApplication : Application(), Configuration.Provider {
         // loadDefaults means the reconcile publishes the enumeration into a
         // store that already reflects the no-auto-grant policy; the consent
         // prompt then collects fresh, explicit consent.
+        //
+        // The sequencing is a LOAD-BEARING fail-closed coupling, not incidental:
+        // if the migration THROWS, loadDefaults must NOT run — rules going live
+        // over an un-migrated store could tap against a stale auto-grant. Do NOT
+        // wrap the migration in a try/catch to "let the rules load anyway": that
+        // silently re-opens the stale-grant window this migration exists to shut.
+        // A failed migration correctly leaves rules unloaded (the #432 gate keeps
+        // sensing fail-closed); the next launch retries the whole sequence.
         applicationScope.launch {
             ruleCapabilityRepository.migrateConsentSchemaIfNeeded()
             jsonRuleInterpreter.loadDefaults()

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
@@ -52,6 +52,7 @@ import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.ui.main.navigation.Screen
+import cloud.trotter.dashbuddy.ui.main.setup.consent.ConsentPromptSheet
 import cloud.trotter.dashbuddy.ui.main.setup.permissions.PermissionsBottomSheet
 import cloud.trotter.dashbuddy.util.PermissionUtils
 
@@ -85,6 +86,15 @@ fun DashboardScreen(
         PermissionsBottomSheet(
             onAllGranted = { showPermissionSheet = false }
         )
+    }
+
+    // Prompted automation consent (#843): once essential permissions are in, the
+    // app-foreground front door asks for per-capability automation consent — the
+    // same rhythm the permission sheet uses. Self-gating: renders nothing when no
+    // capability is undecided. Held back while the permission gate is up so the
+    // two sheets never stack.
+    if (hasPermissions == true && !showPermissionSheet) {
+        ConsentPromptSheet()
     }
 
     Scaffold(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/CapabilityConsentCopy.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/CapabilityConsentCopy.kt
@@ -1,0 +1,36 @@
+package cloud.trotter.dashbuddy.ui.main.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+
+/**
+ * App-owned disclosure copy for one automation [RuleAction], phrased in the
+ * platform app's name. SSOT shared by the settings consent record
+ * ([CapabilityConsentScreen]) and the consent PROMPT (#843) so both surfaces
+ * describe the same tap identically. Copy is always resolved from the app-owned
+ * [RuleAction] vocabulary — never from rule-supplied text (see
+ * `docs/design/rule-capability-consent.md`).
+ */
+data class CapabilityCopy(val title: String, val description: String)
+
+@Composable
+fun capabilityCopy(action: RuleAction, platformName: String): CapabilityCopy = when (action) {
+    RuleAction.ACCEPT_OFFER -> CapabilityCopy(
+        stringResource(R.string.consent_cap_accept_title),
+        stringResource(R.string.consent_cap_accept_desc, platformName),
+    )
+    RuleAction.DECLINE_OFFER -> CapabilityCopy(
+        stringResource(R.string.consent_cap_decline_title),
+        stringResource(R.string.consent_cap_decline_desc, platformName),
+    )
+    RuleAction.CONFIRM_DECLINE -> CapabilityCopy(
+        stringResource(R.string.consent_cap_confirm_decline_title),
+        stringResource(R.string.consent_cap_confirm_decline_desc, platformName),
+    )
+    RuleAction.EXPAND_EARNINGS -> CapabilityCopy(
+        stringResource(R.string.consent_cap_expand_title),
+        stringResource(R.string.consent_cap_expand_desc, platformName),
+    )
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/CapabilityConsentScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/CapabilityConsentScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cloud.trotter.dashbuddy.R
-import cloud.trotter.dashbuddy.domain.action.RuleAction
 import cloud.trotter.dashbuddy.domain.state.Platform
 
 /**
@@ -177,27 +176,4 @@ private fun ConsentSourceSection(
             }
         }
     }
-}
-
-/** App-owned disclosure copy for one action, in the platform app's name. */
-private data class CapabilityCopy(val title: String, val description: String)
-
-@Composable
-private fun capabilityCopy(action: RuleAction, platformName: String): CapabilityCopy = when (action) {
-    RuleAction.ACCEPT_OFFER -> CapabilityCopy(
-        stringResource(R.string.consent_cap_accept_title),
-        stringResource(R.string.consent_cap_accept_desc, platformName),
-    )
-    RuleAction.DECLINE_OFFER -> CapabilityCopy(
-        stringResource(R.string.consent_cap_decline_title),
-        stringResource(R.string.consent_cap_decline_desc, platformName),
-    )
-    RuleAction.CONFIRM_DECLINE -> CapabilityCopy(
-        stringResource(R.string.consent_cap_confirm_decline_title),
-        stringResource(R.string.consent_cap_confirm_decline_desc, platformName),
-    )
-    RuleAction.EXPAND_EARNINGS -> CapabilityCopy(
-        stringResource(R.string.consent_cap_expand_title),
-        stringResource(R.string.consent_cap_expand_desc, platformName),
-    )
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/CapabilityConsentViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/CapabilityConsentViewModel.kt
@@ -58,9 +58,10 @@ data class ConsentSourceGroup(
     /** The platform whose rules this source carries — display only. */
     val platform: Platform,
     /**
-     * True for a bundled (asset) source — auto-granted by default (#417). False
-     * for a downloaded (CDN/fork) source, which is never auto-granted: its
-     * capabilities render pending until the user turns each on here.
+     * True for a bundled (asset) source — shipped inside the APK. Since #843
+     * killed auto-grant this is display-only provenance: bundled and downloaded
+     * sources are BOTH off until the user turns each on (here or via the consent
+     * prompt). It only selects the header/note copy ("built-in" vs "downloaded").
      */
     val isBundled: Boolean,
     val capabilities: List<ConsentCapabilityRow>,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/consent/ConsentPromptSheet.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/consent/ConsentPromptSheet.kt
@@ -1,0 +1,167 @@
+package cloud.trotter.dashbuddy.ui.main.setup.consent
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.Button
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.ui.main.settings.capabilityCopy
+
+/**
+ * Prompted per-capability automation consent (#843). A modal sheet at the app's
+ * front door listing every *undecided* automation as its own row — name,
+ * plain-language behavioral disclosure, source, and an individual Allow /
+ * Don't-allow choice. There is NO "allow all" button (Play policy: each
+ * automation individually). "Not now" defers the whole sheet — undecided stays
+ * undecided, re-prompt next foreground; a "Don't allow" persists a durable
+ * denial that never re-prompts. Answers write THROUGH the grant store the
+ * fail-closed engine gate reads (#417); this sheet is an acquisition surface,
+ * never a second gate.
+ *
+ * Rendered by the dashboard (the start destination) once essential permissions
+ * are satisfied — the same app-foreground rhythm the permission sheet uses.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ConsentPromptSheet(
+    viewModel: ConsentPromptViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // "Not now" defers for THIS foreground only; ON_RESUME re-arms so the sheet
+    // returns on the next app-foreground while anything stays undecided.
+    var deferred by remember { mutableStateOf(false) }
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { deferred = false }
+
+    // Trigger predicate: any undecided capability AND the user hasn't deferred.
+    if (uiState.rows.isEmpty() || deferred) return
+
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val bottomPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+
+    ModalBottomSheet(
+        // Scrim/back = "Not now" (defer), consistent with the per-row button.
+        onDismissRequest = { deferred = true },
+        sheetState = sheetState,
+        modifier = Modifier.padding(bottom = bottomPadding),
+    ) {
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.consent_prompt_heading),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.consent_prompt_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(16.dp))
+
+            uiState.rows.forEach { row ->
+                HorizontalDivider()
+                ConsentPromptRowView(
+                    row = row,
+                    onDecision = viewModel::onDecision,
+                )
+            }
+            HorizontalDivider()
+
+            Spacer(Modifier.height(16.dp))
+            TextButton(
+                onClick = { deferred = true },
+                modifier = Modifier.fillMaxWidth(),
+            ) { Text(stringResource(R.string.consent_prompt_not_now)) }
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun ConsentPromptRowView(
+    row: ConsentPromptRow,
+    onDecision: (key: String, allow: Boolean) -> Unit,
+) {
+    val platformName = row.platform
+        .takeIf { it != Platform.Unknown }
+        ?.displayName
+        ?: stringResource(R.string.consent_platform_unknown)
+
+    val copy = capabilityCopy(row.action, platformName)
+    val sourceLabel = if (row.isBundled) {
+        stringResource(R.string.consent_prompt_source_bundled_format, platformName)
+    } else {
+        stringResource(R.string.consent_prompt_source_downloaded_format, platformName)
+    }
+
+    Column(Modifier.fillMaxWidth().padding(vertical = 12.dp)) {
+        Text(
+            text = copy.title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(Modifier.height(2.dp))
+        Text(
+            text = sourceLabel,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = copy.description,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(10.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            OutlinedButton(
+                onClick = { onDecision(row.key, false) },
+                modifier = Modifier.weight(1f),
+            ) { Text(stringResource(R.string.consent_prompt_deny)) }
+            Button(
+                onClick = { onDecision(row.key, true) },
+                modifier = Modifier.weight(1f),
+            ) { Text(stringResource(R.string.consent_prompt_allow)) }
+        }
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/consent/ConsentPromptSheet.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/consent/ConsentPromptSheet.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -61,7 +61,10 @@ fun ConsentPromptSheet(
 
     // "Not now" defers for THIS foreground only; ON_RESUME re-arms so the sheet
     // returns on the next app-foreground while anything stays undecided.
-    var deferred by remember { mutableStateOf(false) }
+    // rememberSaveable, not remember: a rotation / process-death / nav-return
+    // within the same foreground must NOT re-show the modal the user just
+    // deferred — that is the exact fatigue the deferral exists to prevent (F1).
+    var deferred by rememberSaveable { mutableStateOf(false) }
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { deferred = false }
 
     // Trigger predicate: any undecided capability AND the user hasn't deferred.

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/consent/ConsentPromptViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/consent/ConsentPromptViewModel.kt
@@ -1,0 +1,102 @@
+package cloud.trotter.dashbuddy.ui.main.setup.consent
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.capability.RuleCapability
+import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
+import cloud.trotter.dashbuddy.domain.state.Platform
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Drives the prompted per-capability consent sheet (#843): the app's front-door
+ * acquisition surface for automation consent, joining the a11y/notification
+ * permission chain rather than hiding in a settings menu. It lists ONLY the
+ * *undecided* capabilities — enumerated by a loaded ruleset but neither granted
+ * nor denied — one row each, so the user opts into EACH automation individually
+ * (Google Play policy). State flows down as [ConsentPromptUiState] (UDF); the
+ * only write is [onDecision], routing THROUGH [RuleCapabilityGrants] — the same
+ * grant store the fail-closed engine gate (#417) reads at fire time. This is an
+ * acquisition surface, never a second enforcement point.
+ */
+@HiltViewModel
+class ConsentPromptViewModel @Inject constructor(
+    private val grants: RuleCapabilityGrants,
+) : ViewModel() {
+
+    val uiState: StateFlow<ConsentPromptUiState> =
+        combine(
+            grants.capabilities,
+            grants.grantedKeys,
+            grants.deniedKeys,
+        ) { capabilities, granted, denied ->
+            buildConsentPromptState(capabilities, granted, denied)
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = ConsentPromptUiState(),
+        )
+
+    /**
+     * Record the user's per-row decision: Allow ⇒ grant, Don't allow ⇒ a durable
+     * denial. Either answer removes the row from [uiState] reactively (both leave
+     * the undecided set). "Not now" is NOT a decision — it defers the whole sheet
+     * (composable-local), leaving the capability undecided to re-prompt next
+     * foreground.
+     */
+    fun onDecision(key: String, allow: Boolean) {
+        viewModelScope.launch { grants.setGranted(key, allow) }
+    }
+}
+
+/** Immutable per-screen state (UDF). Empty [rows] ⇒ nothing to ask, sheet stays closed. */
+data class ConsentPromptUiState(
+    val rows: List<ConsentPromptRow> = emptyList(),
+)
+
+/** One undecided capability the user must Allow or Don't-allow. */
+data class ConsentPromptRow(
+    /** The grant key — the write target for [ConsentPromptViewModel.onDecision]. */
+    val key: String,
+    /** The app-owned action; the composable maps it to disclosure copy. */
+    val action: RuleAction,
+    /** The platform whose rules enable this — display only (copy + source label). */
+    val platform: Platform,
+    /** True for a bundled (asset) source — selects the "Built-in" source label. */
+    val isBundled: Boolean,
+)
+
+/**
+ * The prompt-trigger projection (pure, testable without Android): the undecided
+ * set is `capabilities − granted − denied`. A capability is undecided when its
+ * content-pinned [RuleCapability.key] is in neither the granted nor the denied
+ * set. One row per undecided key ([distinctBy] guards a rare duplicate key
+ * across sources), deterministically ordered (action then rule id) so the sheet
+ * never reshuffles between recompositions. Empty rows ⇒ the trigger predicate is
+ * false and the sheet stays closed.
+ */
+fun buildConsentPromptState(
+    capabilities: List<RuleCapability>,
+    grantedKeys: Set<String>,
+    deniedKeys: Set<String>,
+): ConsentPromptUiState {
+    val rows = capabilities
+        .filter { it.key !in grantedKeys && it.key !in deniedKeys }
+        .distinctBy { it.key }
+        .sortedWith(compareBy({ it.action.ordinal }, { it.ruleId }))
+        .map { cap ->
+            ConsentPromptRow(
+                key = cap.key,
+                action = cap.action,
+                platform = Platform.fromRuleId(cap.ruleId),
+                isBundled = cap.source.startsWith(RuleCapabilityGrants.ASSET_SOURCE_PREFIX),
+            )
+        }
+    return ConsentPromptUiState(rows = rows)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,16 +245,25 @@
     <string name="data_export_log_success_format">Exported dashbuddy-log.txt — %1$d line(s) were auto-scrubbed.</string>
     <string name="data_export_log_error_format">Log export failed: %1$s</string>
 
-    <!-- settings/CapabilityConsentScreen.kt (#422) — Google-Play-consistent automation disclosure -->
+    <!-- settings/CapabilityConsentScreen.kt (#422/#843) — Google-Play-consistent automation record -->
     <string name="consent_title">Automation &amp; Consent</string>
-    <string name="consent_disclosure_heading">How DashBuddy uses the Accessibility service</string>
-    <string name="consent_disclosure_body">DashBuddy uses Android\'s Accessibility service to read the screens of the delivery apps you turn on, so it can recognize offers, pickups, and deliveries. This recognition runs entirely on your phone.\n\nDashBuddy can also tap buttons in a delivery app for you — but only the specific actions you allow below, only inside that delivery app, and only on a button whose label matches the action — except the icon-only pay-details arrow, which is verified by app boundary only. Accept and Decline taps fire when you press the button in DashBuddy or when you have armed that automation. Actions bundled with DashBuddy start on — the pay-details tap runs whenever a completed delivery\'s pay breakdown is collapsed. Turn any action off below and DashBuddy will not tap it — you do it manually.</string>
+    <string name="consent_disclosure_heading">Review or change what DashBuddy is allowed to tap</string>
+    <string name="consent_disclosure_body">DashBuddy uses Android\'s Accessibility service to read the screens of the delivery apps you turn on, so it can recognize offers, pickups, and deliveries. This recognition runs entirely on your phone.\n\nDashBuddy can also tap buttons in a delivery app for you — but only the specific actions you allow, only inside that delivery app, and only on a button whose label matches the action (except the icon-only pay-details arrow, which is verified by app boundary only). Nothing is turned on for you: each action below stays off until you allow it, and DashBuddy asks you the first time it can offer one. Turn any action off and DashBuddy will not tap it — you do it manually.</string>
     <string name="consent_empty">No automation actions are available yet. They appear here once your delivery-app rules load and a rule enables an action such as Accept or Decline.</string>
     <string name="consent_platform_unknown">Delivery app</string>
-    <string name="consent_source_bundled_format">%1$s · bundled with DashBuddy</string>
-    <string name="consent_source_bundled_note">These automation rules ship inside the app and are on by default. Turn any off to require a manual tap instead.</string>
+    <string name="consent_source_bundled_format">%1$s · built-in rules</string>
+    <string name="consent_source_bundled_note">These automations ship inside the app. None are turned on for you — each stays off until you allow it.</string>
     <string name="consent_source_downloaded_format">%1$s · downloaded rules</string>
     <string name="consent_source_downloaded_note">Downloaded rules are never turned on automatically. Each action stays off until you turn it on here.</string>
+
+    <!-- setup/consent/ConsentPromptSheet.kt (#843) — prompted per-capability consent -->
+    <string name="consent_prompt_heading">Allow DashBuddy to tap for you?</string>
+    <string name="consent_prompt_body">Your delivery-app rules can automate these taps. Nothing is turned on until you allow it — choose each one individually, or tap \"Not now\" to decide later.</string>
+    <string name="consent_prompt_source_bundled_format">Built-in %1$s rules</string>
+    <string name="consent_prompt_source_downloaded_format">Downloaded %1$s rules</string>
+    <string name="consent_prompt_allow">Allow</string>
+    <string name="consent_prompt_deny">Don\'t allow</string>
+    <string name="consent_prompt_not_now">Not now</string>
     <string name="consent_cap_accept_title">Accept offers</string>
     <string name="consent_cap_accept_desc">Lets DashBuddy tap the Accept button in the %1$s app for you — when you press Accept in DashBuddy, or when you have armed auto-accept. It only taps a button labeled \"Accept\" inside the %1$s app, and never without your go-ahead.</string>
     <string name="consent_cap_decline_title">Decline offers</string>

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/settings/CapabilityConsentViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/settings/CapabilityConsentViewModelTest.kt
@@ -35,13 +35,16 @@ class CapabilityConsentViewModelTest {
     private class FakeGrants : RuleCapabilityGrants {
         private val _capabilities = MutableStateFlow<List<RuleCapability>>(emptyList())
         private val _granted = MutableStateFlow<Set<String>>(emptySet())
+        private val _denied = MutableStateFlow<Set<String>>(emptySet())
         override val capabilities: StateFlow<List<RuleCapability>> = _capabilities
         override val grantedKeys: StateFlow<Set<String>> = _granted
+        override val deniedKeys: StateFlow<Set<String>> = _denied
 
         val setGrantedCalls = mutableListOf<Pair<String, Boolean>>()
 
         fun setEnumeration(caps: List<RuleCapability>) { _capabilities.value = caps }
         fun setGrantedKeys(keys: Set<String>) { _granted.value = keys }
+        fun setDeniedKeys(keys: Set<String>) { _denied.value = keys }
 
         override suspend fun reconcile(capabilities: List<RuleCapability>) = error("unused")
         override suspend fun isActionGranted(ruleId: String?, action: RuleAction) = error("unused")
@@ -49,7 +52,13 @@ class CapabilityConsentViewModelTest {
         override suspend fun setGranted(key: String, granted: Boolean) {
             setGrantedCalls += key to granted
             // Mirror the real store so the UI reflects the change reactively.
-            _granted.value = if (granted) _granted.value + key else _granted.value - key
+            if (granted) {
+                _granted.value = _granted.value + key
+                _denied.value = _denied.value - key
+            } else {
+                _granted.value = _granted.value - key
+                _denied.value = _denied.value + key
+            }
         }
     }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/setup/consent/ConsentPromptViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/setup/consent/ConsentPromptViewModelTest.kt
@@ -1,0 +1,194 @@
+package cloud.trotter.dashbuddy.ui.main.setup.consent
+
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.capability.RuleCapability
+import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * #843 — the prompted per-capability consent surface. Covers the pure trigger
+ * projection ([buildConsentPromptState]: undecided = capabilities − granted −
+ * denied, deterministic order, distinct keys) and that the ViewModel's only
+ * write routes THROUGH [RuleCapabilityGrants] with the correct Allow/Don't-allow
+ * boolean, removing the answered row reactively. The fake records the write; it
+ * never becomes a second gate.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConsentPromptViewModelTest {
+
+    /** In-memory [RuleCapabilityGrants] — enumeration + granted/denied drivable, writes recorded. */
+    private class FakeGrants : RuleCapabilityGrants {
+        private val _capabilities = MutableStateFlow<List<RuleCapability>>(emptyList())
+        private val _granted = MutableStateFlow<Set<String>>(emptySet())
+        private val _denied = MutableStateFlow<Set<String>>(emptySet())
+        override val capabilities: StateFlow<List<RuleCapability>> = _capabilities
+        override val grantedKeys: StateFlow<Set<String>> = _granted
+        override val deniedKeys: StateFlow<Set<String>> = _denied
+
+        val setGrantedCalls = mutableListOf<Pair<String, Boolean>>()
+
+        fun setEnumeration(caps: List<RuleCapability>) { _capabilities.value = caps }
+
+        override suspend fun reconcile(capabilities: List<RuleCapability>) = error("unused")
+        override suspend fun isActionGranted(ruleId: String?, action: RuleAction) = error("unused")
+
+        override suspend fun setGranted(key: String, granted: Boolean) {
+            setGrantedCalls += key to granted
+            if (granted) {
+                _granted.value = _granted.value + key
+                _denied.value = _denied.value - key
+            } else {
+                _granted.value = _granted.value - key
+                _denied.value = _denied.value + key
+            }
+        }
+    }
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @Before fun setUp() = Dispatchers.setMain(dispatcher)
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    private fun cap(
+        key: String,
+        ruleId: String,
+        action: RuleAction,
+        source: String = "asset:rules/doordash.json",
+    ) = RuleCapability(
+        ruleId = ruleId,
+        action = action,
+        targetBindName = action.targetBindName,
+        key = key,
+        source = source,
+    )
+
+    // =========================================================================
+    // buildConsentPromptState — the pure trigger projection
+    // =========================================================================
+
+    @Test
+    fun `only undecided capabilities become rows`() {
+        val state = buildConsentPromptState(
+            capabilities = listOf(
+                cap("granted-k", "doordash.screen.offer_popup", RuleAction.ACCEPT_OFFER),
+                cap("denied-k", "doordash.screen.offer_popup", RuleAction.DECLINE_OFFER),
+                cap("undecided-k", "doordash.screen.delivery_summary_collapsed", RuleAction.EXPAND_EARNINGS),
+            ),
+            grantedKeys = setOf("granted-k"),
+            deniedKeys = setOf("denied-k"),
+        )
+
+        assertEquals(1, state.rows.size)
+        assertEquals("undecided-k", state.rows[0].key)
+        assertEquals(RuleAction.EXPAND_EARNINGS, state.rows[0].action)
+        assertEquals(Platform.DoorDash, state.rows[0].platform)
+        assertTrue(state.rows[0].isBundled)
+    }
+
+    @Test
+    fun `all-decided yields no rows - the trigger predicate is false`() {
+        val state = buildConsentPromptState(
+            capabilities = listOf(
+                cap("a", "doordash.screen.offer_popup", RuleAction.ACCEPT_OFFER),
+                cap("b", "doordash.screen.offer_popup", RuleAction.DECLINE_OFFER),
+            ),
+            grantedKeys = setOf("a"),
+            deniedKeys = setOf("b"),
+        )
+        assertTrue(state.rows.isEmpty())
+    }
+
+    @Test
+    fun `rows are deterministically ordered by action then rule id`() {
+        val state = buildConsentPromptState(
+            capabilities = listOf(
+                cap("decline-k", "doordash.screen.offer_popup", RuleAction.DECLINE_OFFER),
+                cap("accept-k", "doordash.screen.offer_popup", RuleAction.ACCEPT_OFFER),
+            ),
+            grantedKeys = emptySet(),
+            deniedKeys = emptySet(),
+        )
+        // ACCEPT_OFFER (ordinal 0) before DECLINE_OFFER (ordinal 1).
+        assertEquals(RuleAction.ACCEPT_OFFER, state.rows[0].action)
+        assertEquals(RuleAction.DECLINE_OFFER, state.rows[1].action)
+    }
+
+    @Test
+    fun `a duplicate key across sources yields a single row`() {
+        val state = buildConsentPromptState(
+            capabilities = listOf(
+                cap("dupe", "doordash.screen.offer_popup", RuleAction.ACCEPT_OFFER, "asset:rules/doordash.json"),
+                cap("dupe", "doordash.screen.offer_popup", RuleAction.ACCEPT_OFFER, "cdn:https://x/doordash.json"),
+            ),
+            grantedKeys = emptySet(),
+            deniedKeys = emptySet(),
+        )
+        assertEquals(1, state.rows.size)
+    }
+
+    // =========================================================================
+    // ViewModel — reactive state + write routing
+    // =========================================================================
+
+    @Test
+    fun `uiState lists only undecided rows reactively`() = runTest {
+        val grants = FakeGrants()
+        grants.setEnumeration(
+            listOf(cap("k1", "doordash.screen.offer_popup", RuleAction.ACCEPT_OFFER)),
+        )
+        val vm = ConsentPromptViewModel(grants)
+
+        val state = vm.uiState.first { it.rows.isNotEmpty() }
+        assertEquals(1, state.rows.size)
+        assertEquals("k1", state.rows[0].key)
+    }
+
+    @Test
+    fun `Allow routes a grant through the store and drops the row`() = runTest {
+        val grants = FakeGrants()
+        grants.setEnumeration(
+            listOf(cap("k1", "doordash.screen.offer_popup", RuleAction.ACCEPT_OFFER)),
+        )
+        val vm = ConsentPromptViewModel(grants)
+        vm.uiState.first { it.rows.isNotEmpty() }
+
+        vm.onDecision("k1", true)
+
+        assertEquals(listOf("k1" to true), grants.setGrantedCalls)
+        // Granting removes it from the undecided set → row disappears.
+        assertTrue(vm.uiState.first().rows.isEmpty())
+    }
+
+    @Test
+    fun `Don't allow routes a denial through the store and drops the row`() = runTest {
+        val grants = FakeGrants()
+        grants.setEnumeration(
+            listOf(cap("k1", "doordash.screen.offer_popup", RuleAction.ACCEPT_OFFER)),
+        )
+        val vm = ConsentPromptViewModel(grants)
+        vm.uiState.first { it.rows.isNotEmpty() }
+
+        vm.onDecision("k1", false)
+
+        assertEquals(listOf("k1" to false), grants.setGrantedCalls)
+        assertFalse(grants.grantedKeys.value.contains("k1"))
+        assertTrue(grants.deniedKeys.value.contains("k1"))
+        // A denial also leaves the undecided set → row disappears (never re-prompts).
+        assertTrue(vm.uiState.first().rows.isEmpty())
+    }
+}

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -58,4 +58,9 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.kotlinx.coroutines.test)
+    // #843 — RuleCapabilityRepositoryTest drives a real Preferences DataStore
+    // (reconcile-never-grants / undecided-never-fires / migration). :core:datastore
+    // depends on datastore-preferences via `implementation`, so it is not on this
+    // module's test classpath transitively — declare it here.
+    testImplementation(libs.androidx.datastore.preferences)
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityRepository.kt
@@ -48,15 +48,38 @@ class RuleCapabilityRepository @Inject constructor(
     override val grantedKeys: StateFlow<Set<String>> = dataSource.granted
         .stateIn(scope, SharingStarted.Eagerly, emptySet())
 
+    override val deniedKeys: StateFlow<Set<String>> = dataSource.denied
+        .stateIn(scope, SharingStarted.Eagerly, emptySet())
+
     override suspend fun reconcile(capabilities: List<RuleCapability>) {
+        // Publish the enumeration ONLY — grants NOTHING (#843). Bundled and
+        // remote sources are enumerated identically; every capability lands
+        // undecided until the user opts in through the consent prompt. The
+        // fire-time gate stays fail-closed for anything not in the granted set,
+        // so leaving the persisted store untouched here is the whole point.
         enumerated.value = capabilities
-        dataSource.update { granted, denied ->
-            (granted + autoGrantSelection(capabilities, denied)) to denied
-        }
         Timber.tag(TAG).i(
-            "reconciled %d capabilit(ies) from rule load",
+            "reconciled %d capabilit(ies) from rule load (none granted — awaiting consent)",
             capabilities.size,
         )
+    }
+
+    /**
+     * One-shot consent-schema migration (#843), delegated to the persisted
+     * store. The single-user alpha upgrade path: clear any pre-#843
+     * auto-granted keys, keep explicit denials, stamp the version marker so it
+     * runs once. Called at app startup BEFORE the rulesets go live, so no
+     * automation can fire against a stale grant. See
+     * [RuleCapabilityDataSource.migrateConsentSchemaIfNeeded].
+     */
+    suspend fun migrateConsentSchemaIfNeeded() {
+        if (dataSource.migrateConsentSchemaIfNeeded()) {
+            // INFO milestone — PII-safe (no keys, just a count-free status).
+            Timber.tag(TAG).i(
+                "consent-schema migration ran: cleared auto-granted capabilities; " +
+                    "denials preserved; automation stays off until re-consented (#843)",
+            )
+        }
     }
 
     override suspend fun setGranted(key: String, granted: Boolean) {
@@ -92,28 +115,13 @@ class RuleCapabilityRepository @Inject constructor(
 }
 
 /**
- * Auto-grant policy (#417/#422): bundled (asset-source) capabilities are
- * granted on load so the single-user alpha has zero consent friction; any
- * other source (CDN/fork — #192) is NEVER auto-granted and stays pending
- * until the user approves it. An explicitly denied key is excluded — a
- * revocation must not be silently undone by the next rule load.
- *
- * Pure and top-level so policy is testable without Android.
- */
-fun autoGrantSelection(capabilities: List<RuleCapability>, denied: Set<String>): Set<String> =
-    capabilities.asSequence()
-        .filter { it.source.startsWith(RuleCapabilityGrants.ASSET_SOURCE_PREFIX) }
-        .map { it.key }
-        .filterNot { it in denied }
-        .toSet()
-
-/**
- * Consent grant/revoke set transform (#422 PR 3), pure and top-level so it is
- * testable without DataStore. Granting a [key] adds it to [granted] and clears
- * any prior denial; **revoking persists an explicit denial** so the next rule
- * load's asset auto-grant ([autoGrantSelection] excludes denied keys) cannot
- * silently re-grant it. Returns the new (granted, denied) pair for one atomic
- * [RuleCapabilityDataSource.update].
+ * Consent grant/revoke set transform (#422 PR 3 / #843), pure and top-level so
+ * it is testable without DataStore. Granting a [key] adds it to [granted] and
+ * clears any prior denial; **denying persists an explicit denial** so the
+ * capability leaves "undecided" and the consent prompt never re-asks (a denial
+ * is durable, not a deferral). Since #843 killed auto-grant, granting here is
+ * the ONLY way a key enters [granted]. Returns the new (granted, denied) pair
+ * for one atomic [RuleCapabilityDataSource.update].
  */
 fun applyGrantChange(
     key: String,

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityRepository.kt
@@ -73,7 +73,12 @@ class RuleCapabilityRepository @Inject constructor(
      * [RuleCapabilityDataSource.migrateConsentSchemaIfNeeded].
      */
     suspend fun migrateConsentSchemaIfNeeded() {
-        if (dataSource.migrateConsentSchemaIfNeeded()) {
+        // Snapshot BEFORE the migration so the INFO line reflects reality: a fresh
+        // install stamps the marker (ran == true) but had nothing to clear, and a
+        // misleading "cleared auto-granted capabilities" would then pollute the
+        // shareable log every first launch. Only log when real grants were cleared.
+        val hadGrants = dataSource.granted.first().isNotEmpty()
+        if (dataSource.migrateConsentSchemaIfNeeded() && hadGrants) {
             // INFO milestone — PII-safe (no keys, just a count-free status).
             Timber.tag(TAG).i(
                 "consent-schema migration ran: cleared auto-granted capabilities; " +

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityPolicyTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityPolicyTest.kt
@@ -1,66 +1,17 @@
 package cloud.trotter.dashbuddy.core.data.capability
 
-import cloud.trotter.dashbuddy.domain.action.RuleAction
-import cloud.trotter.dashbuddy.domain.capability.RuleCapability
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Pure-policy tests for the consent grant store (#417): the source auto-grant
- * selection and the ALL-keys-granted coverage semantics. The repository glue
- * (DataStore IO) is exercised through the engine-level gate tests in `:app`.
+ * Pure-policy tests for the consent grant store: the ALL-keys-granted coverage
+ * semantics and the grant/deny set transform. The repository glue (DataStore IO
+ * — reconcile-never-grants, undecided-never-fires, the one-shot migration) is
+ * exercised in [RuleCapabilityRepositoryTest] against a real DataStore.
  */
 class RuleCapabilityPolicyTest {
-
-    private fun cap(
-        key: String,
-        source: String,
-        ruleId: String = "doordash.screen.delivery_summary_collapsed",
-        action: RuleAction = RuleAction.EXPAND_EARNINGS,
-    ) = RuleCapability(
-        ruleId = ruleId,
-        action = action,
-        targetBindName = action.targetBindName,
-        key = key,
-        source = source,
-    )
-
-    // =========================================================================
-    // autoGrantSelection — the source policy
-    // =========================================================================
-
-    @Test
-    fun `asset capabilities are auto-granted`() {
-        val selected = autoGrantSelection(
-            listOf(cap("k1", "asset:rules/doordash.json"), cap("k2", "asset:rules/uber.json")),
-            denied = emptySet(),
-        )
-        assertEquals(setOf("k1", "k2"), selected)
-    }
-
-    @Test
-    fun `non-asset sources are never auto-granted`() {
-        val selected = autoGrantSelection(
-            listOf(
-                cap("k1", "cdn:https://rules.example.com/doordash.json"),
-                cap("k2", "fork:community-rules"),
-                cap("k3", "unknown"),
-            ),
-            denied = emptySet(),
-        )
-        assertTrue(selected.isEmpty())
-    }
-
-    @Test
-    fun `an explicitly denied key is excluded from auto-grant`() {
-        val selected = autoGrantSelection(
-            listOf(cap("k1", "asset:rules/doordash.json"), cap("k2", "asset:rules/doordash.json")),
-            denied = setOf("k2"),
-        )
-        assertEquals(setOf("k1"), selected)
-    }
 
     // =========================================================================
     // actionKeysCovered — ALL-keys-granted semantics
@@ -99,8 +50,8 @@ class RuleCapabilityPolicyTest {
 
     @Test
     fun `revoking removes the grant and persists an explicit denial`() {
-        // The explicit denial is what keeps the next load's asset auto-grant from
-        // silently re-granting a revoked capability (fail-closed revocation).
+        // The explicit denial is what moves the capability out of "undecided" so
+        // the consent prompt never re-asks (durable opt-out, #843).
         val (granted, denied) = applyGrantChange(
             key = "k1",
             grant = false,
@@ -109,12 +60,5 @@ class RuleCapabilityPolicyTest {
         )
         assertEquals(setOf("k2"), granted)
         assertEquals(setOf("k1"), denied)
-
-        // And the persisted denial excludes it from a subsequent asset auto-grant.
-        val reGranted = autoGrantSelection(
-            listOf(cap("k1", "asset:rules/doordash.json")),
-            denied = denied,
-        )
-        assertTrue(reGranted.isEmpty())
     }
 }

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityRepositoryTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityRepositoryTest.kt
@@ -1,0 +1,175 @@
+package cloud.trotter.dashbuddy.core.data.capability
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import cloud.trotter.dashbuddy.core.datastore.capability.RuleCapabilityDataSource
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.capability.RuleCapability
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Repository glue over a REAL Preferences DataStore (#843): the Play-policy core
+ * — reconcile grants NOTHING (any source, incl. asset), an undecided capability
+ * never fires the gate, an explicit grant is the only path to firing, denials
+ * are durable, and the one-shot schema migration clears grants / keeps denials /
+ * stamps its marker exactly once.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RuleCapabilityRepositoryTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun newRepo(
+        scope: TestScope,
+        fileName: String,
+    ): Pair<RuleCapabilityRepository, RuleCapabilityDataSource> {
+        val storeScope = CoroutineScope(StandardTestDispatcher(scope.testScheduler) + Job())
+        val ds = PreferenceDataStoreFactory.create(
+            scope = storeScope,
+            produceFile = { File(tmp.root, fileName) },
+        )
+        val dataSource = RuleCapabilityDataSource(ds)
+        return RuleCapabilityRepository(dataSource, storeScope) to dataSource
+    }
+
+    private fun cap(
+        key: String,
+        source: String,
+        ruleId: String = "doordash.screen.offer_popup",
+        action: RuleAction = RuleAction.ACCEPT_OFFER,
+    ) = RuleCapability(
+        ruleId = ruleId,
+        action = action,
+        targetBindName = action.targetBindName,
+        key = key,
+        source = source,
+    )
+
+    // =========================================================================
+    // reconcile grants NOTHING (the Play-policy core)
+    // =========================================================================
+
+    @Test
+    fun `reconcile grants nothing - even asset-prefixed sources`() = runTest {
+        val (repo, _) = newRepo(this, "recon1.preferences_pb")
+
+        repo.reconcile(
+            listOf(
+                cap("asset-k", "asset:rules/doordash.json"),
+                cap("cdn-k", "cdn:https://rules.example.com/uber.json", ruleId = "uber.screen.offer"),
+            ),
+        )
+        advanceUntilIdle()
+
+        assertTrue(
+            "reconcile must never populate the granted set (#843)",
+            repo.grantedKeys.first().isEmpty(),
+        )
+        // The enumeration IS published (the consent surface needs it).
+        assertEquals(2, repo.capabilities.first().size)
+    }
+
+    @Test
+    fun `an undecided asset capability never fires the gate`() = runTest {
+        val (repo, _) = newRepo(this, "recon2.preferences_pb")
+
+        repo.reconcile(listOf(cap("asset-k", "asset:rules/doordash.json")))
+        advanceUntilIdle()
+
+        assertFalse(
+            "an enumerated-but-undecided capability is not granted — fail closed",
+            repo.isActionGranted("doordash.screen.offer_popup", RuleAction.ACCEPT_OFFER),
+        )
+    }
+
+    @Test
+    fun `an explicit grant is the only path to firing`() = runTest {
+        val (repo, _) = newRepo(this, "recon3.preferences_pb")
+
+        repo.reconcile(listOf(cap("asset-k", "asset:rules/doordash.json")))
+        advanceUntilIdle()
+        assertFalse(repo.isActionGranted("doordash.screen.offer_popup", RuleAction.ACCEPT_OFFER))
+
+        repo.setGranted("asset-k", true)
+        advanceUntilIdle()
+
+        assertTrue(
+            "after an explicit user grant the gate fires",
+            repo.isActionGranted("doordash.screen.offer_popup", RuleAction.ACCEPT_OFFER),
+        )
+    }
+
+    // =========================================================================
+    // setGranted round-trip + durable denial
+    // =========================================================================
+
+    @Test
+    fun `setGranted round-trips grant then deny with a durable denial`() = runTest {
+        val (repo, _) = newRepo(this, "grant1.preferences_pb")
+
+        repo.setGranted("k1", true)
+        advanceUntilIdle()
+        assertTrue(repo.grantedKeys.first().contains("k1"))
+        assertFalse(repo.deniedKeys.first().contains("k1"))
+
+        repo.setGranted("k1", false)
+        advanceUntilIdle()
+        assertFalse(repo.grantedKeys.first().contains("k1"))
+        assertTrue("a deny persists an explicit denial", repo.deniedKeys.first().contains("k1"))
+    }
+
+    // =========================================================================
+    // one-shot schema migration
+    // =========================================================================
+
+    @Test
+    fun `migration clears grants keeps denials and stamps the marker once`() = runTest {
+        val (repo, ds) = newRepo(this, "migrate1.preferences_pb")
+
+        // Pre-#843 store: an auto-granted key AND an explicit denial.
+        ds.update { _, _ -> setOf("stale-auto-grant") to setOf("explicit-deny") }
+        advanceUntilIdle()
+
+        repo.migrateConsentSchemaIfNeeded()
+        advanceUntilIdle()
+
+        assertTrue("stale grant cleared", repo.grantedKeys.first().isEmpty())
+        assertEquals("denial preserved", setOf("explicit-deny"), repo.deniedKeys.first())
+    }
+
+    @Test
+    fun `migration is idempotent - a second run does not re-clear a fresh grant`() = runTest {
+        val (repo, _) = newRepo(this, "migrate2.preferences_pb")
+
+        repo.migrateConsentSchemaIfNeeded()
+        advanceUntilIdle()
+
+        // User grants AFTER the migration already ran.
+        repo.setGranted("post-migration-grant", true)
+        advanceUntilIdle()
+
+        // A second migration must no-op (marker already stamped) — the fresh
+        // grant survives.
+        repo.migrateConsentSchemaIfNeeded()
+        advanceUntilIdle()
+
+        assertTrue(
+            "a fresh grant survives a redundant migration call",
+            repo.grantedKeys.first().contains("post-migration-grant"),
+        )
+    }
+}

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/capability/RuleCapabilityDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/capability/RuleCapabilityDataSource.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.core.datastore.capability
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import cloud.trotter.dashbuddy.core.datastore.di.RuleCapabilityPreferences
 import kotlinx.coroutines.flow.Flow
@@ -18,8 +19,9 @@ import javax.inject.Singleton
  * Grants are keyed by content, not rule id, so they survive reloads of an
  * unchanged ruleset and *stop covering* a rule whose binding definition
  * changed — that re-consent property is the point of the key (#422). Denials
- * are stored separately so a future revocation (consent UI, #422 PR 3) is
- * not silently undone by the next load's auto-grant pass.
+ * are stored separately so an explicit opt-out (consent prompt/settings, #843)
+ * is durable — reloads never re-ask, and the one-shot schema migration
+ * ([migrateConsentSchemaIfNeeded]) preserves denials while clearing grants.
  */
 @Singleton
 class RuleCapabilityDataSource @Inject constructor(
@@ -28,6 +30,15 @@ class RuleCapabilityDataSource @Inject constructor(
     private object Keys {
         val GRANTED = stringSetPreferencesKey("granted_capability_keys")
         val DENIED = stringSetPreferencesKey("denied_capability_keys")
+
+        /**
+         * The consent-schema version last applied on this device (#843). Absent
+         * (⇒ 0) on a store written before the no-auto-grant migration existed —
+         * i.e. one that may hold auto-granted keys that were never an explicit
+         * user act. [migrateConsentSchemaIfNeeded] stamps [CONSENT_SCHEMA_VERSION]
+         * here so the one-shot clear runs exactly once.
+         */
+        val SCHEMA_VERSION = intPreferencesKey("consent_schema_version")
     }
 
     /** Granted capability keys; the fire-time gate reads this (fail closed when absent). */
@@ -53,5 +64,42 @@ class RuleCapabilityDataSource @Inject constructor(
             prefs[Keys.GRANTED] = newGranted
             prefs[Keys.DENIED] = newDenied
         }
+    }
+
+    /**
+     * One-shot consent-schema migration (#843). On the first run whose stored
+     * [Keys.SCHEMA_VERSION] is below [CONSENT_SCHEMA_VERSION], **clear the
+     * granted set** — the old auto-grant policy could have populated it without
+     * an explicit user act, so every capability must return to undecided and be
+     * re-consented through the prompt — while **keeping the denied set** (an
+     * explicit opt-out stays honored) — then stamp the version so the clear
+     * never runs again. Idempotent: a second call finds the version already at
+     * target and no-ops. All in one atomic edit.
+     *
+     * Returns true iff the clear ran (for the caller's INFO log), false on a
+     * no-op. Fail-closed by construction: clearing grants can only *remove*
+     * automation, never fabricate it.
+     */
+    suspend fun migrateConsentSchemaIfNeeded(): Boolean {
+        var migrated = false
+        ds.edit { prefs ->
+            val stored = prefs[Keys.SCHEMA_VERSION] ?: 0
+            if (stored < CONSENT_SCHEMA_VERSION) {
+                prefs[Keys.GRANTED] = emptySet()
+                // Keys.DENIED intentionally preserved.
+                prefs[Keys.SCHEMA_VERSION] = CONSENT_SCHEMA_VERSION
+                migrated = true
+            }
+        }
+        return migrated
+    }
+
+    companion object {
+        /**
+         * Current consent-schema version. Bumped from 0 to 1 by #843 (kill the
+         * auto-grant): the bump flips every previously auto-granted capability
+         * back to undecided so the prompt collects fresh, explicit consent.
+         */
+        const val CONSENT_SCHEMA_VERSION = 1
     }
 }

--- a/core/datastore/src/test/java/cloud/trotter/dashbuddy/core/datastore/capability/RuleCapabilityDataSourceTest.kt
+++ b/core/datastore/src/test/java/cloud/trotter/dashbuddy/core/datastore/capability/RuleCapabilityDataSourceTest.kt
@@ -1,0 +1,84 @@
+package cloud.trotter.dashbuddy.core.datastore.capability
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * #843 — the one-shot consent-schema migration marker. The migration clears the
+ * granted set (a pre-#843 store may hold auto-granted keys that were never an
+ * explicit user act), preserves explicit denials, and stamps a version so it
+ * runs exactly once (idempotent). The grant/deny [RuleCapabilityDataSource.update]
+ * round-trip is covered by the repository-level test in :core:data.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RuleCapabilityDataSourceTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun newSource(dispatcher: TestDispatcher, fileName: String): RuleCapabilityDataSource {
+        val ds = PreferenceDataStoreFactory.create(
+            scope = CoroutineScope(dispatcher + Job()),
+            produceFile = { File(tmp.root, fileName) },
+        )
+        return RuleCapabilityDataSource(ds)
+    }
+
+    @Test
+    fun `migration clears grants keeps denials and reports it ran the first time`() = runTest {
+        val source = newSource(StandardTestDispatcher(testScheduler), "cap-migrate1.preferences_pb")
+
+        source.update { _, _ -> setOf("stale-grant-a", "stale-grant-b") to setOf("denied-a") }
+        advanceUntilIdle()
+
+        val ran = source.migrateConsentSchemaIfNeeded()
+        advanceUntilIdle()
+
+        assertTrue("first run reports it migrated", ran)
+        assertTrue("granted set cleared", source.granted.first().isEmpty())
+        assertEquals("denial preserved", setOf("denied-a"), source.denied.first())
+    }
+
+    @Test
+    fun `migration is a no-op on the second run - marker stamped`() = runTest {
+        val source = newSource(StandardTestDispatcher(testScheduler), "cap-migrate2.preferences_pb")
+
+        assertTrue("first run migrates", source.migrateConsentSchemaIfNeeded())
+        advanceUntilIdle()
+
+        assertFalse(
+            "second run is a no-op — the version marker was stamped",
+            source.migrateConsentSchemaIfNeeded(),
+        )
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun `a grant written after migration survives a redundant migration call`() = runTest {
+        val source = newSource(StandardTestDispatcher(testScheduler), "cap-migrate3.preferences_pb")
+
+        source.migrateConsentSchemaIfNeeded()
+        advanceUntilIdle()
+
+        source.update { granted, denied -> (granted + "fresh-grant") to denied }
+        advanceUntilIdle()
+
+        assertFalse("redundant migration no-ops", source.migrateConsentSchemaIfNeeded())
+        advanceUntilIdle()
+        assertTrue("fresh grant untouched", source.granted.first().contains("fresh-grant"))
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/LoadAtomicityTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/LoadAtomicityTest.kt
@@ -38,6 +38,7 @@ class LoadAtomicityTest {
     private class RecordingGrants : RuleCapabilityGrants {
         val reconcileCalls = mutableListOf<List<RuleCapability>>()
         override val grantedKeys: StateFlow<Set<String>> = MutableStateFlow(emptySet())
+        override val deniedKeys: StateFlow<Set<String>> = MutableStateFlow(emptySet())
         override val capabilities: StateFlow<List<RuleCapability>> = MutableStateFlow(emptyList())
         override suspend fun reconcile(capabilities: List<RuleCapability>) {
             reconcileCalls += capabilities

--- a/docs/design/rule-capability-consent.md
+++ b/docs/design/rule-capability-consent.md
@@ -140,13 +140,22 @@ for that action; the *grant* check is for automation-initiated fires. Target
 verification (the dynamic half) applies to **both** — integrity is never
 skipped.
 
-### Source policy (unchanged)
+### Source policy (superseded by #843 — no auto-grant)
 
-- **Asset source** (bundled rules the developer ships) → auto-grant on load;
-  no consent friction in the single-user alpha.
-- **CDN / fork source** (#192) → never auto-grant; every capability pending
-  until approved. A downloaded rule can recognize screens immediately but
-  cannot aim a tap without an explicit, content-pinned grant.
+**As of #843 there is NO auto-grant, from any source.** `reconcile()` only
+publishes the enumeration; every capability — bundled OR downloaded — lands
+**undecided** until the user explicitly opts in. Per Google Play policy each
+automation is consented to individually. Consent is collected by the
+**prompt** (`ConsentPromptSheet`, the app's front door — same rhythm as the
+a11y/notification permission prompts), and reviewed/revoked in the settings
+record. A one-shot schema migration clears any pre-#843 auto-granted keys on
+upgrade (denials preserved) so the prompt re-collects honest consent.
+
+`ASSET_SOURCE_PREFIX` survives as display-only provenance: bundled = "built-in"
+(covered by the APK signature), downloaded = a future CDN/fork source (#192),
+which additionally gates on signature verification (#416) before it may even be
+enumerated. Neither is granted without a user act. A rule can recognize screens
+immediately but cannot aim a tap without an explicit, content-pinned grant.
 
 ## Lifecycle (current state)
 
@@ -176,7 +185,9 @@ skipped.
    auto-decline is a staged plan over *intents* (offer screen → confirm
    screen), each step aimed by that screen's own bound target, with in-flight
    state + timeout + abort-to-manual.
-3. **Asset auto-grant** — keep for the alpha? (recommend yes.)
+3. **Asset auto-grant** — RESOLVED by #843: removed. Bundled sources are
+   prompted, not auto-granted (Google Play per-automation consent). The
+   original alpha recommendation ("keep") is superseded.
 4. **Persist explicit denials** vs treat absence as deny (recommend persist).
 5. **Revocation immediacy** — reactive grant flow should suppress immediately
    (recommend yes).

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,23 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — #843 — prompted per-capability automation consent (no auto-grant).** Automations are
+  no longer pre-granted; each must be consented to individually via a prompt at the app's front
+  door (Google Play policy). On upgrade, a one-shot migration clears the old auto-grants, so every
+  automation starts OFF.
+  **What to watch (first app-open after installing this build):**
+  1. On first open (once accessibility/notification permissions are in), a **consent sheet**
+     appears listing each automation **individually** — Accept, Decline, Confirm-decline, Open
+     pay breakdown — each with its own Allow / Don't-allow buttons and a source line ("Built-in
+     DoorDash rules"). There is **no "allow all"** button; "Not now" dismisses and it should
+     re-appear next time you foreground the app while anything is still undecided.
+  2. Before you grant anything, **quick-decline / auto-expand should do nothing** (stay MANUAL) —
+     the automation is off until consented.
+  3. Grant **exactly one** automation (e.g. Decline) and leave the others "Not now": on the next
+     offer, only that one fires; the un-granted ones still require a manual tap. A "Don't allow"
+     choice must never re-prompt.
+  - Issue: #843. Confirmed: 0/2
+
 - **🆕 NEW — #830 / PR #839 — presentation-scoped offer identity (+ the #826 accept chain).** The
   ticking Uber card no longer mints replacement offers: a re-render with the same store/order shape
   ENRICHES the pending offer in place (keeps its presentation epoch and click latches; heads-up

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capability/RuleCapabilityGrants.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capability/RuleCapabilityGrants.kt
@@ -69,8 +69,9 @@ interface RuleCapabilityGrants {
      * bundled (asset) source is enumerated exactly like a future remote source,
      * landing every capability as UNDECIDED until the user opts in through the
      * consent prompt. Per Google Play policy the user must consent to EACH
-     * automation individually; no capability arrives pre-granted, so [source]
-     * is recorded for provenance/display only, never as a grant trigger.
+     * automation individually; no capability arrives pre-granted, so
+     * [RuleCapability.source] is recorded for provenance/display only, never as
+     * a grant trigger.
      *
      * Called by the rule loader BEFORE the compiled rules go live, so the
      * consent surface and the fire-time gate see the current enumeration; the

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capability/RuleCapabilityGrants.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capability/RuleCapabilityGrants.kt
@@ -20,11 +20,25 @@ import kotlinx.coroutines.flow.StateFlow
 interface RuleCapabilityGrants {
 
     /**
-     * Reactive set of granted capability keys. Revocation (#422 PR 3)
+     * Reactive set of granted capability keys — the ONLY keys the fire-time
+     * gate ([isActionGranted]) treats as fireable. A key is here iff the user
+     * explicitly opted in (there is no auto-grant, #843). A grant/revoke
      * surfaces here immediately; the fire-time gate reads the persisted
      * store, so a revoked key suppresses the very next fire.
      */
     val grantedKeys: StateFlow<Set<String>>
+
+    /**
+     * Reactive set of explicitly DENIED capability keys — the user opted out.
+     * A denial persists across rule loads and never re-prompts (#843). Exposed
+     * so the consent PROMPT (#843) can derive the *undecided* set
+     * (`capabilities − granted − denied`): a capability is undecided when it is
+     * enumerated but appears in neither this set nor [grantedKeys]. Symmetric
+     * read projection of the same persisted store as [grantedKeys]; never a
+     * gate (an undecided key already fails [isActionGranted] by absence from the
+     * granted set — denial vs undecided differ only in whether we re-prompt).
+     */
+    val deniedKeys: StateFlow<Set<String>>
 
     /**
      * The capabilities the CURRENTLY loaded rulesets enumerate — the same list
@@ -37,27 +51,30 @@ interface RuleCapabilityGrants {
     val capabilities: StateFlow<List<RuleCapability>>
 
     /**
-     * Grant ([granted] = true) or revoke ([granted] = false) one capability
-     * [key] from the consent surface (#422 PR 3). Both sides write atomically:
-     * granting adds [key] to the granted set and clears any prior denial;
-     * **revoking persists an explicit denial** so the next rule load's asset
-     * auto-grant can't silently undo it (the point of the separate denied set).
-     * A revocation surfaces on [grantedKeys] immediately, so the fail-closed
-     * fire-time gate ([isActionGranted]) suppresses the very next automation
-     * tap — revocation is fail-closed.
+     * Grant ([granted] = true) or revoke/deny ([granted] = false) one
+     * capability [key] — the consent decision, written from the prompt (#843)
+     * or the settings record (#422 PR 3). This is the ONLY way a grant comes
+     * to exist. Both sides write atomically: granting adds [key] to the granted
+     * set and clears any prior denial; **denying persists an explicit denial in
+     * [deniedKeys]** so the capability moves out of "undecided" and the prompt
+     * never re-asks (a denial is durable, not a deferral). A revocation
+     * surfaces on [grantedKeys] immediately, so the fail-closed fire-time gate
+     * ([isActionGranted]) suppresses the very next automation tap.
      */
     suspend fun setGranted(key: String, granted: Boolean)
 
     /**
-     * Publish the capabilities the just-loaded rulesets enable — REPLACING
-     * the previous enumeration — and apply the source auto-grant policy:
-     * capabilities from a bundled asset source ([ASSET_SOURCE_PREFIX]) are
-     * granted unless explicitly denied; any other source (CDN/fork, #192)
-     * is never auto-granted and stays pending until the user approves it.
+     * Publish the capabilities the just-loaded rulesets enable — REPLACING the
+     * previous enumeration. **Grants NOTHING, from any source (#843):** a
+     * bundled (asset) source is enumerated exactly like a future remote source,
+     * landing every capability as UNDECIDED until the user opts in through the
+     * consent prompt. Per Google Play policy the user must consent to EACH
+     * automation individually; no capability arrives pre-granted, so [source]
+     * is recorded for provenance/display only, never as a grant trigger.
      *
-     * Called by the rule loader BEFORE the compiled rules go live, so by the
-     * time a frame can classify (and an action can fire) the grant store
-     * already reflects the bundle.
+     * Called by the rule loader BEFORE the compiled rules go live, so the
+     * consent surface and the fire-time gate see the current enumeration; the
+     * gate stays fail-closed for anything not in [grantedKeys].
      */
     suspend fun reconcile(capabilities: List<RuleCapability>)
 
@@ -75,9 +92,12 @@ interface RuleCapabilityGrants {
     companion object {
         /**
          * Source-string prefix marking bundled rule files
-         * (`asset:rules/doordash.json`) — the only source the auto-grant
-         * policy accepts. SSOT for both the loader (which stamps sources)
-         * and the grant policy (which checks them).
+         * (`asset:rules/doordash.json`), covered by the APK signature. Since
+         * #843 killed auto-grant this no longer gates any grant — bundled and
+         * remote sources are enumerated identically and both land undecided —
+         * it only lets the consent surface label a source's provenance
+         * ("built-in" vs a future downloaded source). SSOT for both the loader
+         * (which stamps sources) and that display distinction.
          */
         const val ASSET_SOURCE_PREFIX = "asset:"
     }


### PR DESCRIPTION
Closes #843. Dev-flagged Play-policy priority: automation consent must be **prompted and per-capability**, never auto-granted.

## Design conformance (per the vetted "Design pass (fable, 2026-07-23)" comment)

1. **Kill the auto-grant.** `RuleCapabilityRepository.reconcile()` no longer touches the persisted store — it only publishes the enumeration. `autoGrantSelection` deleted. Three states are load-bearing: **granted** (explicit user act only), **denied** (explicit, durable), **undecided** (default; fires nothing). The `isActionGranted` gate is byte-for-byte unchanged — it already required membership in the granted set, so undecided fails it by absence. Interface KDoc rewritten truthfully.
2. **Prompt surface.** `ConsentPromptSheet` (new, `ui/main/setup/consent/`) joins the app's existing front-door permission chain — rendered by `DashboardScreen` once essential permissions are satisfied, on the same `ON_RESUME` app-foreground rhythm the `PermissionsBottomSheet` uses. One row **per undecided capability**: name, plain-language behavioral disclosure (reused from the #422 copy SSOT, corrected), source ("Built-in DoorDash rules"), individual **Allow / Don't allow**. **No "allow all".** "Not now" defers (composable-local, re-arms on `ON_RESUME`). Rows write through `RuleCapabilityGrants.setGranted`.
3. **Migration.** `RuleCapabilityDataSource.migrateConsentSchemaIfNeeded()` — one atomic edit: if stored `consent_schema_version` < 1, clear the **granted** set, **keep denied**, stamp the marker. Idempotent (second run no-ops). Wired into `DashBuddyApplication` before `loadDefaults()` so nothing fires against a stale grant. Automation silently stops until re-granted (fail-closed, correct direction).
4. **Copy corrections.** Settings screen reframed acquisition→record. Through string resources (#428-A convention).
5. **Did not touch** `PerformRuleAction`, `SideEffectEngine` gates, `isActionGranted` semantics, `:core:pipeline` (no collision with #844's `RulesetVerifier`).

## Trigger predicate
`buildConsentPromptState(capabilities, granted, denied)` → rows = `capabilities − granted − denied`, `distinctBy(key)`, ordered by (action, ruleId). Sheet shows iff `rows.isNotEmpty() && !deferred`. Pure + unit-tested.

## Migration behavior
One-shot on first post-upgrade run: granted cleared once, denials preserved, version stamped → never re-runs. Every capability returns to undecided; the prompt collects fresh consent (single-user alpha: one re-prompt, which doubles as the field validation).

## Copy before → after (quoted)
- `consent_disclosure_heading`: "How DashBuddy uses the Accessibility service" → **"Review or change what DashBuddy is allowed to tap"**
- `consent_disclosure_body`: dropped "…Actions bundled with DashBuddy start on — the pay-details tap runs whenever a completed delivery's pay breakdown is collapsed." → **"Nothing is turned on for you: each action below stays off until you allow it, and DashBuddy asks you the first time it can offer one."**
- `consent_source_bundled_format`: "%1$s · bundled with DashBuddy" → **"%1$s · built-in rules"**
- `consent_source_bundled_note`: "These automation rules ship inside the app and are on by default…" → **"These automations ship inside the app. None are turned on for you — each stays off until you allow it."**
- New: `consent_prompt_heading/body/allow/deny/not_now/source_*`.

## Play-policy posture
Per-automation opt-in, no bundled pre-grant, no bulk grant; enforcement stays at the `PerformRuleAction` seam (consent is acquisition + record, never a second gate); a dasher-pressed Accept/Decline remains its own consent. Untrusted-input boundary unchanged; the change can only *remove* automation, never fabricate it (fail-closed).

## Test evidence
`export JAVA_HOME=/usr/lib/jvm/java-25; ./gradlew testDebugUnitTest :domain:test` → **BUILD SUCCESSFUL**; `:app:assembleDebug` → **BUILD SUCCESSFUL**. New tests:
- `RuleCapabilityRepositoryTest` (real DataStore): reconcile-never-grants (incl. asset), undecided-never-fires, explicit-grant-only-path, setGranted round-trip + durable denial, migration clears/keeps/idempotent.
- `RuleCapabilityDataSourceTest`: migration returns-ran-once / no-op-second / fresh-grant-survives.
- `ConsentPromptViewModelTest`: undecided-only rows, all-decided→no rows, deterministic order, distinct keys, reactive Allow/Don't-allow row removal + write routing.
- Extended the two interface fakes (`LoadAtomicityTest`, `CapabilityConsentViewModelTest`) for the new `deniedKeys`.

## Deviations / residuals
- **Trigger host:** the spec named "MainActivity's permission-prompting chain", but that chain actually lives in `DashboardScreen` (MainActivity is a pure NavHost). The sheet is rendered there — the app's start-destination front door — which is the faithful "on app foreground" trigger.
- **`deniedKeys` added to `RuleCapabilityGrants`:** the prompt derives undecided in the ViewModel (design's preferred "no new stored state"), which needs denied exposed reactively; added as a symmetric read projection of the same persisted store as `grantedKeys` — not a gate.
- One test-only dep added: `testImplementation(libs.androidx.datastore.preferences)` on `:core:data` (its `:core:datastore` dep uses `implementation`, so datastore-preferences isn't on the test classpath transitively).

### Design-goal review
- **UDF:** state flows down as immutable `ConsentPromptUiState`; the only write (`onDecision`) routes through the grant store, never a repo write from the composable. "Not now" is composable-local ephemeral state, correct.
- **SSOT:** extracted `capabilityCopy` into `CapabilityConsentCopy.kt` so the prompt and the settings record share one disclosure-copy definition (removed the duplicate). Grant/deny transform stays the one `applyGrantChange`.
- **Security & privacy (#6):** consent is fail-closed — grant is the only fire path; migration can only remove automation; enforcement seam untouched; INFO logs are PII-safe (status, no keys/PII).
- **Reactive UI:** the sheet re-derives from `grants.{capabilities,grantedKeys,deniedKeys}` — answering a row removes it live.
- **Platform-agnostic (#8):** no new platform literals; the diff doesn't touch `:core:state`/`:core:pipeline`; source labeling stays data-driven via `ASSET_SOURCE_PREFIX` + `Platform.fromRuleId`.

### Adversarial review
Pending — to be run (`/code-review` + `/security-review`, fable tier) before merge.
