### PR TITLE
feat(analytics): #810 B2 — orphan offer resolution (store-evidence inference + driver attestation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,8 +440,12 @@ the driver picks the unassigned offer → `CorrectionRepository.correctOfferOutc
 exclusion:** `AnalyticsDao.offerOutcomes`/`offerScoreOutcomes` (the Decisions-tab funnel + score aggregates)
 gain `outcomeResolved IS NULL`, so a resolved orphan no longer inflates `accepted`/`received`. The session-level
 `session_records.offersAccepted` live counter (bubble ModeCard + CSV) is a DIFFERENT fold and is left as-is
-(a retrospective analytics resolution doesn't rewrite the per-dash counter — a documented residual). No
-state-machine changes.
+(a retrospective analytics resolution doesn't rewrite the per-dash counter — a documented residual). The
+Tier-1 reconcile reads only delivered rows sequenced BEFORE the mismatch event and the state machine emits
+`JOB_ACCEPT_MISMATCH` AFTER the closing job's final `DELIVERY_COMPLETED` (`EffectMap` emission order, #810 B2
+review F1) so the store evidence is complete by construction and the fold is paging-independent (historical
+logs carrying the old mismatch-first order deterministically fall to Tier 2). The only state-machine touch is
+that emission-ORDER within one close step (no new events, no reducer change).
 
 ## Development Principles
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,6 +422,26 @@ per-drop net redistributes within a stack while session/period/IRS/CSV mileage t
 leg columns are provenance and are never rewritten, so leg-sum ≠ realizedMiles IS the visible edit trail.
 CSV gains `miles_to_store`/`miles_to_dropoff`. `newCompletedAt` stays banned on `DELIVERY_ADJUSTMENT`.
 Session-categorize of an unattributed remainder is deferred (#650 follow-up). Related: #653/#655/#703.
+**Orphan-offer resolution (#810 B2, Room v14→v15 additive `offer_records.outcomeResolved`, `PROJECTOR_VERSION`
+7→8):** an accepted offer whose job produced no matching delivery (the invisible-unassign class B1's
+`JOB_ACCEPT_MISMATCH` tripwire surfaces) is resolved in two tiers, both write-only to the new nullable
+`outcomeResolved` column (original `outcome` never rewritten — the #688 edit-trail pattern). **Tier 1
+(projector, automatic):** folding a `JOB_ACCEPT_MISMATCH` emits an `OfferReconcileFold` the orchestrator runs
+resolve-from-rows in-transaction — the pure `JobAcceptMismatchResolver` joins the closing job's delivered-drop
+store evidence (`delivery_records.storeName` + `payoutStoreForms`, normalized via `StoreKeys`) against each
+accepted `offer_record`'s parsed store; EXACTLY one store-unaccounted offer while all others are accounted →
+stamp `UNASSIGNED_INFERRED`; any other shape (same-store tie, multiple/zero unaccounted, no evidence) is
+INCONCLUSIVE → Tier 2 (fail-null beats fail-wrong, #745). The refold retro-resolves the seq-114 orphan (which,
+being same-store, lands in Tier 2). **Tier 2 (driver attestation):** a Money-tab callout (`orphanOfferGroups`,
+read by joining the `JOB_ACCEPT_MISMATCH` events to accepted `offer_records`) opens `OrphanOfferAttestDialog`;
+the driver picks the unassigned offer → `CorrectionRepository.correctOfferOutcome` appends a new
+`OFFER_OUTCOME_CORRECTION` event → `CorrectionFolds.foldOfferOutcomeCorrection` → the orchestrator stamps
+`UNASSIGNED_ATTESTED` (null ⇒ undo), rebuild-faithfully (correction sequences after its target). **Read-side
+exclusion:** `AnalyticsDao.offerOutcomes`/`offerScoreOutcomes` (the Decisions-tab funnel + score aggregates)
+gain `outcomeResolved IS NULL`, so a resolved orphan no longer inflates `accepted`/`received`. The session-level
+`session_records.offersAccepted` live counter (bubble ModeCard + CSV) is a DIFFERENT fold and is left as-is
+(a retrospective analytics resolution doesn't rewrite the per-dash counter — a documented residual). No
+state-machine changes.
 
 ## Development Principles
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
@@ -52,6 +52,7 @@ fun AnalyticsScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     // "(No session)" categorize flow (#660 piece 2) — opened from the Money-tab callout.
     var showAssignSheet by remember { mutableStateOf(false) }
+    var showOrphanOfferSheet by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -110,8 +111,10 @@ fun AnalyticsScreen(
                         topStores = uiState.topStores,
                         recentSessions = uiState.recentSessions,
                         dailyEarnings = uiState.dailyEarnings,
+                        orphanOfferGroups = uiState.orphanOfferGroups,
                         onOpenSession = onOpenSession,
                         onOpenNoSession = { showAssignSheet = true },
+                        onOpenOrphanOffers = { showOrphanOfferSheet = true },
                     )
                 }
 
@@ -148,6 +151,14 @@ fun AnalyticsScreen(
             candidateSessionsFor = viewModel::candidateSessionsFor,
             onAssign = viewModel::assignToSession,
             onDismiss = { showAssignSheet = false },
+        )
+    }
+
+    if (showOrphanOfferSheet) {
+        OrphanOfferAttestDialog(
+            groups = uiState.orphanOfferGroups,
+            onResolve = viewModel::resolveOrphanOffer,
+            onDismiss = { showOrphanOfferSheet = false },
         )
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
@@ -7,6 +7,7 @@ import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
 import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
+import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferGroup
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
@@ -66,6 +67,13 @@ data class AnalyticsUiState(
      * from the Money-tab callout. Reactive: shrinks as the projector folds a `DELIVERY_SESSION_ASSIGN`.
      */
     val noSessionDeliveries: List<DeliveryRecord> = emptyList(),
+    /**
+     * The period's still-open orphan-offer mismatches (#810 B2 Tier 2) — accepted offers whose job
+     * produced no matching delivery and whose same-store shape the projector's Tier-1 join could not
+     * resolve. The Money-tab callout opens the attestation dialog; reactive — shrinks as the driver
+     * attests (or Tier-1 resolves) an orphan.
+     */
+    val orphanOfferGroups: List<OrphanOfferGroup> = emptyList(),
     /** Offer-decision economics for [selectedPeriod] — the Decisions tab (#315 H3, frozen est.). */
     val decisions: DecisionEconomics = DecisionEconomics.EMPTY,
     /** Time / mileage economics for [selectedPeriod] — the Time tab (#315 H4, measured). */

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
@@ -8,6 +8,7 @@ import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
+import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferGroup
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
@@ -70,14 +71,16 @@ class AnalyticsViewModel @Inject constructor(
                 analyticsRepository.decisionEconomics(period),
                 analyticsRepository.timeEconomics(period),
                 // The typed `combine` tops out at 5 flows, so the per-day chart + the "(No session)"
-                // orphan list (#660 piece 2) ride ONE nested sub-combine into the 5th slot. Both are
-                // period-anchored, so they re-anchor atomically with everything else on a period switch.
+                // orphan list (#660 piece 2) + the orphan-OFFER groups (#810 B2 Tier 2) ride ONE nested
+                // sub-combine into the 5th slot. All period-anchored, so they re-anchor atomically with
+                // everything else on a period switch.
                 combine(
                     analyticsRepository.dailyEarnings(period),
                     analyticsRepository.noSessionDeliveries(period),
-                ) { daily, orphans -> daily to orphans },
-            ) { economics, stores, decisions, time, (daily, orphans) ->
-                PeriodData(period, economics, stores, decisions, time, daily, orphans)
+                    analyticsRepository.orphanOfferGroups(period),
+                ) { daily, orphans, offerGroups -> Triple(daily, orphans, offerGroups) },
+            ) { economics, stores, decisions, time, (daily, orphans, offerGroups) ->
+                PeriodData(period, economics, stores, decisions, time, daily, orphans, offerGroups)
             }
         },
         analyticsRepository.recentSessions(RECENT_SESSIONS_LIMIT),
@@ -96,6 +99,7 @@ class AnalyticsViewModel @Inject constructor(
             time = data.time,
             dailyEarnings = data.dailyEarnings,
             noSessionDeliveries = data.orphanDeliveries,
+            orphanOfferGroups = data.orphanOfferGroups,
             storeReportCards = storeCards,
             earningsHeatmap = heatmap,
         )
@@ -143,6 +147,28 @@ class AnalyticsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * UDF intent (#810 B2 Tier 2) — attest that an accepted offer was invisibly unassigned (or UNDO)
+     * by appending an `OFFER_OUTCOME_CORRECTION`. The projector stamps `offer_records.outcomeResolved`
+     * (with its fail-closed guards) and Room invalidation refreshes the callout + the open-mismatch
+     * list — no optimistic local mutation. [attested] false is the undo (clears the resolution).
+     */
+    fun resolveOrphanOffer(offerEventSequenceId: Long, attested: Boolean) {
+        viewModelScope.launch {
+            try {
+                correctionRepository.correctOfferOutcome(
+                    targetOfferEventSequenceId = offerEventSequenceId,
+                    attested = attested,
+                )
+            } catch (e: CancellationException) {
+                throw e // cooperative cancellation — never swallow it
+            } catch (e: Exception) {
+                // P7: counts/ids only.
+                Timber.tag(TAG).w(e, "resolveOrphanOffer rejected for offer seq %d", offerEventSequenceId)
+            }
+        }
+    }
+
     /** One period switch's worth of read-model, re-anchored atomically under [flatMapLatest]. */
     private data class PeriodData(
         val period: AnalyticsPeriod,
@@ -152,6 +178,7 @@ class AnalyticsViewModel @Inject constructor(
         val time: TimeEconomics,
         val dailyEarnings: List<DailyEarnings>,
         val orphanDeliveries: List<DeliveryRecord>,
+        val orphanOfferGroups: List<OrphanOfferGroup>,
     )
 
     private companion object {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -119,9 +119,10 @@ fun MoneyTab(
         // delivery — the invisible-unassign class the projector's Tier-1 store-evidence join could NOT
         // auto-resolve (a same-store tie). TAPPABLE: opens the attestation dialog where the driver marks
         // which accepted offer was unassigned, which un-inflates the accepted-offer counts. Same
-        // review-flag pattern as the callouts above; gated on there being an open, still-owed mismatch.
-        if (orphanOfferGroups.isNotEmpty()) {
-            val orphanCount = orphanOfferGroups.sumOf { it.orphansOwed }
+        // review-flag pattern as the callouts above; gated on the still-OWED count (F3 — a fully-resolved
+        // group stays in the dialog for undo but no longer drives the callout).
+        val orphanCount = orphanOfferGroups.sumOf { it.owedRemaining }
+        if (orphanCount > 0) {
             val clickLabel = stringResource(R.string.money_tab_orphan_offers_callout_click_label)
             AppCallout(
                 text = stringResource(R.string.money_tab_orphan_offers_callout_format, Formats.commaInt(orphanCount)),

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -34,6 +34,7 @@ import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
+import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferGroup
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
@@ -58,8 +59,10 @@ fun MoneyTab(
     topStores: List<StoreEconomics>,
     recentSessions: List<SessionRecord>,
     dailyEarnings: List<DailyEarnings>,
+    orphanOfferGroups: List<OrphanOfferGroup>,
     onOpenSession: (String) -> Unit,
     onOpenNoSession: () -> Unit,
+    onOpenOrphanOffers: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
@@ -110,6 +113,22 @@ fun MoneyTab(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable(onClickLabel = clickLabel, role = Role.Button) { onOpenNoSession() },
+            )
+        }
+        // Orphan-offer mismatches (#810 B2 Tier 2): accepted offers whose job produced no matching
+        // delivery — the invisible-unassign class the projector's Tier-1 store-evidence join could NOT
+        // auto-resolve (a same-store tie). TAPPABLE: opens the attestation dialog where the driver marks
+        // which accepted offer was unassigned, which un-inflates the accepted-offer counts. Same
+        // review-flag pattern as the callouts above; gated on there being an open, still-owed mismatch.
+        if (orphanOfferGroups.isNotEmpty()) {
+            val orphanCount = orphanOfferGroups.sumOf { it.orphansOwed }
+            val clickLabel = stringResource(R.string.money_tab_orphan_offers_callout_click_label)
+            AppCallout(
+                text = stringResource(R.string.money_tab_orphan_offers_callout_format, Formats.commaInt(orphanCount)),
+                container = AppTheme.colors.warnBg,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClickLabel = clickLabel, role = Role.Button) { onOpenOrphanOffers() },
             )
         }
         TopStoresCard(topStores)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/OrphanOfferAttestDialog.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/OrphanOfferAttestDialog.kt
@@ -1,0 +1,133 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferCandidate
+import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferGroup
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.format.formatClockTime
+import cloud.trotter.dashbuddy.domain.format.formatShortDate
+
+/**
+ * The orphan-offer attestation flow (#810 B2 Tier 2) — a one-step dialog opened from the Money-tab
+ * callout. Lists each still-open `JOB_ACCEPT_MISMATCH` group (an accepted-offer-vs-delivery mismatch
+ * the projector's Tier-1 store-evidence join could not disambiguate — a same-store tie), and under each,
+ * the job's accepted offers with store / pay / decision time (driver-recognizable facts). Tapping an
+ * unresolved offer attests it as the invisibly-unassigned one; tapping an already-resolved offer undoes
+ * it. Confirming writes an `OFFER_OUTCOME_CORRECTION` via the ViewModel; Room invalidation shrinks
+ * [groups] reactively (a resolved orphan leaves the open set), so the list updates without a refresh.
+ *
+ * Kept OUT of `MoneyTab.kt` (Principle 3 — file-size budget). Pure data in / lambdas out (Principle 1):
+ * [onResolve] appends the correction event. No PII surface — store names are merchant data; pay/time are
+ * decision facts; no customer hashes.
+ */
+@Composable
+fun OrphanOfferAttestDialog(
+    groups: List<OrphanOfferGroup>,
+    onResolve: (offerEventSequenceId: Long, attested: Boolean) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val c = AppTheme.colors
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.orphan_offers_title)) },
+        text = {
+            Column(
+                modifier = Modifier
+                    .heightIn(max = 400.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.orphan_offers_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = c.text3,
+                )
+                if (groups.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.orphan_offers_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = c.text3,
+                        modifier = Modifier.padding(vertical = 8.dp),
+                    )
+                } else {
+                    groups.forEach { group ->
+                        Text(
+                            text = stringResource(
+                                R.string.orphan_offers_group_header,
+                                Formats.commaInt(group.offers.size),
+                                Formats.commaInt(group.orphansOwed),
+                            ),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = c.text2,
+                            modifier = Modifier.padding(top = 8.dp),
+                        )
+                        group.offers.forEach { offer ->
+                            OfferRow(offer = offer, onResolve = onResolve)
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.orphan_offers_close)) }
+        },
+    )
+}
+
+@Composable
+private fun OfferRow(
+    offer: OrphanOfferCandidate,
+    onResolve: (offerEventSequenceId: Long, attested: Boolean) -> Unit,
+) {
+    val c = AppTheme.colors
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            // Tap toggles resolution: an unresolved offer becomes attested; a resolved one undoes.
+            .clickable { onResolve(offer.offerEventSequenceId, !offer.resolved) }
+            .padding(vertical = 8.dp),
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = offer.storeName ?: stringResource(R.string.orphan_offers_unknown_store),
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (offer.resolved) c.text3 else c.text,
+            )
+            Text(
+                text = if (offer.resolved) {
+                    stringResource(R.string.orphan_offers_resolved_caption)
+                } else {
+                    // Date AND time-of-day so two same-store offers stay distinguishable (the #660 pattern).
+                    "${formatShortDate(offer.decidedAt)} · ${formatClockTime(offer.decidedAt)}"
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = c.text3,
+            )
+        }
+        Text(
+            text = offer.payAmount?.let { Formats.money(it) } ?: EMPTY_VALUE,
+            style = AppTheme.num.smNum,
+            color = if (offer.resolved) c.text3 else c.text,
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -578,7 +578,7 @@
 
     <!-- main/analytics/OrphanOfferAttestDialog.kt (#810 B2 Tier 2) -->
     <string name="orphan_offers_title">Unassigned offers</string>
-    <string name="orphan_offers_subtitle">These offers were accepted but never delivered. Tap the one that was unassigned; tap again to undo.</string>
+    <string name="orphan_offers_subtitle">These offers were accepted but never delivered. Tap the one that was unassigned; tap a resolved row to undo.</string>
     <string name="orphan_offers_empty">No unresolved orphan offers in this period.</string>
     <string name="orphan_offers_group_header">%1$s accepted, %2$s unassigned</string>
     <string name="orphan_offers_resolved_caption">Unassigned · tap to undo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -522,6 +522,8 @@
     <string name="money_tab_over_attributed_callout_format">attributed exceeds reported by %1$s — review estimates/corrections</string>
     <string name="money_tab_no_session_callout_format">(No session): %1$s across %2$s %3$s not tied to a dash — data-quality flag (#660)</string>
     <string name="money_tab_no_session_callout_click_label">Assign to a dash</string>
+    <string name="money_tab_orphan_offers_callout_format">%1$s accepted offer(s) have no matching delivery — mark which was unassigned (#810)</string>
+    <string name="money_tab_orphan_offers_callout_click_label">Resolve orphan offers</string>
     <string name="money_tab_recent_sessions_title">RECENT SESSIONS</string>
     <string name="money_tab_no_sessions_recorded_yet">No sessions recorded yet.</string>
     <string name="money_tab_cash_marker_format">+%1$s cash</string>
@@ -573,6 +575,15 @@
     <string name="no_session_assign_session_deliveries_format">%1$s · %2$s %3$s</string>
     <string name="no_session_assign_close">Close</string>
     <string name="no_session_assign_back">Back</string>
+
+    <!-- main/analytics/OrphanOfferAttestDialog.kt (#810 B2 Tier 2) -->
+    <string name="orphan_offers_title">Unassigned offers</string>
+    <string name="orphan_offers_subtitle">These offers were accepted but never delivered. Tap the one that was unassigned; tap again to undo.</string>
+    <string name="orphan_offers_empty">No unresolved orphan offers in this period.</string>
+    <string name="orphan_offers_group_header">%1$s accepted, %2$s unassigned</string>
+    <string name="orphan_offers_resolved_caption">Unassigned · tap to undo</string>
+    <string name="orphan_offers_unknown_store">Unknown store</string>
+    <string name="orphan_offers_close">Close</string>
 
     <!-- bubble/cards/FlowCardItem.kt -->
     <string name="flow_card_content_desc_collapse">Collapse</string>

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
@@ -73,6 +73,8 @@ class AnalyticsViewModelTest {
         // The VM also collects the "(No session)" orphan list per period (#660 piece 2) in the same
         // combine, so it must be stubbed or the combine folds a null Flow.
         whenever(analyticsRepository.noSessionDeliveries(eq(period))).thenReturn(flowOf(emptyList()))
+        // The orphan-OFFER groups (#810 B2 Tier 2) ride the same 5th-slot sub-combine — stub too.
+        whenever(analyticsRepository.orphanOfferGroups(eq(period))).thenReturn(flowOf(emptyList()))
     }
 
     private fun decisions(accepted: Int, declined: Int, timedOut: Int, acceptanceRate: Double?) =

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -13,8 +13,11 @@ import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
 import cloud.trotter.dashbuddy.core.database.event.AppEventDao
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryAdjustmentFold
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryFold
+import cloud.trotter.dashbuddy.domain.analytics.JobAcceptMismatchResolver
 import cloud.trotter.dashbuddy.domain.analytics.LegStateCodec
 import cloud.trotter.dashbuddy.domain.analytics.OfferFold
+import cloud.trotter.dashbuddy.domain.analytics.OfferOutcomeCorrectionFold
+import cloud.trotter.dashbuddy.domain.analytics.OfferReconcileFold
 import cloud.trotter.dashbuddy.domain.analytics.PayAdjustmentFold
 import cloud.trotter.dashbuddy.domain.analytics.PayBasis
 import cloud.trotter.dashbuddy.domain.analytics.PickupFold
@@ -23,6 +26,8 @@ import cloud.trotter.dashbuddy.domain.analytics.SessionAssignFold
 import cloud.trotter.dashbuddy.domain.analytics.SessionFoldContext
 import cloud.trotter.dashbuddy.domain.analytics.StoreResolution
 import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferOutcomeResolution
 import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -195,6 +200,8 @@ class AnalyticsProjector @Inject constructor(
             outcome.payAdjustment?.let { adjustments += Adjustment.Pay(ev.sequenceId, it) }
             outcome.deliveryAdjustment?.let { adjustments += Adjustment.Delivery(ev.sequenceId, it) }
             outcome.sessionAssign?.let { adjustments += Adjustment.SessionAssign(ev.sequenceId, it) }
+            outcome.offerReconcile?.let { adjustments += Adjustment.OfferReconcile(ev.sequenceId, it) }
+            outcome.offerOutcomeCorrection?.let { adjustments += Adjustment.OfferOutcomeCorrect(ev.sequenceId, it) }
             outcome.context?.let { ctx ->
                 contexts[ctx.sessionId] = ctx
                 touched += ctx.sessionId
@@ -229,6 +236,8 @@ class AnalyticsProjector @Inject constructor(
                     is Adjustment.Pay -> applyPayAdjustment(adj.fold)
                     is Adjustment.Delivery -> applyDeliveryAdjustment(adj.fold)
                     is Adjustment.SessionAssign -> applySessionAssign(adj.fold)
+                    is Adjustment.OfferReconcile -> applyOfferReconcile(adj.fold)
+                    is Adjustment.OfferOutcomeCorrect -> applyOfferOutcomeCorrection(adj.fold)
                 }
                 if (skipped) adjustmentSkips++
             }
@@ -261,6 +270,8 @@ class AnalyticsProjector @Inject constructor(
         data class Pay(override val sequenceId: Long, val fold: PayAdjustmentFold) : Adjustment
         data class Delivery(override val sequenceId: Long, val fold: DeliveryAdjustmentFold) : Adjustment
         data class SessionAssign(override val sequenceId: Long, val fold: SessionAssignFold) : Adjustment
+        data class OfferReconcile(override val sequenceId: Long, val fold: OfferReconcileFold) : Adjustment
+        data class OfferOutcomeCorrect(override val sequenceId: Long, val fold: OfferOutcomeCorrectionFold) : Adjustment
     }
 
     /** A #159 store-resolution trigger carrying its source event's [sequenceId] for the seq-ordered
@@ -487,6 +498,78 @@ class AnalyticsProjector @Inject constructor(
         )
         if (oldSessionId != null) analyticsDao.bumpSessionDeliveries(oldSessionId, -1)
         if (newSessionId != null) analyticsDao.bumpSessionDeliveries(newSessionId, +1)
+        return false
+    }
+
+    /**
+     * #810 B2 Tier 1 — resolve a `JOB_ACCEPT_MISMATCH` orphan from committed store evidence
+     * (resolve-from-rows, the #159 pattern). Reads the closing job's accepted `offer_records` (by the
+     * payload's offer hashes + session) and its delivered `delivery_records`, runs the pure
+     * [JobAcceptMismatchResolver] over their store names, and stamps `UNASSIGNED_INFERRED` on the ONE
+     * cross-store orphan it proves. **Any ambiguity is a no-op** (INCONCLUSIVE → Tier 2) — it re-prices
+     * nothing and mutates only the new `outcomeResolved` column. Runs inside the batch transaction after
+     * the delivery/offer upserts, so a same-batch job is already committed; deterministic on a from-zero
+     * refold because the mismatch event sequences after the job's offers/deliveries.
+     *
+     * Returns true only for the defensive skips (no sessionId / no offer hashes / <2 accepted rows) — an
+     * INCONCLUSIVE resolution is a valid processed no-op, not a skip.
+     */
+    private suspend fun applyOfferReconcile(fold: OfferReconcileFold): Boolean {
+        val sid = fold.sessionId ?: run {
+            Timber.tag(TAG).w("JOB_ACCEPT_MISMATCH reconcile: job has no sessionId — skipped")
+            return true
+        }
+        if (fold.acceptedOfferHashes.isEmpty()) return true
+        val acceptedRows = analyticsDao.offerRecordsByHashes(
+            fold.acceptedOfferHashes, sid, AppEventType.OFFER_ACCEPTED.name,
+        )
+        // Need ≥2 accepted rows to have an orphan to disambiguate (the resolver also guards this).
+        if (acceptedRows.size < 2) return true
+        val deliveredForms = analyticsDao.deliveryRecordsForJob(fold.jobId).flatMap { row ->
+            buildList {
+                row.storeName?.let { add(it) }
+                addAll(StoreResolutionRunner.decodeForms(row.payoutStoreForms))
+            }
+        }
+        val orphanSeq = JobAcceptMismatchResolver.resolveOrphan(
+            acceptedOffers = acceptedRows.map {
+                JobAcceptMismatchResolver.AcceptedOffer(it.eventSequenceId, it.merchantName)
+            },
+            deliveredStoreForms = deliveredForms,
+        ) ?: return false // INCONCLUSIVE (same-store tie / multi-unmatched / no evidence) → Tier 2.
+        analyticsDao.stampOfferOutcomeResolved(orphanSeq, OfferOutcomeResolution.UNASSIGNED_INFERRED)
+        return false
+    }
+
+    /**
+     * #810 B2 Tier 2 — apply a driver `OFFER_OUTCOME_CORRECTION` by-PK: stamp `offer_records
+     * .outcomeResolved` (`UNASSIGNED_ATTESTED`, or null to UNDO), never any frozen estimate column.
+     * Returns true iff SKIPPED (a counted skip + PII-safe WARN). Three fail-closed guards: target row
+     * exists, it is an ACCEPTED offer (only an accept can be an orphan), and the resolution value is
+     * known (`UNASSIGNED_ATTESTED` or null). Because the correction sequences after its target's
+     * `OFFER_ACCEPTED`, a from-zero refold reproduces the identical stamp.
+     */
+    private suspend fun applyOfferOutcomeCorrection(fold: OfferOutcomeCorrectionFold): Boolean {
+        val row = analyticsDao.offerRecord(fold.targetOfferEventSequenceId) ?: run {
+            Timber.tag(TAG).w("OFFER_OUTCOME_CORRECTION: target offer row %d not found", fold.targetOfferEventSequenceId)
+            return true
+        }
+        if (row.outcome != AppEventType.OFFER_ACCEPTED.name) {
+            Timber.tag(TAG).w(
+                "OFFER_OUTCOME_CORRECTION: offer row %d is not an accepted offer — skipped",
+                fold.targetOfferEventSequenceId,
+            )
+            return true
+        }
+        val resolved = fold.resolvedOutcome
+        if (resolved != null && resolved != OfferOutcomeResolution.UNASSIGNED_ATTESTED) {
+            Timber.tag(TAG).w(
+                "OFFER_OUTCOME_CORRECTION: unknown resolution value for offer row %d — skipped",
+                fold.targetOfferEventSequenceId,
+            )
+            return true
+        }
+        analyticsDao.stampOfferOutcomeResolved(fold.targetOfferEventSequenceId, resolved)
         return false
     }
 
@@ -795,7 +878,16 @@ class AnalyticsProjector @Inject constructor(
          * those stay chain-only — a partial, honest backfill). Purely a projection re-key: `app_events`,
          * every frozen economy column, and pay/net/miles are untouched. Precedented side effect (as
          * v2/v3/v4/v6): the refold also re-stamps `CURRENT_FALLBACK` rows against today's economy.
+         * v8 (#810 B2): the from-zero refold re-processes the `JOB_ACCEPT_MISMATCH` tripwire events
+         * already in the log (the seq-114 orphan) through the Tier-1 store-evidence join, stamping
+         * `offer_records.outcomeResolved = UNASSIGNED_INFERRED` on any single cross-store orphan and
+         * leaving the fielded same-store shape NULL (for Tier-2 driver attestation). A new event type
+         * (`OFFER_OUTCOME_CORRECTION`) folds on a fresh drain and cannot exist in already-folded history,
+         * so the bump exists for the Tier-1 retro-resolve, not the correction. Purely a projection re-key
+         * of the new nullable column: `app_events`, every frozen economy column, and pay/net/miles are
+         * untouched. Precedented side effect (as v2/v3/v4/v6/v7): the refold also re-stamps
+         * `CURRENT_FALLBACK` rows against today's economy.
          */
-        private const val PROJECTOR_VERSION = 7
+        private const val PROJECTOR_VERSION = 8
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -236,7 +236,7 @@ class AnalyticsProjector @Inject constructor(
                     is Adjustment.Pay -> applyPayAdjustment(adj.fold)
                     is Adjustment.Delivery -> applyDeliveryAdjustment(adj.fold)
                     is Adjustment.SessionAssign -> applySessionAssign(adj.fold)
-                    is Adjustment.OfferReconcile -> applyOfferReconcile(adj.fold)
+                    is Adjustment.OfferReconcile -> applyOfferReconcile(adj.fold, adj.sequenceId)
                     is Adjustment.OfferOutcomeCorrect -> applyOfferOutcomeCorrection(adj.fold)
                 }
                 if (skipped) adjustmentSkips++
@@ -507,25 +507,54 @@ class AnalyticsProjector @Inject constructor(
      * payload's offer hashes + session) and its delivered `delivery_records`, runs the pure
      * [JobAcceptMismatchResolver] over their store names, and stamps `UNASSIGNED_INFERRED` on the ONE
      * cross-store orphan it proves. **Any ambiguity is a no-op** (INCONCLUSIVE → Tier 2) — it re-prices
-     * nothing and mutates only the new `outcomeResolved` column. Runs inside the batch transaction after
-     * the delivery/offer upserts, so a same-batch job is already committed; deterministic on a from-zero
-     * refold because the mismatch event sequences after the job's offers/deliveries.
+     * nothing and mutates only the new `outcomeResolved` column.
+     *
+     * **Paging-independence (review F1).** The evidence read is scoped to `eventSequenceId <
+     * [mismatchSeq]` — the rows sequenced BEFORE this mismatch event. The state machine now emits
+     * `JOB_ACCEPT_MISMATCH` AFTER the closing job's final `DELIVERY_COMPLETED` (both on the same close
+     * step; EffectMap review F1), so all of the job's delivered rows sort before the mismatch and this
+     * bound is a no-op on today's order — but it makes the reconcile deterministic across page
+     * boundaries AND for HISTORICAL logs carrying the OLD (mismatch-first) order: there the closing
+     * drop's row is `> mismatchSeq`, excluded, so the evidence is short one store and the mismatch
+     * deterministically falls to Tier 2 (fail-null) whether folded incrementally or from-zero.
+     *
+     * **Missing-evidence guard (review F2).** If ANY delivered row has NO usable store evidence (blank
+     * `storeName` AND empty decoded `payoutStoreForms`), the delivered-store set is incomplete and a
+     * DELIVERED offer could be mis-stamped as the orphan — so bail to INCONCLUSIVE (Tier 2).
      *
      * Returns true only for the defensive skips (no sessionId / no offer hashes / <2 accepted rows) — an
      * INCONCLUSIVE resolution is a valid processed no-op, not a skip.
      */
-    private suspend fun applyOfferReconcile(fold: OfferReconcileFold): Boolean {
+    private suspend fun applyOfferReconcile(fold: OfferReconcileFold, mismatchSeq: Long): Boolean {
         val sid = fold.sessionId ?: run {
             Timber.tag(TAG).w("JOB_ACCEPT_MISMATCH reconcile: job has no sessionId — skipped")
             return true
         }
-        if (fold.acceptedOfferHashes.isEmpty()) return true
+        if (fold.acceptedOfferHashes.isEmpty()) {
+            Timber.tag(TAG).w("JOB_ACCEPT_MISMATCH reconcile: no accepted offer hashes on the mismatch — skipped")
+            return true
+        }
         val acceptedRows = analyticsDao.offerRecordsByHashes(
             fold.acceptedOfferHashes, sid, AppEventType.OFFER_ACCEPTED.name,
         )
         // Need ≥2 accepted rows to have an orphan to disambiguate (the resolver also guards this).
-        if (acceptedRows.size < 2) return true
-        val deliveredForms = analyticsDao.deliveryRecordsForJob(fold.jobId).flatMap { row ->
+        if (acceptedRows.size < 2) {
+            Timber.tag(TAG).w(
+                "JOB_ACCEPT_MISMATCH reconcile: %d accepted offer row(s) found (<2) — skipped",
+                acceptedRows.size,
+            )
+            return true
+        }
+        // F1: evidence is only the rows sequenced before this mismatch (paging + historical-order safe).
+        val deliveredRows = analyticsDao.deliveryRecordsForJob(fold.jobId)
+            .filter { it.eventSequenceId < mismatchSeq }
+        // F2: a delivered row with NO store evidence would silently shrink the delivered-store set and
+        // could make the resolver stamp a DELIVERED offer as the orphan — fail-null to Tier 2 instead.
+        val anyEvidenceless = deliveredRows.any {
+            it.storeName.isNullOrBlank() && StoreResolutionRunner.decodeForms(it.payoutStoreForms).isEmpty()
+        }
+        if (anyEvidenceless) return false
+        val deliveredForms = deliveredRows.flatMap { row ->
             buildList {
                 row.storeName?.let { add(it) }
                 addAll(StoreResolutionRunner.decodeForms(row.payoutStoreForms))

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -365,17 +365,24 @@ class AnalyticsRepository @Inject constructor(
         }
 
     /**
-     * The still-open orphan-offer mismatches for [period] (#810 B2 Tier 2) — the driver-attestation
-     * surface. Joins each `JOB_ACCEPT_MISMATCH` event (whose payload carries the closing job's accepted
-     * offer hashes + the mismatch counts) to the ACCEPTED `offer_records`, and keeps only the groups
-     * still owed a resolution (`resolvedCount < orphansOwed` with at least one unresolved offer). The
-     * projector's Tier-1 store-evidence join has already auto-resolved every cross-store orphan
-     * (`outcomeResolved = UNASSIGNED_INFERRED`), so this surface is the same-store residue only.
+     * The orphan-offer mismatches for [period] (#810 B2 Tier 2) — the driver-attestation surface. Joins
+     * each `JOB_ACCEPT_MISMATCH` event (whose payload carries the closing job's accepted offer hashes +
+     * the mismatch counts) to the ACCEPTED `offer_records`. The projector's Tier-1 store-evidence join
+     * has already auto-resolved every cross-store orphan (`outcomeResolved = UNASSIGNED_INFERRED`), so
+     * this surface is the same-store residue.
      *
-     * Reactive: re-emits as the projector folds a mismatch, folds an `OFFER_OUTCOME_CORRECTION`
-     * (an attestation shrinks the open set), or Tier-1 resolves one. Period-anchored on the mismatch
-     * event's `occurredAt` (the close time), consistent with the Money-tab window. No new PII surface —
-     * store/pay/time are merchant/decision data; no customer hashes.
+     * A group is listed while its mismatch owes ≥1 orphan (`orphansOwed > 0`) and its accepted offers
+     * are present — **including once its orphans are resolved** (review F3): keeping a resolved group
+     * visible is what makes the mis-tap UNDO reachable in the primary 1-owed/2-accept shape (the
+     * callout gates on the still-OWED count via [OrphanOfferGroup.owedRemaining], so a fully-resolved
+     * group no longer contributes to the callout, but its rows stay in the dialog for undo). Residual:
+     * if EVERY listed group is fully resolved the callout hides, so re-opening to undo the very last
+     * resolution isn't reachable until a new mismatch appears (documented).
+     *
+     * Reactive: re-emits as the projector folds a mismatch, folds an `OFFER_OUTCOME_CORRECTION`, or
+     * Tier-1 resolves one. Period-anchored on the mismatch event's `occurredAt` (the close time),
+     * consistent with the Money-tab window. No new PII surface — store/pay/time are merchant/decision
+     * data; no customer hashes.
      */
     fun orphanOfferGroups(period: AnalyticsPeriod): Flow<List<OrphanOfferGroup>> =
         periodBoundariesFlow(period).flatMapLatest { (start, end) ->
@@ -393,9 +400,9 @@ class AnalyticsRepository @Inject constructor(
                         .mapNotNull { offersByKey[it to sid] }
                         .map { it.toOrphanCandidate() }
                     val owed = (payload.acceptedCount - payload.accountedCount).coerceAtLeast(0)
-                    val resolvedCount = candidates.count { it.resolved }
-                    // Still open iff fewer orphans resolved than owed AND ≥1 candidate remains to attest.
-                    if (owed > 0 && resolvedCount < owed && candidates.any { !it.resolved }) {
+                    // List every owed mismatch whose offers we found — resolved OR open (F3: keep the
+                    // undo reachable). owedRemaining (owed − resolved) drives the callout downstream.
+                    if (owed > 0 && candidates.isNotEmpty()) {
                         OrphanOfferGroup(
                             jobId = payload.jobId,
                             sessionId = sid,

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -2,9 +2,11 @@ package cloud.trotter.dashbuddy.core.data.analytics
 
 import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
 import cloud.trotter.dashbuddy.core.database.analytics.DeliveryTimeTotalsRow
+import cloud.trotter.dashbuddy.core.database.analytics.OfferRecordEntity
 import cloud.trotter.dashbuddy.core.database.analytics.OutcomeCountRow
 import cloud.trotter.dashbuddy.core.database.analytics.ScoreOutcomeRow
 import cloud.trotter.dashbuddy.core.database.analytics.SessionTotalsRow
+import cloud.trotter.dashbuddy.core.database.event.AppEventDao
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
@@ -20,8 +22,12 @@ import cloud.trotter.dashbuddy.domain.analytics.SessionSpan
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
 import cloud.trotter.dashbuddy.domain.analytics.StoreReportCard
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
+import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferCandidate
+import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferGroup
 import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
+import cloud.trotter.dashbuddy.domain.model.event.AppEventCodec
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.JobAcceptMismatchPayload
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.StoreKeys
 import java.time.Instant
@@ -62,6 +68,10 @@ import javax.inject.Singleton
 @OptIn(ExperimentalCoroutinesApi::class)
 class AnalyticsRepository @Inject constructor(
     private val analyticsDao: AnalyticsDao,
+    // #810 B2: the Tier-2 orphan-attestation surface reads the `JOB_ACCEPT_MISMATCH` events (the
+    // source-of-truth log) to enumerate a job's accepted offers — a DAO read, no economy dependency,
+    // so the "net is the frozen stored value" posture above is preserved.
+    private val appEventDao: AppEventDao,
 ) {
 
     /**
@@ -353,6 +363,67 @@ class AnalyticsRepository @Inject constructor(
         periodBoundariesFlow(period).flatMapLatest { (start, end) ->
             analyticsDao.noSessionDeliveryRows(start, end).map { rows -> rows.map { it.toDomain() } }
         }
+
+    /**
+     * The still-open orphan-offer mismatches for [period] (#810 B2 Tier 2) — the driver-attestation
+     * surface. Joins each `JOB_ACCEPT_MISMATCH` event (whose payload carries the closing job's accepted
+     * offer hashes + the mismatch counts) to the ACCEPTED `offer_records`, and keeps only the groups
+     * still owed a resolution (`resolvedCount < orphansOwed` with at least one unresolved offer). The
+     * projector's Tier-1 store-evidence join has already auto-resolved every cross-store orphan
+     * (`outcomeResolved = UNASSIGNED_INFERRED`), so this surface is the same-store residue only.
+     *
+     * Reactive: re-emits as the projector folds a mismatch, folds an `OFFER_OUTCOME_CORRECTION`
+     * (an attestation shrinks the open set), or Tier-1 resolves one. Period-anchored on the mismatch
+     * event's `occurredAt` (the close time), consistent with the Money-tab window. No new PII surface —
+     * store/pay/time are merchant/decision data; no customer hashes.
+     */
+    fun orphanOfferGroups(period: AnalyticsPeriod): Flow<List<OrphanOfferGroup>> =
+        periodBoundariesFlow(period).flatMapLatest { (start, end) ->
+            combine(
+                appEventDao.getEventsByType(AppEventType.JOB_ACCEPT_MISMATCH),
+                analyticsDao.acceptedOfferRecords(AppEventType.OFFER_ACCEPTED.name),
+            ) { mismatchRows, offerRows ->
+                val offersByKey: Map<Pair<String, String?>, OfferRecordEntity> =
+                    offerRows.associateBy { it.offerHash to it.sessionId }
+                mismatchRows.mapNotNull { row ->
+                    if (row.occurredAt < start || row.occurredAt >= end) return@mapNotNull null
+                    val payload = decodeMismatch(row.eventType, row.eventPayload) ?: return@mapNotNull null
+                    val sid = row.aggregateId
+                    val candidates = payload.acceptedOfferHashes
+                        .mapNotNull { offersByKey[it to sid] }
+                        .map { it.toOrphanCandidate() }
+                    val owed = (payload.acceptedCount - payload.accountedCount).coerceAtLeast(0)
+                    val resolvedCount = candidates.count { it.resolved }
+                    // Still open iff fewer orphans resolved than owed AND ≥1 candidate remains to attest.
+                    if (owed > 0 && resolvedCount < owed && candidates.any { !it.resolved }) {
+                        OrphanOfferGroup(
+                            jobId = payload.jobId,
+                            sessionId = sid,
+                            orphansOwed = owed,
+                            offers = candidates.sortedBy { it.decidedAt },
+                        )
+                    } else {
+                        null
+                    }
+                }.sortedByDescending { g -> g.offers.maxOfOrNull { it.decidedAt } ?: 0L }
+            }
+        }
+
+    /** Decode a `JOB_ACCEPT_MISMATCH` payload for the Tier-2 read; fail-null on a malformed row. */
+    private fun decodeMismatch(type: AppEventType, payloadJson: String): JobAcceptMismatchPayload? =
+        try {
+            AppEventCodec.decodePayload(type, payloadJson) as? JobAcceptMismatchPayload
+        } catch (_: Exception) {
+            null
+        }
+
+    private fun OfferRecordEntity.toOrphanCandidate() = OrphanOfferCandidate(
+        offerEventSequenceId = eventSequenceId,
+        storeName = merchantName,
+        payAmount = payAmount,
+        decidedAt = decidedAt,
+        resolved = outcomeResolved != null,
+    )
 
     /**
      * The **candidate dashes** an orphan delivery could be categorized into (#660 piece 2): ENDED

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CorrectionRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CorrectionRepository.kt
@@ -6,6 +6,8 @@ import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliverySessionAssignPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferOutcomeCorrectionPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferOutcomeResolution
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -161,6 +163,42 @@ class CorrectionRepository @Inject constructor(
         Timber.tag(TAG).i(
             "DELIVERY_SESSION_ASSIGN appended for delivery seq %d (assigned=%b)",
             targetEventSequenceId, newSessionId != null,
+        )
+    }
+
+    /**
+     * Append a driver attestation that an accepted offer was invisibly unassigned (#810 B2 Tier 2), or
+     * an UNDO. [targetOfferEventSequenceId] is the PK of the target `offer_record` (its source
+     * `OFFER_ACCEPTED` sequenceId). [attested] `true` stamps `outcomeResolved = UNASSIGNED_ATTESTED`
+     * (the accepted orphan leaves the counted-accept population); `false` clears it back to a normal
+     * counted accept (the undo). The projector applies the stamp — with its fail-closed guards (row
+     * exists, is an accepted offer, known value) — on its next drain; the original `OFFER_ACCEPTED`
+     * event and its `outcome` column stay, and it re-prices NOTHING.
+     *
+     * The event carries NO `sessionId` (it targets an offer row by PK; attribution/liveness is not
+     * touched, mirroring the corrections convention that a re-price/attest is bookkeeping, not activity).
+     */
+    suspend fun correctOfferOutcome(
+        targetOfferEventSequenceId: Long,
+        attested: Boolean,
+        note: String? = null,
+    ) {
+        appEventRepo.appendUserEvent(
+            AppEvent(
+                type = AppEventType.OFFER_OUTCOME_CORRECTION,
+                occurredAt = System.currentTimeMillis(),
+                sessionId = null,
+                payload = OfferOutcomeCorrectionPayload(
+                    targetOfferEventSequenceId = targetOfferEventSequenceId,
+                    resolvedOutcome = if (attested) OfferOutcomeResolution.UNASSIGNED_ATTESTED else null,
+                    note = note,
+                ),
+            ),
+        )
+        // P7: no note text — counts/ids only.
+        Timber.tag(TAG).i(
+            "OFFER_OUTCOME_CORRECTION appended for offer seq %d (attested=%b)",
+            targetOfferEventSequenceId, attested,
         )
     }
 

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsDailyEarningsTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsDailyEarningsTest.kt
@@ -50,7 +50,7 @@ class AnalyticsDailyEarningsTest {
             .allowMainThreadQueries()
             .build()
         dao = db.analyticsDao()
-        repo = AnalyticsRepository(dao)
+        repo = AnalyticsRepository(dao, db.appEventDao())
     }
 
     @After

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsDecisionsTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsDecisionsTest.kt
@@ -47,7 +47,7 @@ class AnalyticsDecisionsTest {
             .allowMainThreadQueries()
             .build()
         dao = db.analyticsDao()
-        repo = AnalyticsRepository(dao)
+        repo = AnalyticsRepository(dao, db.appEventDao())
     }
 
     @After

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsHeatmapTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsHeatmapTest.kt
@@ -44,7 +44,7 @@ class AnalyticsHeatmapTest {
             .allowMainThreadQueries()
             .build()
         dao = db.analyticsDao()
-        repo = AnalyticsRepository(dao)
+        repo = AnalyticsRepository(dao, db.appEventDao())
     }
 
     @After

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjectorTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjectorTest.kt
@@ -667,7 +667,7 @@ class AnalyticsProjectorTest {
         val deliverySeq = seedCorrectableSession(deliveryPay = 10.0, reportedEarnings = 20.0)
         projector().catchUp()
 
-        val repo = AnalyticsRepository(analyticsDao)
+        val repo = AnalyticsRepository(analyticsDao, eventDao)
         assertEquals("before: reported 20 − captured 10", 10.0, repo.sessionDetail("S1").first()!!.unattributedPay, 1e-9)
 
         // The driver re-prices the captured delivery up to $15 (a mis-captured tip).

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepositoryTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepositoryTest.kt
@@ -44,7 +44,7 @@ class AnalyticsRepositoryTest {
             .allowMainThreadQueries()
             .build()
         dao = db.analyticsDao()
-        repo = AnalyticsRepository(dao)
+        repo = AnalyticsRepository(dao, db.appEventDao())
     }
 
     @After

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsSessionDetailTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsSessionDetailTest.kt
@@ -42,7 +42,7 @@ class AnalyticsSessionDetailTest {
             .allowMainThreadQueries()
             .build()
         dao = db.analyticsDao()
-        repo = AnalyticsRepository(dao)
+        repo = AnalyticsRepository(dao, db.appEventDao())
     }
 
     @After

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsTimeTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsTimeTest.kt
@@ -52,7 +52,7 @@ class AnalyticsTimeTest {
             .allowMainThreadQueries()
             .build()
         dao = db.analyticsDao()
-        repo = AnalyticsRepository(dao)
+        repo = AnalyticsRepository(dao, db.appEventDao())
     }
 
     @After

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CorrectionRepositoryTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CorrectionRepositoryTest.kt
@@ -4,6 +4,8 @@ import cloud.trotter.dashbuddy.core.data.analytics.CorrectionRepository
 import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliverySessionAssignPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferOutcomeCorrectionPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferOutcomeResolution
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -111,6 +113,34 @@ class CorrectionRepositoryTest {
             runBlocking { repo.assignDeliverySession(targetEventSequenceId = 1L, newSessionId = "   ") }
         }
         verify(appEventRepo, never()).appendUserEvent(any(), anyOrNull())
+    }
+
+    // ── correctOfferOutcome (#810 B2 Tier 2) ────────────────────────────
+
+    @Test
+    fun `correctOfferOutcome attested appends an ATTESTED correction with no envelope sessionId`() = runTest {
+        repo.correctOfferOutcome(targetOfferEventSequenceId = 42L, attested = true, note = "chat unassign")
+
+        val captor = argumentCaptor<cloud.trotter.dashbuddy.domain.model.event.AppEvent>()
+        verify(appEventRepo).appendUserEvent(captor.capture(), anyOrNull())
+        val event = captor.firstValue
+        assertEquals(AppEventType.OFFER_OUTCOME_CORRECTION, event.type)
+        assertNull("an offer-outcome correction targets an offer by PK — no session envelope", event.sessionId)
+        val payload = event.payload as OfferOutcomeCorrectionPayload
+        assertEquals(42L, payload.targetOfferEventSequenceId)
+        assertEquals(OfferOutcomeResolution.UNASSIGNED_ATTESTED, payload.resolvedOutcome)
+        assertEquals("chat unassign", payload.note)
+    }
+
+    @Test
+    fun `correctOfferOutcome undo appends a null-resolution correction`() = runTest {
+        repo.correctOfferOutcome(targetOfferEventSequenceId = 7L, attested = false)
+
+        val captor = argumentCaptor<cloud.trotter.dashbuddy.domain.model.event.AppEvent>()
+        verify(appEventRepo).appendUserEvent(captor.capture(), anyOrNull())
+        val payload = captor.firstValue.payload as OfferOutcomeCorrectionPayload
+        assertEquals(7L, payload.targetOfferEventSequenceId)
+        assertNull("undo clears the resolution", payload.resolvedOutcome)
     }
 
     @Test

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/OrphanOfferResolutionTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/OrphanOfferResolutionTest.kt
@@ -114,6 +114,16 @@ class OrphanOfferResolutionTest {
         ),
     )
 
+    private suspend fun declined(sid: String, at: Long, hash: String, merchant: String): Long = insert(
+        AppEventType.OFFER_DECLINED, sid, at,
+        OfferPayload(
+            offerHash = hash,
+            parsedOffer = ParsedOffer(offerHash = hash, payAmount = 12.0, distanceMiles = 3.0),
+            evaluation = eval(merchant), outcome = AppEventType.OFFER_DECLINED,
+            presentedAt = at - 30, decidedAt = at, returnFlow = Flow.Idle,
+        ),
+    )
+
     private suspend fun mismatch(sid: String, at: Long, jobId: String, hashes: List<String>, accounted: Int) = insert(
         AppEventType.JOB_ACCEPT_MISMATCH, sid, at,
         JobAcceptMismatchPayload(
@@ -228,6 +238,89 @@ class OrphanOfferResolutionTest {
         )
         projector().catchUp() // must not throw
         assertEquals("the real accept is untouched", 1, acceptedCount())
+    }
+
+    @Test
+    fun `an attestation targeting a DECLINED offer is a no-op (only an accept can be an orphan)`() = runBlocking {
+        val s = "S1"
+        start(s)
+        val declinedSeq = declined(s, 2_000, "hD", "H-E-B")
+        stop(s, 3_000)
+        projector().catchUp()
+
+        insert(
+            AppEventType.OFFER_OUTCOME_CORRECTION, null, 4_000,
+            OfferOutcomeCorrectionPayload(declinedSeq, OfferOutcomeResolution.UNASSIGNED_ATTESTED),
+        )
+        projector().catchUp() // must not throw
+        assertNull("a declined offer is never resolvable as an orphan", analyticsDao.offerRecord(declinedSeq)!!.outcomeResolved)
+    }
+
+    @Test
+    fun `an attestation with an unknown resolution value is a no-op`() = runBlocking {
+        val s = "S1"
+        start(s)
+        val aSeq = accept(s, 2_000, "hA", "H-E-B")
+        stop(s, 3_000)
+        projector().catchUp()
+
+        insert(
+            AppEventType.OFFER_OUTCOME_CORRECTION, null, 4_000,
+            OfferOutcomeCorrectionPayload(aSeq, "SOME_GARBAGE_VALUE"),
+        )
+        projector().catchUp() // must not throw
+        assertNull("an unknown resolution value is rejected", analyticsDao.offerRecord(aSeq)!!.outcomeResolved)
+        assertEquals("count unchanged", 1, acceptedCount())
+    }
+
+    @Test
+    fun `Tier 1 bails to INCONCLUSIVE when a delivered row carries no store evidence (review F2)`() = runBlocking {
+        // 3 accepts: O(H-E-B, the true orphan), Y(H-E-B, delivered), X(Chipotle, delivered but its
+        // delivery row has a BLANK store + no payout forms). Without the guard the evidence set = {heb}
+        // and the resolver would wrongly stamp X (a DELIVERED offer) as the orphan; the guard bails.
+        val s = "S1"
+        start(s)
+        val oSeq = accept(s, 2_000, "hO", "H-E-B")
+        val ySeq = accept(s, 2_050, "hY", "H-E-B")
+        val xSeq = accept(s, 2_100, "hX", "Chipotle")
+        delivered(s, 3_000, "J1", "T-Y", "H-E-B")
+        delivered(s, 3_100, "J1", "T-X", "")   // blank store, no payout forms → evidenceless
+        mismatch(s, 3_500, "J1", listOf("hO", "hY", "hX"), accounted = 2)
+        stop(s, 4_000)
+
+        projector().catchUp()
+
+        assertNull("no auto-resolve on O", analyticsDao.offerRecord(oSeq)!!.outcomeResolved)
+        assertNull("no auto-resolve on Y", analyticsDao.offerRecord(ySeq)!!.outcomeResolved)
+        assertNull("the delivered Chipotle offer is NEVER mis-stamped as the orphan", analyticsDao.offerRecord(xSeq)!!.outcomeResolved)
+    }
+
+    @Test
+    fun `Tier 1 is paging-independent for a mismatch sequenced BEFORE its final delivery (review F1)`() = runBlocking {
+        // The OLD emission order (historical logs): JOB_ACCEPT_MISMATCH sequences BEFORE the closing
+        // job's final DELIVERY_COMPLETED. The seq-scoped evidence read excludes that later-sequenced
+        // delivery, so the reconcile deterministically falls to Tier 2 (fail-null) — the SAME outcome
+        // under paged incremental folding and a from-zero refold (the invariant the reviewer's probe broke).
+        val s = "S1"
+        start(s)
+        val hebSeq = accept(s, 2_000, "hA", "H-E-B")
+        accept(s, 2_100, "hB", "Whataburger")
+        mismatch(s, 3_000, "J1", listOf("hA", "hB"), accounted = 1)   // BEFORE the delivery
+        delivered(s, 3_100, "J1", "T1", "Whataburger")                // sequences after the mismatch
+        stop(s, 4_000)
+
+        // Paged incremental fold across small batch boundaries.
+        val live = projector()
+        while (live.processBatch(limit = 2) != null) { /* drain in pages */ }
+        val liveHeb = analyticsDao.offerRecord(hebSeq)!!.outcomeResolved
+
+        // From-zero refold.
+        analyticsDao.setWatermark(AnalyticsProjectionStateEntity(watermarkSequenceId = 999, projectorVersion = 99))
+        projector().catchUp()
+        val refoldHeb = analyticsDao.offerRecord(hebSeq)!!.outcomeResolved
+
+        assertEquals("incremental ≡ from-zero refold under the old order", liveHeb, refoldHeb)
+        assertNull("the later-sequenced delivery isn't evidence → deterministic Tier 2", refoldHeb)
     }
 
     // ── Determinism ─────────────────────────────────────────────────────

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/OrphanOfferResolutionTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/OrphanOfferResolutionTest.kt
@@ -1,0 +1,272 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import androidx.room.Room
+import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
+import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsProjectionStateEntity
+import cloud.trotter.dashbuddy.core.database.event.AppEventDao
+import cloud.trotter.dashbuddy.core.database.event.AppEventEntity
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
+import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
+import cloud.trotter.dashbuddy.domain.model.event.AppEventCodec
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.JobAcceptMismatchPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferOutcomeCorrectionPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferOutcomeResolution
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionEndSource
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartSource
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * #810 B2 — the durable, transactional edges of orphan-offer resolution against an in-memory Room DB:
+ * the projector's Tier-1 store-evidence join (cross-store auto-resolves, same-store falls through),
+ * the Tier-2 `OFFER_OUTCOME_CORRECTION` round-trip + undo, incremental ≡ from-zero refold, and the
+ * read-side count exclusion. The pure join predicate is covered in `:domain`'s
+ * `JobAcceptMismatchResolverTest`; this proves the resolve-from-rows orchestration.
+ */
+@RunWith(RobolectricTestRunner::class)
+class OrphanOfferResolutionTest {
+
+    private lateinit var db: DashBuddyDatabase
+    private lateinit var analyticsDao: AnalyticsDao
+    private lateinit var eventDao: AppEventDao
+    private lateinit var repo: AppEventRepo
+    private lateinit var prefs: AppPreferencesRepository
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(context, DashBuddyDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        analyticsDao = db.analyticsDao()
+        eventDao = db.appEventDao()
+        repo = AppEventRepo(db, eventDao, db.effectsFiredDao())
+        prefs = mock { on { userEconomy } doReturn flowOf(UserEconomy()) }
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun projector() = AnalyticsProjector(db, repo, eventDao, analyticsDao, prefs)
+
+    private suspend fun insert(
+        type: AppEventType,
+        sessionId: String?,
+        at: Long,
+        payload: AppEventPayload?,
+    ): Long = eventDao.insert(
+        AppEventEntity(
+            aggregateId = sessionId,
+            eventType = type,
+            eventPayload = payload?.let(AppEventCodec::encodePayload) ?: "{}",
+            occurredAt = at,
+        ),
+    )
+
+    private fun eval(merchant: String) = OfferEvaluation(
+        action = OfferAction.ACCEPT, score = 80.0, qualityLevel = OfferQuality.GOOD,
+        payAmount = 12.0, fuelCostEstimate = 0.0, nonFuelCostEstimate = 0.75,
+        operatingCostPerMile = 0.25, netPayAmount = 11.25, distanceMiles = 3.0,
+        dollarsPerMile = 4.0, dollarsPerHour = 20.0, estimatedTimeMinutes = 15.0,
+        itemCount = 1.0, merchantName = merchant,
+    )
+
+    private suspend fun accept(sid: String, at: Long, hash: String, merchant: String): Long = insert(
+        AppEventType.OFFER_ACCEPTED, sid, at,
+        OfferPayload(
+            offerHash = hash,
+            parsedOffer = ParsedOffer(offerHash = hash, payAmount = 12.0, distanceMiles = 3.0),
+            evaluation = eval(merchant), outcome = AppEventType.OFFER_ACCEPTED,
+            presentedAt = at - 30, decidedAt = at, returnFlow = Flow.Idle,
+        ),
+    )
+
+    private suspend fun delivered(sid: String, at: Long, jobId: String, taskId: String, store: String) = insert(
+        AppEventType.DELIVERY_COMPLETED, sid, at,
+        DeliveryPayload(
+            jobId = jobId, taskId = taskId, storeName = store, customerHash = "c-$taskId",
+            phaseStartedAt = at - 600, arrivedAt = at - 120, completedAt = at, totalPay = 10.0,
+        ),
+    )
+
+    private suspend fun mismatch(sid: String, at: Long, jobId: String, hashes: List<String>, accounted: Int) = insert(
+        AppEventType.JOB_ACCEPT_MISMATCH, sid, at,
+        JobAcceptMismatchPayload(
+            jobId = jobId, acceptedCount = hashes.size, accountedCount = accounted,
+            acceptedOfferHashes = hashes, deliveredCustomerHashes = emptyList(),
+            leftoverTbdPlaceholders = hashes.size - accounted, unassignedCount = 0,
+        ),
+    )
+
+    private suspend fun start(sid: String) = insert(
+        AppEventType.DASH_START, sid, 1_000,
+        SessionStartPayload(sid, Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+    )
+
+    private suspend fun stop(sid: String, at: Long) = insert(
+        AppEventType.DASH_STOP, sid, at,
+        SessionStopPayload(sid, endedAt = at, source = SessionEndSource.SUMMARY_SCREEN, totalEarnings = 10.0),
+    )
+
+    private suspend fun acceptedCount(): Int =
+        analyticsDao.offerOutcomes(0, Long.MAX_VALUE).first()
+            .find { it.outcome == AppEventType.OFFER_ACCEPTED.name }?.count ?: 0
+
+    // ── Tier 1 ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `Tier 1 auto-resolves a cross-store orphan and excludes it from the accepted count`() = runBlocking {
+        val s = "S1"
+        start(s)
+        val hebSeq = accept(s, 2_000, "hA", "H-E-B")
+        accept(s, 2_100, "hB", "Whataburger")
+        delivered(s, 3_000, "J1", "T1", "Whataburger")
+        mismatch(s, 3_500, "J1", listOf("hA", "hB"), accounted = 1)
+        stop(s, 4_000)
+
+        projector().catchUp()
+
+        assertEquals(
+            "the undelivered H-E-B offer is inferred-unassigned",
+            OfferOutcomeResolution.UNASSIGNED_INFERRED,
+            analyticsDao.offerRecord(hebSeq)!!.outcomeResolved,
+        )
+        assertEquals("the delivered Whataburger offer stays a normal accept", 1, acceptedCount())
+    }
+
+    @Test
+    fun `Tier 1 leaves a same-store mismatch INCONCLUSIVE (the fielded seq-114 shape)`() = runBlocking {
+        val s = "S1"
+        start(s)
+        val aSeq = accept(s, 2_000, "hA", "H-E-B")
+        val bSeq = accept(s, 2_100, "hB", "H-E-B")
+        delivered(s, 3_000, "J1", "T1", "H-E-B")
+        mismatch(s, 3_500, "J1", listOf("hA", "hB"), accounted = 1)
+        stop(s, 4_000)
+
+        projector().catchUp()
+
+        assertNull("same-store: no auto-resolve on hA", analyticsDao.offerRecord(aSeq)!!.outcomeResolved)
+        assertNull("same-store: no auto-resolve on hB", analyticsDao.offerRecord(bSeq)!!.outcomeResolved)
+        assertEquals("both accepts still counted — nothing silently resolved", 2, acceptedCount())
+    }
+
+    // ── Tier 2 ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `Tier 2 attestation resolves a same-store orphan and undo restores the count`() = runBlocking {
+        val s = "S1"
+        start(s)
+        val aSeq = accept(s, 2_000, "hA", "H-E-B")
+        accept(s, 2_100, "hB", "H-E-B")
+        delivered(s, 3_000, "J1", "T1", "H-E-B")
+        mismatch(s, 3_500, "J1", listOf("hA", "hB"), accounted = 1)
+        stop(s, 4_000)
+        projector().catchUp()
+        assertEquals("both counted before attestation", 2, acceptedCount())
+
+        // The driver attests offer hA was the unassigned one.
+        insert(
+            AppEventType.OFFER_OUTCOME_CORRECTION, null, 5_000,
+            OfferOutcomeCorrectionPayload(aSeq, OfferOutcomeResolution.UNASSIGNED_ATTESTED),
+        )
+        projector().catchUp()
+        assertEquals(
+            "hA is driver-attested unassigned",
+            OfferOutcomeResolution.UNASSIGNED_ATTESTED,
+            analyticsDao.offerRecord(aSeq)!!.outcomeResolved,
+        )
+        assertEquals("attested orphan leaves the accepted count", 1, acceptedCount())
+
+        // Undo (null resolution) restores it to a normal counted accept.
+        insert(
+            AppEventType.OFFER_OUTCOME_CORRECTION, null, 6_000,
+            OfferOutcomeCorrectionPayload(aSeq, null),
+        )
+        projector().catchUp()
+        assertNull("undo clears the resolution", analyticsDao.offerRecord(aSeq)!!.outcomeResolved)
+        assertEquals("count restored", 2, acceptedCount())
+    }
+
+    @Test
+    fun `an attestation targeting a non-accepted or missing offer is a no-op`() = runBlocking {
+        val s = "S1"
+        start(s)
+        accept(s, 2_000, "hA", "H-E-B")
+        stop(s, 3_000)
+        projector().catchUp()
+
+        // Target a sequenceId that has no offer_record → skipped, no crash.
+        insert(
+            AppEventType.OFFER_OUTCOME_CORRECTION, null, 4_000,
+            OfferOutcomeCorrectionPayload(999_999, OfferOutcomeResolution.UNASSIGNED_ATTESTED),
+        )
+        projector().catchUp() // must not throw
+        assertEquals("the real accept is untouched", 1, acceptedCount())
+    }
+
+    // ── Determinism ─────────────────────────────────────────────────────
+
+    @Test
+    fun `Tier 1 + Tier 2 resolution is reproduced by a from-zero refold`() = runBlocking {
+        val s = "S1"
+        start(s)
+        val hebSeq = accept(s, 2_000, "hA", "H-E-B")            // cross-store orphan (Tier 1)
+        val wSeq = accept(s, 2_100, "hB", "Whataburger")
+        delivered(s, 3_000, "J1", "T1", "Whataburger")
+        mismatch(s, 3_500, "J1", listOf("hA", "hB"), accounted = 1)
+        // A same-store second job, resolved by Tier-2 attestation.
+        val cSeq = accept(s, 4_000, "hC", "Chipotle")
+        accept(s, 4_100, "hD", "Chipotle")
+        delivered(s, 5_000, "J2", "T2", "Chipotle")
+        mismatch(s, 5_500, "J2", listOf("hC", "hD"), accounted = 1)
+        insert(
+            AppEventType.OFFER_OUTCOME_CORRECTION, null, 6_000,
+            OfferOutcomeCorrectionPayload(cSeq, OfferOutcomeResolution.UNASSIGNED_ATTESTED),
+        )
+        stop(s, 7_000)
+
+        // Incremental fold across small batch boundaries.
+        val live = projector()
+        while (live.processBatch(limit = 2) != null) { /* drain in pages */ }
+        val liveHeb = analyticsDao.offerRecord(hebSeq)!!.outcomeResolved
+        val liveW = analyticsDao.offerRecord(wSeq)!!.outcomeResolved
+        val liveC = analyticsDao.offerRecord(cSeq)!!.outcomeResolved
+
+        // From-zero refold (projectorVersion bump wipes + refolds in one drain).
+        analyticsDao.setWatermark(AnalyticsProjectionStateEntity(watermarkSequenceId = 999, projectorVersion = 99))
+        projector().catchUp()
+
+        assertEquals("Tier-1 inferred orphan reproduced", liveHeb, analyticsDao.offerRecord(hebSeq)!!.outcomeResolved)
+        assertEquals("survivor stays null on refold", liveW, analyticsDao.offerRecord(wSeq)!!.outcomeResolved)
+        assertEquals("Tier-2 attested orphan reproduced", liveC, analyticsDao.offerRecord(cSeq)!!.outcomeResolved)
+        assertEquals(OfferOutcomeResolution.UNASSIGNED_INFERRED, analyticsDao.offerRecord(hebSeq)!!.outcomeResolved)
+        assertNull(analyticsDao.offerRecord(wSeq)!!.outcomeResolved)
+        assertEquals(OfferOutcomeResolution.UNASSIGNED_ATTESTED, analyticsDao.offerRecord(cSeq)!!.outcomeResolved)
+    }
+}

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreReadsTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreReadsTest.kt
@@ -38,7 +38,7 @@ class StoreReadsTest {
             .allowMainThreadQueries()
             .build()
         dao = db.analyticsDao()
-        repo = AnalyticsRepository(dao)
+        repo = AnalyticsRepository(dao, db.appEventDao())
     }
 
     @After

--- a/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/15.json
+++ b/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/15.json
@@ -1,0 +1,1130 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 15,
+    "identityHash": "2678f7bffa4140465b061b9ecc83a91d",
+    "entities": [
+      {
+        "tableName": "app_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `aggregateId` TEXT, `eventType` TEXT NOT NULL, `eventPayload` TEXT NOT NULL, `occurredAt` INTEGER NOT NULL, `metadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "aggregateId",
+            "columnName": "aggregateId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventPayload",
+            "columnName": "eventPayload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_app_events_aggregateId",
+            "unique": false,
+            "columnNames": [
+              "aggregateId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_aggregateId` ON `${TABLE_NAME}` (`aggregateId`)"
+          },
+          {
+            "name": "index_app_events_eventType",
+            "unique": false,
+            "columnNames": [
+              "eventType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_eventType` ON `${TABLE_NAME}` (`eventType`)"
+          },
+          {
+            "name": "index_app_events_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "app_state_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`correlationVersion` INTEGER NOT NULL, `capturedAt` INTEGER NOT NULL, `sessionId` TEXT, `stateJson` TEXT NOT NULL, PRIMARY KEY(`correlationVersion`))",
+        "fields": [
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stateJson",
+            "columnName": "stateJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "correlationVersion"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `dashId` TEXT, `text` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `personaType` TEXT NOT NULL, `personaName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dashId",
+            "columnName": "dashId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaType",
+            "columnName": "personaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaName",
+            "columnName": "personaName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_dashId",
+            "unique": false,
+            "columnNames": [
+              "dashId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_dashId` ON `${TABLE_NAME}` (`dashId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "effects_fired",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `effectKey` TEXT NOT NULL, `firedAt` INTEGER NOT NULL, `correlationVersion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "effectKey",
+            "columnName": "effectKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firedAt",
+            "columnName": "firedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_effects_fired_effectKey",
+            "unique": true,
+            "columnNames": [
+              "effectKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_effects_fired_effectKey` ON `${TABLE_NAME}` (`effectKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "observations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `occurredAt` INTEGER NOT NULL, `sessionId` TEXT, `pipelineId` TEXT NOT NULL, `ruleId` TEXT, `platform` TEXT, `flow` TEXT, `modeHint` TEXT, `parsedJson` TEXT NOT NULL, `captureId` TEXT, `metadataJson` TEXT NOT NULL, `correlationVersion` INTEGER NOT NULL, `timeoutType` TEXT, `payloadJson` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pipelineId",
+            "columnName": "pipelineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "ruleId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "flow",
+            "columnName": "flow",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modeHint",
+            "columnName": "modeHint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "parsedJson",
+            "columnName": "parsedJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "captureId",
+            "columnName": "captureId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeoutType",
+            "columnName": "timeoutType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadJson",
+            "columnName": "payloadJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_observations_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_observations_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          },
+          {
+            "name": "index_observations_correlationVersion",
+            "unique": false,
+            "columnNames": [
+              "correlationVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_correlationVersion` ON `${TABLE_NAME}` (`correlationVersion`)"
+          }
+        ]
+      },
+      {
+        "tableName": "delivery_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `jobId` TEXT NOT NULL, `taskId` TEXT NOT NULL, `storeName` TEXT, `customerHash` TEXT, `addressHash` TEXT, `phaseStartedAt` INTEGER NOT NULL, `arrivedAt` INTEGER, `completedAt` INTEGER NOT NULL, `deadlineMillis` INTEGER, `realizedPay` REAL, `payBasis` TEXT NOT NULL, `tip` REAL, `basePay` REAL, `odometerAtCompletion` REAL, `realizedMiles` REAL, `realizedMinutes` REAL, `frozenCostPerMile` REAL, `frozenFuelPerMile` REAL, `frozenNonFuelPerMile` REAL, `netProfit` REAL, `costBasis` TEXT NOT NULL, `cashTip` REAL, `originalPayBasis` TEXT, `storeKey` TEXT, `payoutStoreForms` TEXT, `storeKeyPinned` INTEGER NOT NULL DEFAULT 0, `milesToStore` REAL, `milesToDropoff` REAL, `sessionAssigned` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeName",
+            "columnName": "storeName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customerHash",
+            "columnName": "customerHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addressHash",
+            "columnName": "addressHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "phaseStartedAt",
+            "columnName": "phaseStartedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arrivedAt",
+            "columnName": "arrivedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deadlineMillis",
+            "columnName": "deadlineMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "realizedPay",
+            "columnName": "realizedPay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "payBasis",
+            "columnName": "payBasis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tip",
+            "columnName": "tip",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "basePay",
+            "columnName": "basePay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "odometerAtCompletion",
+            "columnName": "odometerAtCompletion",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "realizedMiles",
+            "columnName": "realizedMiles",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "realizedMinutes",
+            "columnName": "realizedMinutes",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenCostPerMile",
+            "columnName": "frozenCostPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenFuelPerMile",
+            "columnName": "frozenFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenNonFuelPerMile",
+            "columnName": "frozenNonFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "netProfit",
+            "columnName": "netProfit",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "costBasis",
+            "columnName": "costBasis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cashTip",
+            "columnName": "cashTip",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "originalPayBasis",
+            "columnName": "originalPayBasis",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payoutStoreForms",
+            "columnName": "payoutStoreForms",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "storeKeyPinned",
+            "columnName": "storeKeyPinned",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "milesToStore",
+            "columnName": "milesToStore",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "milesToDropoff",
+            "columnName": "milesToDropoff",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "sessionAssigned",
+            "columnName": "sessionAssigned",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_delivery_records_completedAt",
+            "unique": false,
+            "columnNames": [
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_completedAt` ON `${TABLE_NAME}` (`completedAt`)"
+          },
+          {
+            "name": "index_delivery_records_platform_completedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_platform_completedAt` ON `${TABLE_NAME}` (`platform`, `completedAt`)"
+          },
+          {
+            "name": "index_delivery_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_delivery_records_sessionId_jobId",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "jobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_sessionId_jobId` ON `${TABLE_NAME}` (`sessionId`, `jobId`)"
+          },
+          {
+            "name": "index_delivery_records_jobId",
+            "unique": false,
+            "columnNames": [
+              "jobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_jobId` ON `${TABLE_NAME}` (`jobId`)"
+          },
+          {
+            "name": "index_delivery_records_storeName",
+            "unique": false,
+            "columnNames": [
+              "storeName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_storeName` ON `${TABLE_NAME}` (`storeName`)"
+          },
+          {
+            "name": "index_delivery_records_storeKey",
+            "unique": false,
+            "columnNames": [
+              "storeKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_storeKey` ON `${TABLE_NAME}` (`storeKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "session_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `platform` TEXT NOT NULL, `startedAt` INTEGER NOT NULL, `endedAt` INTEGER, `lastEventAt` INTEGER NOT NULL, `endSource` TEXT, `startSource` TEXT, `startOdometer` REAL, `lastOdometer` REAL, `reportedEarnings` REAL, `reportedDurationMillis` INTEGER, `offersReceived` INTEGER NOT NULL, `offersAccepted` INTEGER NOT NULL, `offersDeclined` INTEGER NOT NULL, `offersTimeout` INTEGER NOT NULL, `deliveries` INTEGER NOT NULL, `jobsCompleted` INTEGER NOT NULL, `legStateJson` TEXT, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "endedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastEventAt",
+            "columnName": "lastEventAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endSource",
+            "columnName": "endSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startSource",
+            "columnName": "startSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startOdometer",
+            "columnName": "startOdometer",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "lastOdometer",
+            "columnName": "lastOdometer",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "reportedEarnings",
+            "columnName": "reportedEarnings",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "reportedDurationMillis",
+            "columnName": "reportedDurationMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "offersReceived",
+            "columnName": "offersReceived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersAccepted",
+            "columnName": "offersAccepted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersDeclined",
+            "columnName": "offersDeclined",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersTimeout",
+            "columnName": "offersTimeout",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deliveries",
+            "columnName": "deliveries",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobsCompleted",
+            "columnName": "jobsCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "legStateJson",
+            "columnName": "legStateJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_records_startedAt",
+            "unique": false,
+            "columnNames": [
+              "startedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_records_startedAt` ON `${TABLE_NAME}` (`startedAt`)"
+          },
+          {
+            "name": "index_session_records_platform_startedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "startedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_records_platform_startedAt` ON `${TABLE_NAME}` (`platform`, `startedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "offer_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `offerHash` TEXT NOT NULL, `outcome` TEXT NOT NULL, `presentedAt` INTEGER NOT NULL, `decidedAt` INTEGER NOT NULL, `payAmount` REAL, `distanceMiles` REAL, `itemCount` INTEGER NOT NULL, `merchantName` TEXT, `score` REAL, `action` TEXT, `quality` TEXT, `estNetPay` REAL, `estDollarsPerHour` REAL, `estDollarsPerMile` REAL, `estTimeMinutes` REAL, `estOperatingCostPerMile` REAL, `estFuelPerMile` REAL, `estNonFuelPerMile` REAL, `storeKey` TEXT, `linkedJobId` TEXT, `outcomeResolved` TEXT, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offerHash",
+            "columnName": "offerHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outcome",
+            "columnName": "outcome",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentedAt",
+            "columnName": "presentedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decidedAt",
+            "columnName": "decidedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payAmount",
+            "columnName": "payAmount",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "distanceMiles",
+            "columnName": "distanceMiles",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchantName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "action",
+            "columnName": "action",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quality",
+            "columnName": "quality",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "estNetPay",
+            "columnName": "estNetPay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estDollarsPerHour",
+            "columnName": "estDollarsPerHour",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estDollarsPerMile",
+            "columnName": "estDollarsPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estTimeMinutes",
+            "columnName": "estTimeMinutes",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estOperatingCostPerMile",
+            "columnName": "estOperatingCostPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estFuelPerMile",
+            "columnName": "estFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estNonFuelPerMile",
+            "columnName": "estNonFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "linkedJobId",
+            "columnName": "linkedJobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "outcomeResolved",
+            "columnName": "outcomeResolved",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_offer_records_decidedAt",
+            "unique": false,
+            "columnNames": [
+              "decidedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_decidedAt` ON `${TABLE_NAME}` (`decidedAt`)"
+          },
+          {
+            "name": "index_offer_records_platform_decidedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "decidedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_platform_decidedAt` ON `${TABLE_NAME}` (`platform`, `decidedAt`)"
+          },
+          {
+            "name": "index_offer_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_offer_records_offerHash",
+            "unique": false,
+            "columnNames": [
+              "offerHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_offerHash` ON `${TABLE_NAME}` (`offerHash`)"
+          },
+          {
+            "name": "index_offer_records_linkedJobId",
+            "unique": false,
+            "columnNames": [
+              "linkedJobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_linkedJobId` ON `${TABLE_NAME}` (`linkedJobId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "analytics_projection_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `watermarkSequenceId` INTEGER NOT NULL, `projectorVersion` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watermarkSequenceId",
+            "columnName": "watermarkSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "projectorVersion",
+            "columnName": "projectorVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stores",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storeKey` TEXT NOT NULL, `platform` TEXT NOT NULL, `normalizedChain` TEXT NOT NULL, `chainDisplay` TEXT NOT NULL, `runningKey` TEXT, `offerNameForm` TEXT, `pickupNameForm` TEXT, `payoutNameForm` TEXT, `address` TEXT, PRIMARY KEY(`storeKey`))",
+        "fields": [
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedChain",
+            "columnName": "normalizedChain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chainDisplay",
+            "columnName": "chainDisplay",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningKey",
+            "columnName": "runningKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "offerNameForm",
+            "columnName": "offerNameForm",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pickupNameForm",
+            "columnName": "pickupNameForm",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payoutNameForm",
+            "columnName": "payoutNameForm",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storeKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stores_normalizedChain",
+            "unique": false,
+            "columnNames": [
+              "normalizedChain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stores_normalizedChain` ON `${TABLE_NAME}` (`normalizedChain`)"
+          }
+        ]
+      },
+      {
+        "tableName": "pickup_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `jobId` TEXT NOT NULL, `taskId` TEXT NOT NULL, `storeName` TEXT NOT NULL, `storeKey` TEXT, `phaseStartedAt` INTEGER NOT NULL, `arrivedAt` INTEGER, `confirmedAt` INTEGER, `deadlineMillis` INTEGER, `activity` TEXT, `storeAddress` TEXT, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeName",
+            "columnName": "storeName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "phaseStartedAt",
+            "columnName": "phaseStartedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arrivedAt",
+            "columnName": "arrivedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "confirmedAt",
+            "columnName": "confirmedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "deadlineMillis",
+            "columnName": "deadlineMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "activity",
+            "columnName": "activity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "storeAddress",
+            "columnName": "storeAddress",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pickup_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pickup_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_pickup_records_jobId",
+            "unique": false,
+            "columnNames": [
+              "jobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pickup_records_jobId` ON `${TABLE_NAME}` (`jobId`)"
+          },
+          {
+            "name": "index_pickup_records_storeKey",
+            "unique": false,
+            "columnNames": [
+              "storeKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pickup_records_storeKey` ON `${TABLE_NAME}` (`storeKey`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2678f7bffa4140465b061b9ecc83a91d')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration14to15Test.kt
+++ b/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration14to15Test.kt
@@ -1,0 +1,67 @@
+package cloud.trotter.dashbuddy.core.database
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * #810 B2 — execute the REAL committed `AutoMigration(14→15)` against a **populated** v14 database and
+ * prove it is additive-only: the pre-existing analytics rows survive, and the one new nullable column
+ * (offer_records.outcomeResolved) is present and NULL on existing rows. The `PROJECTOR_VERSION` 7→8
+ * refold this bump triggers re-resolves the `JOB_ACCEPT_MISMATCH` events already in the log, so the
+ * NULL post-migration value is transient for a cross-store orphan (stamped `UNASSIGNED_INFERRED`) and
+ * correct-forever for the same-store residue (left for Tier-2 attestation).
+ *
+ * Instrumented (androidTest) because [MigrationTestHelper] opens an on-disk SQLite DB via the framework
+ * factory and replays the exported schema JSONs. Runs under `:core:database:connectedAndroidTest` — it
+ * does NOT gate unit-only PR CI (the unit-level [SchemaVersionGuardTest] is the CI-gating guard); needs
+ * one device/emulator run before merge.
+ */
+@RunWith(AndroidJUnit4::class)
+class AnalyticsMigration14to15Test {
+
+    private val dbName = "migration-14-to-15-test"
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        DashBuddyDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory(),
+    )
+
+    @Test
+    fun migrate14To15_preservesRows_addsOutcomeResolvedColumnNull() {
+        helper.createDatabase(dbName, 14).use { db ->
+            db.execSQL(
+                """INSERT INTO offer_records
+                   (eventSequenceId, sessionId, platform, offerHash, outcome, presentedAt, decidedAt,
+                    payAmount, distanceMiles, itemCount, merchantName, score, action, quality, estNetPay,
+                    estDollarsPerHour, estDollarsPerMile, estTimeMinutes, estOperatingCostPerMile,
+                    estFuelPerMile, estNonFuelPerMile, storeKey, linkedJobId)
+                   VALUES (1, 'S1', 'doordash', 'h1', 'OFFER_ACCEPTED', 1900, 2000, 12.0, 3.0, 1, 'H-E-B',
+                           80.0, 'ACCEPT', 'GOOD', 11.25, 20.0, 4.0, 15.0, 0.25, 0.0, 0.75,
+                           'doordash|h-e-b|', NULL)""",
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(dbName, 15, true)
+
+        // Pre-existing row survived (additive-only).
+        db.query("SELECT COUNT(*) FROM offer_records").use { c ->
+            c.moveToFirst(); assertEquals(1, c.getInt(0))
+        }
+        // New outcomeResolved column exists and is NULL on the pre-existing row.
+        db.query("SELECT outcomeResolved FROM offer_records WHERE eventSequenceId = 1").use { c ->
+            c.moveToFirst()
+            assertTrue("outcomeResolved NULL post-migration", c.isNull(0))
+        }
+        db.close()
+    }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
@@ -77,6 +77,14 @@ import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotEntity
     // is a new event type that cannot exist in already-folded history, and the DEFAULT 0 is correct for
     // all history — a fresh drain folds new assigns; nothing needs refolding. Additive ⇒ never wipes
     // app_events or the existing analytics rows.
+    // v14→v15 (#810 B2) is additive-only: one new nullable TEXT column on offer_records
+    // (outcomeResolved — the resolved fate of an accepted orphan offer, "UNASSIGNED_INFERRED" from the
+    // projector store-evidence join or "UNASSIGNED_ATTESTED" from a driver OFFER_OUTCOME_CORRECTION;
+    // NULL for every normal offer, back-filled NULL on existing rows). The `PROJECTOR_VERSION` 7→8
+    // refold this bump triggers re-processes the `JOB_ACCEPT_MISMATCH` events already in the log (the
+    // seq-114 orphan), stamping `UNASSIGNED_INFERRED` on any cross-store single orphan and leaving the
+    // same-store fielded shape NULL for Tier-2 driver attestation. Additive ⇒ never wipes app_events or
+    // the existing analytics rows.
     autoMigrations = [
         AutoMigration(from = 8, to = 9),
         AutoMigration(from = 9, to = 10),
@@ -84,6 +92,7 @@ import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotEntity
         AutoMigration(from = 11, to = 12),
         AutoMigration(from = 12, to = 13),
         AutoMigration(from = 13, to = 14),
+        AutoMigration(from = 14, to = 15),
     ],
 )
 @TypeConverters(DataTypeConverters::class)
@@ -111,7 +120,7 @@ abstract class DashBuddyDatabase : RoomDatabase() {
          * this in lockstep with a new `schemas/**/<N>.json`, an `AutoMigration(N-1 → N)`, and its
          * `MigrationTestHelper` case — see the release checklist in CLAUDE.md.
          */
-        const val VERSION = 14
+        const val VERSION = 15
     }
 
 }

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -106,6 +106,19 @@ interface AnalyticsDao {
     @Query("SELECT * FROM offer_records WHERE eventSequenceId = :eventSequenceId")
     suspend fun offerRecord(eventSequenceId: Long): OfferRecordEntity?
 
+    /**
+     * Stamp an accepted orphan offer's resolved fate (#810 B2) — [resolved] is one of
+     * `OfferOutcomeResolution.*` (Tier 1 `UNASSIGNED_INFERRED` / Tier 2 `UNASSIGNED_ATTESTED`) or
+     * null (undo). The `IS NOT` value guard makes an identical re-stamp match ZERO rows (no Room
+     * invalidation churn on a re-drain), and it never touches the original `outcome` column
+     * (provenance stays visible — the #688 edit-trail pattern).
+     */
+    @Query(
+        "UPDATE offer_records SET outcomeResolved = :resolved " +
+            "WHERE eventSequenceId = :eventSequenceId AND outcomeResolved IS NOT :resolved"
+    )
+    suspend fun stampOfferOutcomeResolved(eventSequenceId: Long, resolved: String?)
+
     /** All store entities (resolution debug / rebuild-equivalence assertions). */
     @Query("SELECT * FROM stores ORDER BY storeKey ASC")
     suspend fun allStores(): List<StoreEntity>
@@ -173,6 +186,12 @@ interface AnalyticsDao {
      *  already holds a claim never nominates a second temporal offer (the DASH_STOP re-run defect). */
     @Query("SELECT COUNT(*) FROM offer_records WHERE linkedJobId = :jobId")
     suspend fun offerLinkCountForJob(jobId: String): Int
+
+    /** Every ACCEPTED offer row (#810 B2) — the Tier-2 orphan-attestation surface joins these to the
+     *  `JOB_ACCEPT_MISMATCH` events' `acceptedOfferHashes`. Reactive: re-emits as `outcomeResolved`
+     *  changes. [acceptedOutcome] is `AppEventType.OFFER_ACCEPTED.name` (bound, not a magic literal). */
+    @Query("SELECT * FROM offer_records WHERE outcome = :acceptedOutcome")
+    fun acceptedOfferRecords(acceptedOutcome: String): Flow<List<OfferRecordEntity>>
 
     /** Nominate the most recent accepted, not-already-claimed offer at-or-before [atOrBefore] in a
      *  session — the temporal fallback (#159 F4). Nomination is NOT a link; the projector stamps only
@@ -522,15 +541,21 @@ interface AnalyticsDao {
      * true in SQL, so the two clauses are disjoint (no double count), and LIFETIME `(0, MAX)` keeps
      * every row. GROUP BY outcome only (no per-offer list yet). Estimates are the offer's frozen
      * decision-time snapshot, not realized net.
+     *
+     * **#810 B2 orphan exclusion:** `outcomeResolved IS NULL` drops accepted offers resolved as
+     * invisibly-unassigned (Tier-1 `UNASSIGNED_INFERRED` or Tier-2 `UNASSIGNED_ATTESTED`) — a resolved
+     * orphan never delivered, so counting it would inflate `accepted` (and thus `received`). The
+     * original `outcome` column is untouched; only this read excludes it.
      */
     @Query(
         """SELECT outcome,
                   COUNT(*) AS count,
                   COALESCE(SUM(estNetPay), 0) AS estNetSum
            FROM offer_records
-           WHERE sessionId IN (SELECT sessionId FROM session_records
-                               WHERE startedAt >= :start AND startedAt < :end)
-              OR (sessionId IS NULL AND decidedAt >= :start AND decidedAt < :end)
+           WHERE outcomeResolved IS NULL
+              AND (sessionId IN (SELECT sessionId FROM session_records
+                                 WHERE startedAt >= :start AND startedAt < :end)
+                   OR (sessionId IS NULL AND decidedAt >= :start AND decidedAt < :end))
            GROUP BY outcome"""
     )
     fun offerOutcomes(start: Long, end: Long): Flow<List<OutcomeCountRow>>
@@ -538,8 +563,8 @@ interface AnalyticsDao {
     /**
      * Per-outcome count + `AVG(score)` + `AVG(estDollarsPerHour)` for a period — the score-vs-outcome
      * read (#315 H3). Same session-anchored WHERE shape + null-session `decidedAt` fallback as
-     * [offerOutcomes]/[deliveryTotals]. `AVG` skips nulls and yields null for an all-null group (no
-     * fabricated 0). Frozen estimates.
+     * [offerOutcomes]/[deliveryTotals], and the same `outcomeResolved IS NULL` orphan exclusion (#810
+     * B2). `AVG` skips nulls and yields null for an all-null group (no fabricated 0). Frozen estimates.
      */
     @Query(
         """SELECT outcome,
@@ -547,9 +572,10 @@ interface AnalyticsDao {
                   AVG(score) AS avgScore,
                   AVG(estDollarsPerHour) AS avgEstPerHour
            FROM offer_records
-           WHERE sessionId IN (SELECT sessionId FROM session_records
-                               WHERE startedAt >= :start AND startedAt < :end)
-              OR (sessionId IS NULL AND decidedAt >= :start AND decidedAt < :end)
+           WHERE outcomeResolved IS NULL
+              AND (sessionId IN (SELECT sessionId FROM session_records
+                                 WHERE startedAt >= :start AND startedAt < :end)
+                   OR (sessionId IS NULL AND decidedAt >= :start AND decidedAt < :end))
            GROUP BY outcome"""
     )
     fun offerScoreOutcomes(start: Long, end: Long): Flow<List<ScoreOutcomeRow>>

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/OfferRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/OfferRecordEntity.kt
@@ -77,4 +77,18 @@ data class OfferRecordEntity(
      * for money.
      */
     val linkedJobId: String? = null,
+
+    // ── Orphan-offer resolution (#810 B2, v15) ──────────────────────────────
+    /**
+     * The resolved fate of an ACCEPTED offer whose job produced no matching delivery — the
+     * invisible-unassign class (#810). Null for every normal offer; non-null ONLY on an accepted
+     * orphan that has been resolved, and the ORIGINAL [outcome] column is never rewritten (provenance
+     * stays visible — the #688 edit-trail pattern). Two values:
+     *  - `"UNASSIGNED_INFERRED"` — Tier 1, the projector's store-evidence join proved a single
+     *    cross-store orphan at fold time (`JobAcceptMismatchResolver`).
+     *  - `"UNASSIGNED_ATTESTED"` — Tier 2, the driver attested it via an `OFFER_OUTCOME_CORRECTION`.
+     * Read-side offer counts (the Decisions tab funnel + score aggregates) exclude rows where this is
+     * non-null, so a resolved orphan no longer inflates `accepted`/`received`. Null again ⇒ undo.
+     */
+    val outcomeResolved: String? = null,
 )

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -208,14 +208,20 @@ class EffectMap @Inject constructor(
             addAll(diffTask(p, next, obs))
             addAll(diffPostTask(p, next, actedNextFlow, obs))
             addAll(diffNotification(obs))
-            // #810 B1: the job-close accept-reconciliation tripwire — diffs the activeJob close
-            // (any in-scope close routes through completeActiveJob; endSession is excluded inside).
-            addAll(diffJobClose(p, next, obs))
 
             // #438 B5/#240: the DELIVERY_COMPLETED mint (PostTask-exit + the #596 close-out
             // sweep) extracted to DeliveryCompletionEffects.kt as one unit — both blocks share the
             // emittedThisStep dual-mint-exclusivity set (amdt #2), so they moved together.
             addAll(diffDeliveryCompletion(p, next, actedPrevFlow, actedNextFlow, obs))
+            // #810 B1: the job-close accept-reconciliation tripwire — diffs the activeJob close
+            // (any in-scope close routes through completeActiveJob; endSession is excluded inside).
+            // Emitted AFTER diffDeliveryCompletion (#810 B2 review F1) so the JOB_ACCEPT_MISMATCH
+            // event sequences AFTER the closing job's final DELIVERY_COMPLETED (the #596 close-out
+            // sweep mints that drop on this SAME close step). This makes the B2 Tier-1 store-evidence
+            // reconcile paging-independent — the projector's evidence read sees every delivered row of
+            // the job by construction. Behaviorally inert to B1 (diffJobClose only diffs prev/next +
+            // emits a log effect; the sweep's emittedThisStep set is local to diffDeliveryCompletion).
+            addAll(diffJobClose(p, next, obs))
         }
     }
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/CorrectionFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/CorrectionFolds.kt
@@ -5,6 +5,7 @@ import cloud.trotter.dashbuddy.domain.model.event.SequencedAppEvent
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliverySessionAssignPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferOutcomeCorrectionPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PayAdjustmentPayload
 
 /**
@@ -165,6 +166,26 @@ internal object CorrectionFolds {
         return FoldOutcome(
             context = context,
             sessionAssign = SessionAssignFold(p.targetEventSequenceId, p.newSessionId),
+        )
+    }
+
+    /**
+     * A driver OFFER_OUTCOME_CORRECTION (#810 B2 Tier 2) — the pure fold emits the
+     * [OfferOutcomeCorrectionFold] decision (which offer row, which resolution / undo); it CANNOT
+     * read/guard the target `offer_record` here, so the orchestrator applies the stamp (with its
+     * fail-closed guards) inside the batch transaction. The session context passes through UNTOUCHED
+     * (the #650 review F2 liveness discipline, identical to the delivery corrections): an attestation
+     * recorded days later must not stretch a crash-orphaned session's online span, and it must not
+     * synthesize a context (the target's offer row already exists — the UI can only offer an accepted
+     * offer surfaced by a `JOB_ACCEPT_MISMATCH`).
+     */
+    fun foldOfferOutcomeCorrection(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val p = e.payload as? OfferOutcomeCorrectionPayload
+            ?: return FoldOutcome(context = context, skip = "OFFER_OUTCOME_CORRECTION: missing/malformed payload")
+        return FoldOutcome(
+            context = context,
+            offerOutcomeCorrection = OfferOutcomeCorrectionFold(p.targetOfferEventSequenceId, p.resolvedOutcome),
         )
     }
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/JobAcceptMismatchResolver.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/JobAcceptMismatchResolver.kt
@@ -1,0 +1,69 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import cloud.trotter.dashbuddy.domain.state.StoreKeys
+
+/**
+ * #810 B2 Tier 1 — the pure store-evidence join that resolves an invisible-unassign orphan when the
+ * surrounding screens make it unambiguous, and INCONCLUSIVE (null) otherwise.
+ *
+ * When a job closes carrying MORE accepted offers than delivered drops (`JOB_ACCEPT_MISMATCH`, B1), an
+ * accepted offer silently vanished — but WHICH one is only knowable when the delivered drops' stores
+ * distinguish it. The dev steer ("surrounding/resulting screens should clear that up, no?"): **yes for
+ * cross-store, structurally no for same-store.** The resulting delivery screens tell you which offer
+ * SURVIVED (its parsed store joins one delivered drop's store), so a cross-store orphan is
+ * machine-resolvable; but the fielded seq-114 shape was two same-store (H-E-B) accepts with one
+ * delivered H-E-B drop, and an offer carries no customer identity pre-accept, so nothing before or
+ * after breaks that tie — it must fall to Tier-2 driver attestation.
+ *
+ * **The predicate (design point):** an accepted offer is "store-accounted" when its parsed store's
+ * chain bucket ([StoreKeys.normalizedChain], the #159 SSOT) matches ANY delivered drop's store
+ * evidence. Resolve the orphan **iff exactly one accepted offer is unaccounted while every other is
+ * accounted**; any other shape (same-store tie ⇒ zero unaccounted, multiple unaccounted, or
+ * unusable/missing evidence) is INCONCLUSIVE. **Fail-null beats fail-wrong** (the #745 doctrine): a
+ * wrong auto-resolution silently mis-attributes money-adjacent counts, so every ambiguity falls to
+ * Tier 2 rather than guessing.
+ *
+ * Pure and `Platform`-agnostic (P8): operates only on already-parsed store text; no `Platform` branch,
+ * no wall clock. So the projector's fold reproduces the same resolution on a from-zero refold.
+ */
+object JobAcceptMismatchResolver {
+
+    /** One accepted offer's store identity for the join — its `offer_record` PK + its parsed store. */
+    data class AcceptedOffer(
+        /** `offer_record.eventSequenceId` (the source `OFFER_ACCEPTED` sequenceId) — the resolve target. */
+        val eventSequenceId: Long,
+        /** The offer's parsed store (`offer_records.merchantName`); null/blank ⇒ unusable evidence. */
+        val storeName: String?,
+    )
+
+    /**
+     * Return the single orphan offer's `eventSequenceId`, or null when the mismatch is INCONCLUSIVE.
+     *
+     * @param acceptedOffers the closing job's accepted offers (PK + parsed store).
+     * @param deliveredStoreForms every store-name string carried by the job's delivered drops (the
+     *   `delivery_records.storeName` plus each `payoutStoreForms` entry) — the "surrounding screens"
+     *   evidence, already committed to the read model at fold time.
+     */
+    fun resolveOrphan(
+        acceptedOffers: List<AcceptedOffer>,
+        deliveredStoreForms: List<String>,
+    ): Long? {
+        // A single-accept job has no orphan to disambiguate; need ≥2 accepts for a mismatch.
+        if (acceptedOffers.size < 2) return null
+        // Any accepted offer with no usable store text makes the join unreliable → fail-null (Tier 2).
+        if (acceptedOffers.any { it.storeName.isNullOrBlank() }) return null
+
+        val deliveredChains = deliveredStoreForms
+            .filter { it.isNotBlank() }
+            .map { StoreKeys.normalizedChain(it) }
+            .toSet()
+        // No delivered-store evidence to match against → nothing distinguishes the offers → Tier 2.
+        if (deliveredChains.isEmpty()) return null
+
+        val unaccounted = acceptedOffers.filter {
+            StoreKeys.normalizedChain(it.storeName!!) !in deliveredChains
+        }
+        // Resolve iff EXACTLY one accepted offer is unaccounted while every other is store-accounted.
+        return if (unaccounted.size == 1) unaccounted.single().eventSequenceId else null
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/OrphanOffer.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/OrphanOffer.kt
@@ -1,0 +1,33 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+/**
+ * #810 B2 Tier 2 — the read model for the driver-attestation surface. A [OrphanOfferGroup] is one
+ * still-open `JOB_ACCEPT_MISMATCH` (an accepted-offer-vs-delivery mismatch the projector's Tier-1
+ * store-evidence join could not resolve) whose accepted offers the driver can attest one of as the
+ * invisibly-unassigned one. No customer PII — store/pay/time are driver-recognizable facts (merchant
+ * data), and no customer hashes ride these models (Principle 6/7).
+ */
+data class OrphanOfferGroup(
+    /** The closing job that carried more accepted offers than delivered drops. */
+    val jobId: String,
+    /** The dash the mismatch belonged to (the `JOB_ACCEPT_MISMATCH` event's session). */
+    val sessionId: String?,
+    /** How many accepted offers are owed a resolution (`acceptedCount − accountedCount`). */
+    val orphansOwed: Int,
+    /** The job's accepted offers — the pick-from list (store/pay/time; resolved state carried). */
+    val offers: List<OrphanOfferCandidate>,
+)
+
+/** One accepted offer the driver can attest as unassigned (or undo), within an [OrphanOfferGroup]. */
+data class OrphanOfferCandidate(
+    /** `offer_records.eventSequenceId` — the by-PK target of the `OFFER_OUTCOME_CORRECTION`. */
+    val offerEventSequenceId: Long,
+    /** The offer's parsed store (`offer_records.merchantName`), driver-recognizable. */
+    val storeName: String?,
+    /** The offer's parsed pay (`offer_records.payAmount`). */
+    val payAmount: Double?,
+    /** When the offer was decided (`offer_records.decidedAt`) — distinguishes same-store offers. */
+    val decidedAt: Long,
+    /** True once this offer has been resolved (Tier-1 inferred or Tier-2 attested) — undo target. */
+    val resolved: Boolean,
+)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/OrphanOffer.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/OrphanOffer.kt
@@ -16,7 +16,14 @@ data class OrphanOfferGroup(
     val orphansOwed: Int,
     /** The job's accepted offers — the pick-from list (store/pay/time; resolved state carried). */
     val offers: List<OrphanOfferCandidate>,
-)
+) {
+    /**
+     * Orphans still awaiting resolution (`orphansOwed − resolved`, floored at 0) — the Money-tab
+     * callout gates/counts on this so a fully-resolved group (still listed in the dialog for undo, F3)
+     * no longer contributes to the callout.
+     */
+    val owedRemaining: Int get() = (orphansOwed - offers.count { it.resolved }).coerceAtLeast(0)
+}
 
 /** One accepted offer the driver can attest as unassigned (or undo), within an [OrphanOfferGroup]. */
 data class OrphanOfferCandidate(

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.domain.analytics
 
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.event.SequencedAppEvent
+import cloud.trotter.dashbuddy.domain.model.event.payload.JobAcceptMismatchPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
@@ -259,6 +260,19 @@ data class FoldOutcome(
      * orchestrator applies the re-attribution (with its fail-closed guards) inside the batch transaction.
      */
     val sessionAssign: SessionAssignFold? = null,
+    /**
+     * A JOB_ACCEPT_MISMATCH Tier-1 orphan-reconcile trigger (#810 B2): the pure fold cannot read the
+     * job's committed offer/delivery rows here, so the orchestrator runs the store-evidence join
+     * ([JobAcceptMismatchResolver]) against them inside the batch transaction and stamps
+     * `outcomeResolved = UNASSIGNED_INFERRED` on a single cross-store orphan (else leaves it for Tier 2).
+     */
+    val offerReconcile: OfferReconcileFold? = null,
+    /**
+     * A driver OFFER_OUTCOME_CORRECTION decision (#810 B2 Tier 2): the pure fold decides WHICH offer
+     * row and WHICH resolution (null ⇒ undo), but cannot read/guard the target `offer_record` here —
+     * the orchestrator applies the stamp inside the batch transaction.
+     */
+    val offerOutcomeCorrection: OfferOutcomeCorrectionFold? = null,
 )
 
 /**
@@ -304,6 +318,35 @@ data class DeliveryAdjustmentFold(
 data class SessionAssignFold(
     val targetEventSequenceId: Long,
     val newSessionId: String? = null,
+)
+
+/**
+ * A Tier-1 orphan-reconcile decision (#810 B2) — the pure fold's output for a `JOB_ACCEPT_MISMATCH`.
+ * The orchestrator loads the closing [jobId]'s accepted `offer_records` (by [acceptedOfferHashes] +
+ * [sessionId]) and its delivered `delivery_records`, runs [JobAcceptMismatchResolver.resolveOrphan]
+ * over their store evidence, and — only when a single cross-store orphan is proven — stamps that offer
+ * row's `outcomeResolved = UNASSIGNED_INFERRED`. Every ambiguous shape falls through untouched to Tier
+ * 2. Because the mismatch event always sequences AFTER the job's offers/deliveries, a from-zero refold
+ * replays it against the same committed rows and reproduces the identical stamp (or non-stamp).
+ * A `sessionId`-less mismatch cannot scope its session-keyed offer lookup, so the orchestrator no-ops.
+ */
+data class OfferReconcileFold(
+    val jobId: String,
+    val sessionId: String?,
+    val acceptedOfferHashes: List<String>,
+)
+
+/**
+ * A driver's offer-outcome attestation (#810 B2 Tier 2) — the pure fold's output for an
+ * `OFFER_OUTCOME_CORRECTION`. The orchestrator looks up [targetOfferEventSequenceId] in `offer_records`
+ * and, subject to its fail-closed guards (row exists, is an ACCEPTED offer, known resolution value),
+ * stamps ONLY `outcomeResolved` to [resolvedOutcome] (null ⇒ undo back to a normal counted accept) —
+ * never any frozen estimate column. Because the correction always sequences after its target's
+ * `OFFER_ACCEPTED`, a from-zero refold replays it in order and reproduces the identical stamp.
+ */
+data class OfferOutcomeCorrectionFold(
+    val targetOfferEventSequenceId: Long,
+    val resolvedOutcome: String? = null,
 )
 
 /**
@@ -353,6 +396,11 @@ object RecordFolds {
             AppEventType.PAY_ADJUSTMENT -> CorrectionFolds.foldPayAdjustment(event, context)
             AppEventType.DELIVERY_ADJUSTMENT -> CorrectionFolds.foldDeliveryAdjustment(event, context)
             AppEventType.DELIVERY_SESSION_ASSIGN -> CorrectionFolds.foldDeliverySessionAssign(event, context)
+            AppEventType.OFFER_OUTCOME_CORRECTION -> CorrectionFolds.foldOfferOutcomeCorrection(event, context)
+            // #810 B2 Tier 1: emit the orphan-reconcile trigger (the orchestrator runs the store-evidence
+            // join against committed rows in-transaction) AND still advance liveness exactly as the old
+            // read-model-inert `else` arm did (the #810 B1 tripwire mints no record itself).
+            AppEventType.JOB_ACCEPT_MISMATCH -> foldJobAcceptMismatch(event, context)
             AppEventType.DASH_STOP -> foldDashStop(event, context)
             // Every other session-attributed event just advances the liveness/odometer anchors so
             // the open-session duration and lastOdometer stay honest; the watermark still moves past
@@ -483,6 +531,29 @@ object RecordFolds {
                 )
         }
         return FoldOutcome(context = newCtx, offer = offer)
+    }
+
+    /**
+     * #810 B2 Tier 1 — fold a `JOB_ACCEPT_MISMATCH` tripwire (B1). It mints no record (the #810 B1
+     * event is read-model-inert), so this preserves the old `else`-arm liveness advance verbatim; it
+     * additionally emits an [OfferReconcileFold] the orchestrator runs against committed rows. A
+     * missing/malformed payload degrades to a plain liveness advance (never a crash) — the tripwire's
+     * own record-inertness is unaffected.
+     */
+    private fun foldJobAcceptMismatch(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val sid = e.sessionId
+        val ctx = sid?.let { resolveContext(context, it, e.occurredAt).advance(e.occurredAt, event.metadata?.odometer) }
+        val p = e.payload as? JobAcceptMismatchPayload
+            ?: return FoldOutcome(context = ctx ?: context, skip = "JOB_ACCEPT_MISMATCH: missing/malformed payload")
+        return FoldOutcome(
+            context = ctx ?: context,
+            offerReconcile = OfferReconcileFold(
+                jobId = p.jobId,
+                sessionId = sid,
+                acceptedOfferHashes = p.acceptedOfferHashes,
+            ),
+        )
     }
 
     private fun foldDashStop(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodec.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodec.kt
@@ -5,6 +5,7 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryAdjustmentPayl
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliverySessionAssignPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferOutcomeCorrectionPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PayAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferReceivedPayload
@@ -44,6 +45,7 @@ object AppEventCodec {
         is PayAdjustmentPayload -> json.encodeToString(payload)
         is DeliveryAdjustmentPayload -> json.encodeToString(payload)
         is DeliverySessionAssignPayload -> json.encodeToString(payload)
+        is OfferOutcomeCorrectionPayload -> json.encodeToString(payload)
         is TaskUnassignedPayload -> json.encodeToString(payload)
         is JobAcceptMismatchPayload -> json.encodeToString(payload)
     }
@@ -96,6 +98,9 @@ object AppEventCodec {
 
             AppEventType.DELIVERY_SESSION_ASSIGN ->
                 json.decodeFromString<DeliverySessionAssignPayload>(payloadJson)
+
+            AppEventType.OFFER_OUTCOME_CORRECTION ->
+                json.decodeFromString<OfferOutcomeCorrectionPayload>(payloadJson)
 
             AppEventType.TASK_UNASSIGNED ->
                 json.decodeFromString<TaskUnassignedPayload>(payloadJson)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventType.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventType.kt
@@ -44,6 +44,9 @@ enum class AppEventType {
                          // PAY_ADJUSTMENT (store/pay/tip/cash-tip/miles/note); the original event stays
     DELIVERY_SESSION_ASSIGN, // A driver assigns/unassigns an orphan "(No session)" delivery's session
                              // (#660 piece 2) — changes ATTRIBUTION only (never pay/net); the original event stays
+    OFFER_OUTCOME_CORRECTION, // A driver attests (or undoes) which accepted offer was invisibly unassigned
+                              // (#810 B2 Tier 2) — stamps offer_records.outcomeResolved only (never pay/net);
+                              // the original OFFER_ACCEPTED event/outcome stays
 
     // --- System / Generic ---
     SCREEN_VIEWED, // For generic screen transitions like "Earnings Screen"

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
@@ -352,6 +352,48 @@ data class DeliverySessionAssignPayload(
     val note: String? = null,
 ) : AppEventPayload
 
+/**
+ * The wire vocabulary of `offer_records.outcomeResolved` (#810 B2) — the SSOT both the projector
+ * writes and the read-side count-exclusion / UI derive from. A `null` column means "a normal offer /
+ * not resolved"; a non-null value marks a resolved accepted orphan whose ORIGINAL `outcome` column is
+ * never rewritten.
+ */
+object OfferOutcomeResolution {
+    /** Tier 1 — the projector's store-evidence join proved a single cross-store orphan at fold time. */
+    const val UNASSIGNED_INFERRED = "UNASSIGNED_INFERRED"
+
+    /** Tier 2 — the driver attested this accepted offer was invisibly unassigned. */
+    const val UNASSIGNED_ATTESTED = "UNASSIGNED_ATTESTED"
+}
+
+/**
+ * Payload for `OFFER_OUTCOME_CORRECTION` (#810 B2 Tier 2) — a driver attestation of which accepted
+ * offer was invisibly unassigned (the seq-114 class: an accepted offer whose job produced no matching
+ * delivery and whose same-store shape the projector's Tier-1 join could NOT disambiguate). It is an
+ * **event, never a destructive edit**: the original `OFFER_ACCEPTED` event and its `outcome` column
+ * stay in the log; the projector stamps ONLY `offer_records.outcomeResolved` on the target row inside
+ * the batch transaction. Because a correction always sequences AFTER its target's `OFFER_ACCEPTED`
+ * (and after the `JOB_ACCEPT_MISMATCH` that surfaced it), a from-zero refold replays it in order and
+ * reproduces the identical stamp.
+ *
+ * It changes **outcome-resolution ONLY** — never pay/net/score or any frozen estimate column. The
+ * target is identified by the offer_record PK ([targetOfferEventSequenceId] = the source
+ * `OFFER_ACCEPTED` event's `sequenceId`), the same by-PK convention as the delivery corrections.
+ */
+@Serializable
+data class OfferOutcomeCorrectionPayload(
+    /** PK (source `OFFER_ACCEPTED` `sequenceId`) of the `offer_record` being resolved. */
+    val targetOfferEventSequenceId: Long,
+    /**
+     * The resolution to stamp — [OfferOutcomeResolution.UNASSIGNED_ATTESTED], or **null to UNDO**
+     * (clear a prior attestation back to a normal counted accept). Only these two shapes are valid;
+     * the projector guards an unknown value.
+     */
+    val resolvedOutcome: String? = null,
+    /** Driver-authored free text — driver-owned local data, never in INFO+ logs (P7). */
+    val note: String? = null,
+) : AppEventPayload
+
 /** Wire values for [SessionStartPayload.source] (#366) — mirrors [SessionEndSource]. */
 object SessionStartSource {
     /** Normal user-initiated start. */

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/JobAcceptMismatchResolverTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/JobAcceptMismatchResolverTest.kt
@@ -1,0 +1,101 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import cloud.trotter.dashbuddy.domain.analytics.JobAcceptMismatchResolver.AcceptedOffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #810 B2 Tier 1 — the pure store-evidence join ([JobAcceptMismatchResolver]). Proves the exact
+ * predicate: resolve iff exactly one accepted offer is store-unaccounted while every other is
+ * accounted; every ambiguous shape is INCONCLUSIVE (fail-null beats fail-wrong).
+ */
+class JobAcceptMismatchResolverTest {
+
+    private fun resolve(offers: List<AcceptedOffer>, delivered: List<String>) =
+        JobAcceptMismatchResolver.resolveOrphan(offers, delivered)
+
+    @Test
+    fun `cross-store orphan resolves to the single unaccounted offer`() {
+        // Two accepts (HEB + Whataburger), only Whataburger delivered → HEB (seq 10) is the orphan.
+        val orphan = resolve(
+            offers = listOf(AcceptedOffer(10, "H-E-B"), AcceptedOffer(20, "Whataburger")),
+            delivered = listOf("Whataburger (0456)"),
+        )
+        assertEquals("the undelivered store's offer is the orphan", 10L, orphan)
+    }
+
+    @Test
+    fun `same-store tie falls through to INCONCLUSIVE (the fielded seq-114 shape)`() {
+        // Two H-E-B accepts, one delivered H-E-B drop → both offers match the one HEB chain → no
+        // single unaccounted offer → Tier 2.
+        val orphan = resolve(
+            offers = listOf(AcceptedOffer(10, "H-E-B"), AcceptedOffer(20, "H-E-B")),
+            delivered = listOf("H-E-B (0123)"),
+        )
+        assertNull("a same-store tie cannot be auto-resolved", orphan)
+    }
+
+    @Test
+    fun `multiple unaccounted offers fall through to INCONCLUSIVE`() {
+        // Three accepts, only one store delivered → two unaccounted → ambiguous → Tier 2.
+        val orphan = resolve(
+            offers = listOf(
+                AcceptedOffer(10, "H-E-B"),
+                AcceptedOffer(20, "Whataburger"),
+                AcceptedOffer(30, "Chipotle"),
+            ),
+            delivered = listOf("Chipotle Mexican Grill"),
+        )
+        assertNull("two unaccounted offers are ambiguous", orphan)
+    }
+
+    @Test
+    fun `zero unaccounted offers is a no-op`() {
+        // Both stores delivered → nothing unaccounted → no orphan to stamp.
+        val orphan = resolve(
+            offers = listOf(AcceptedOffer(10, "H-E-B"), AcceptedOffer(20, "Whataburger")),
+            delivered = listOf("H-E-B (0123)", "Whataburger (0456)"),
+        )
+        assertNull("every accepted offer's store delivered", orphan)
+    }
+
+    @Test
+    fun `no delivered evidence is INCONCLUSIVE (never resolves everything as orphan)`() {
+        val orphan = resolve(
+            offers = listOf(AcceptedOffer(10, "H-E-B"), AcceptedOffer(20, "Whataburger")),
+            delivered = emptyList(),
+        )
+        assertNull("no store evidence to distinguish offers", orphan)
+    }
+
+    @Test
+    fun `a null or blank offer store forces INCONCLUSIVE (unreliable evidence)`() {
+        val orphan = resolve(
+            offers = listOf(AcceptedOffer(10, null), AcceptedOffer(20, "Whataburger")),
+            delivered = listOf("Whataburger (0456)"),
+        )
+        assertNull("a store-less offer can't be safely reasoned about", orphan)
+    }
+
+    @Test
+    fun `a single accept never resolves (no mismatch to disambiguate)`() {
+        val orphan = resolve(
+            offers = listOf(AcceptedOffer(10, "H-E-B")),
+            delivered = listOf("Whataburger (0456)"),
+        )
+        assertNull("a single-accept job is not this signal", orphan)
+    }
+
+    @Test
+    fun `store forms match by normalized chain across payout qualifiers`() {
+        // The delivered evidence carries a parenthetical location code; the offer store is bare. The
+        // normalizedChain SSOT strips the qualifier, so the surviving offer is store-accounted and the
+        // cross-store one is the orphan.
+        val orphan = resolve(
+            offers = listOf(AcceptedOffer(10, "Panda Express"), AcceptedOffer(20, "H-E-B")),
+            delivered = listOf("H-E-B (Loop 410) - San Antonio"),
+        )
+        assertEquals("Panda Express is unaccounted", 10L, orphan)
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -226,6 +226,13 @@ class RecordFoldsTest {
         // Liveness advanced to the event's time (the `else` arm's `ctx.advance`).
         assertNotNull("context carries through", mismatch.context)
         assertEquals("liveness advanced to the mismatch event time", 3_500L, mismatch.context!!.lastEventAt)
+        // #810 B2 Tier 1: it now ALSO emits an orphan-reconcile trigger (still no record row) so the
+        // orchestrator can run the store-evidence join against committed rows in-transaction.
+        val reconcile = mismatch.offerReconcile
+        assertNotNull("emits the Tier-1 orphan-reconcile trigger", reconcile)
+        assertEquals("carries the closing job id", "J1", reconcile!!.jobId)
+        assertEquals("carries the session for the offer lookup", s, reconcile.sessionId)
+        assertEquals("carries both accepted offer hashes", listOf("hA", "hB"), reconcile.acceptedOfferHashes)
     }
 
     @Test

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodecTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodecTest.kt
@@ -5,6 +5,8 @@ import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.JobAcceptMismatchPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferOutcomeCorrectionPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferOutcomeResolution
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.TaskUnassignedPayload
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
@@ -99,6 +101,10 @@ class AppEventCodecTest {
                 jobId = "j1", acceptedCount = 2, accountedCount = 1,
                 acceptedOfferHashes = listOf("hA", "hB"), deliveredCustomerHashes = listOf("c1"),
                 leftoverTbdPlaceholders = 1, unassignedCount = 0,
+            ),
+            AppEventType.OFFER_OUTCOME_CORRECTION to OfferOutcomeCorrectionPayload(
+                targetOfferEventSequenceId = 42L,
+                resolvedOutcome = OfferOutcomeResolution.UNASSIGNED_ATTESTED, note = "chat unassign",
             ),
         )
 


### PR DESCRIPTION
Closes the B2 remaining scope on #810 (dev-approved to build, 2026-07-23). Resolves an accepted offer whose job produced no matching delivery — the invisible-unassign class B1's `JOB_ACCEPT_MISMATCH` tripwire (PR #818) surfaces — in two tiers, both write-only to a new nullable `offer_records.outcomeResolved` column (the original `outcome` column is never rewritten; the #688 edit-trail pattern).

## Tier 1 — automatic store-evidence inference (projector)
Folding a `JOB_ACCEPT_MISMATCH` emits an `OfferReconcileFold` the orchestrator runs **resolve-from-rows** inside the batch transaction (the #159 pattern — deliveries/offers are already committed at that point). The pure `JobAcceptMismatchResolver.resolveOrphan` joins the closing job's delivered-drop store evidence against each accepted offer's parsed store.

**The Tier-1 join predicate exactly as shipped:**
- Inputs: `acceptedOffers` = the job's accepted `offer_records` (by the payload's `acceptedOfferHashes` + `sessionId`, `outcome = OFFER_ACCEPTED`); `deliveredStoreForms` = every `delivery_records.storeName` + each decoded `payoutStoreForms` entry for the job (`deliveryRecordsForJob(jobId)`).
- `if (acceptedOffers.size < 2) return null` — no orphan to disambiguate.
- `if (any offer storeName is null/blank) return null` — unreliable evidence, fail-null.
- `deliveredChains = deliveredStoreForms.filter{blank}.map{ StoreKeys.normalizedChain(it) }.toSet()`; `if (deliveredChains.isEmpty()) return null`.
- `unaccounted = acceptedOffers.filter { StoreKeys.normalizedChain(it.storeName) !in deliveredChains }`.
- **`return if (unaccounted.size == 1) unaccounted.single().eventSequenceId else null`** — resolve iff EXACTLY one accepted offer is store-unaccounted while every other is accounted; any other shape (same-store tie ⇒ 0 unaccounted, multiple unaccounted, no evidence) is INCONCLUSIVE → Tier 2. **Fail-null beats fail-wrong (#745).**

On a match the orchestrator stamps `outcomeResolved = UNASSIGNED_INFERRED`. `PROJECTOR_VERSION` 7→8 re-processes the `JOB_ACCEPT_MISMATCH` events already in the log (the seq-114 orphan), which — being same-store H-E-B — lands INCONCLUSIVE and falls to Tier 2 (asserted by test).

## Tier 2 — driver attestation (corrections family, #650/#660 pattern)
Money-tab callout (`AppCallout`, warnBg, tappable — same pattern as unattributed/no-session) → `OrphanOfferAttestDialog` lists each still-open mismatch's accepted offers (store/pay/decision-time — driver-recognizable, no PII) → the driver taps the unassigned one (tap again to undo) → `CorrectionRepository.correctOfferOutcome` appends a new `OFFER_OUTCOME_CORRECTION` event (`OfferOutcomeCorrectionPayload{targetOfferEventSequenceId, resolvedOutcome, note}`, via `AppEventType` + `AppEventCodec`) → `CorrectionFolds.foldOfferOutcomeCorrection` → orchestrator `applyOfferOutcomeCorrection` stamps `UNASSIGNED_ATTESTED` (null ⇒ undo) behind three fail-closed guards (row exists, is an ACCEPTED offer, known resolution value). Rebuild-faithful: the correction always sequences after its target.

The open-mismatch read (`AnalyticsRepository.orphanOfferGroups`) joins the `JOB_ACCEPT_MISMATCH` events (via `AppEventDao` — a DAO read of the source-of-truth log, no economy dependency) to accepted `offer_records`, keeping only groups still owed a resolution.

## Read sites changed
- `AnalyticsDao.offerOutcomes` — added `outcomeResolved IS NULL` (the Decisions-tab funnel counts: `accepted`/`declined`/`timedOut`/`received` + Σ declined est-net). A resolved orphan (always an accept) drops from `accepted` and thus `received`.
- `AnalyticsDao.offerScoreOutcomes` — same exclusion (Decisions-tab score-vs-outcome AVGs).
- **Deliberately NOT changed:** `session_records.offersAccepted` (bubble `ModeCards` + CSV) — a different per-dash fold counter; a retrospective analytics resolution doesn't rewrite the live session counter (documented residual, would need a #660-style relative bump).

## Migration / projector
- Room **v14→v15**, additive-only: one nullable `TEXT offer_records.outcomeResolved` (`AutoMigration(14→15)`, exported `15.json` committed, `AnalyticsMigration14to15Test` androidTest case, `SchemaVersionGuardTest` green).
- `PROJECTOR_VERSION` **7→8** (Tier-1 retro-resolve of the in-log `JOB_ACCEPT_MISMATCH`; the new `OFFER_OUTCOME_CORRECTION` type can't exist in folded history so a fresh drain folds it). Precedented `CURRENT_FALLBACK` re-stamp side effect only; app_events + every frozen economy column untouched.
- **No `:core:state` changes.**

## Tests (all green: `testDebugUnitTest :domain:test`)
- `JobAcceptMismatchResolverTest` (:domain) — cross-store resolves, same-store falls through, multiple-unmatched falls through, zero-unmatched no-op, no-evidence/null-store/single-accept INCONCLUSIVE, normalized-chain match across payout qualifiers.
- `OrphanOfferResolutionTest` (:core:data, Robolectric+Room) — Tier-1 cross-store auto-resolve + count exclusion; **Tier-1 same-store INCONCLUSIVE (the fielded seq-114 shape — never silently auto-resolved)**; Tier-2 attestation round-trip + undo + count exclusion; missing/non-accepted target no-op; **incremental (paged) ≡ from-zero refold with Tier-1 + Tier-2 corrections interleaved**.
- `RecordFoldsTest` — the mismatch fold now also emits the Tier-1 trigger (still record-inert, liveness advances).
- `AppEventCodecTest` — `OfferOutcomeCorrectionPayload` round-trip.
- `CorrectionRepositoryTest` — `correctOfferOutcome` attested/undo append shape.

## Security/privacy posture
No new capture, network, or PII surface. `outcomeResolved` is a resolution enum; the Tier-2 read/UI carry merchant store names + decision pay/time only (no customer hashes). `OFFER_OUTCOME_CORRECTION` INFO log is counts/ids only (P7). `JobAcceptMismatchResolver` is pure + platform-agnostic (P8 — store text only, no `Platform` branch).

## Residuals
- Same-store mismatches require driver attestation by design (no pre/post screen breaks the tie — the dev-confirmed structural limit).
- `session_records.offersAccepted` live counter not adjusted (above).
- Tier-2 read enumerates via `JOB_ACCEPT_MISMATCH` events + accepted offers (one nullable column kept the migration minimal, per spec).


---

## Adversarial review follow-up (APPROVE-WITH-FIXES → applied)

**F1 — REQUIRED (HIGH): Tier-1 rebuild-faithfulness under the real emission order. FIXED.** The reviewer empirically demonstrated `EffectMap` emitted `diffJobClose` (JOB_ACCEPT_MISMATCH) *before* `diffDeliveryCompletion`, so in the field the mismatch row sequenced BEFORE the closing job's final DELIVERY_COMPLETED (the #596 close-out sweep mints that drop on the same step) — the opposite of my fixtures — breaking incremental≡refold.
- Part 1 `core/state/.../EffectMap.kt`: moved `addAll(diffJobClose(...))` to AFTER `addAll(diffDeliveryCompletion(...))` (emission-order only within one close step; diffJobClose only diffs prev/next + emits a log effect, the sweep's `emittedThisStep` set is local to diffDeliveryCompletion — inert to B1). Sole `:core:state` touch, an ordering change not a new event/reducer.
- Part 2 `AnalyticsProjector.applyOfferReconcile`: evidence read scoped to `deliveryRecordsForJob(jobId).filter { eventSequenceId < mismatchSeq }` (new `adj.sequenceId`). No-op under the new order; makes the reconcile paging-independent AND makes HISTORICAL old-order logs deterministically fall to Tier 2 (fail-null) under both paged and from-zero folding.
- Regression test `Tier 1 is paging-independent for a mismatch sequenced BEFORE its final delivery (review F1)`: mismatch(3000) before delivered(3100), paged(limit=2) `outcomeResolved` ≡ from-zero refold (both null). Green.

**F2 — STRONGLY RECOMMENDED (MED, fail-wrong): evidenceless delivered row. FIXED.** `applyOfferReconcile` returns INCONCLUSIVE if ANY delivered row (in the sequenced-before set) has blank `storeName` AND empty decoded `payoutStoreForms` — else the shrunk evidence set could stamp a DELIVERED offer as the orphan (the O/Y/X 3-accept scenario). Test `Tier 1 bails to INCONCLUSIVE when a delivered row carries no store evidence (review F2)`. Green.

**F3 — fix-or-document (MED UX): undo reachability. FIXED (cheap path) + residual documented.** `orphanOfferGroups` now lists a group while its mismatch owes ≥1 orphan and its offers are present — INCLUDING after resolution — so a mis-tap undo is reachable in the dialog. The callout gates/counts on `OrphanOfferGroup.owedRemaining` (owed − resolved), so a fully-resolved group stays in the dialog for undo but no longer drives the callout. Documented residual: if EVERY listed group is fully resolved the callout hides, so undoing the very last resolution isn't reachable from the callout until a new mismatch appears (KDoc + change note).

**F4 — tests. DONE.** Added `an attestation targeting a DECLINED offer is a no-op` and `an attestation with an unknown resolution value is a no-op`.

**F6 — optional. DONE.** ids-only WARNs on `applyOfferReconcile`'s empty-hashes and <2-accepted-rows defensive skips (the `applySessionAssign` pattern).

Full `testDebugUnitTest :domain:test` green under `allWarningsAsErrors` (JobCloseEffectsTest + all analytics suites pass with the EffectMap reorder). Not merged.
