### PR TITLE
feat(offer-engine): #823 Phase 1 — learned items:units ratio for units-denominated shop offers

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -344,6 +344,26 @@ class SideEffectEngine @Inject constructor(
                 Timber.tag("ShopRate").d("recorded shop store=%s", effect.storeName ?: "?")
             }
 
+            is AppEffect.RecordItemsPerUnitRatio -> {
+                // #823 Phase 1: learn the dasher's items:units ratio for THIS platform from a
+                // units-denominated shop's ground truth (items actually shopped vs the offer's units).
+                val learned = strategyRepository.recordItemsPerUnitRatio(
+                    effect.platform, effect.offerUnitCount, effect.itemsShopped,
+                )
+                val sampleRatio =
+                    if (effect.offerUnitCount > 0) effect.itemsShopped.toDouble() / effect.offerUnitCount else 0.0
+                // #551 P7: ratio + counts + platform wire are shareable INFO milestones (all numeric /
+                // registry tokens, no raw store/customer text). A never-learned mean renders "?"
+                // (an out-of-band sample folds nothing); Locale.ROOT keeps the desk grep stable.
+                val learnedStr =
+                    learned.ratio?.let { String.format(Locale.ROOT, "%.2f", it) } ?: "?"
+                Timber.tag("ShopRate").i(
+                    "items:units %d items / %d units = %.2f [%s] → learned %s (n=%d)",
+                    effect.itemsShopped, effect.offerUnitCount, sampleRatio, effect.platform.wire,
+                    learnedStr, learned.sampleCount,
+                )
+            }
+
             is AppEffect.ProcessTipNotification -> tipEffectHandler.process(engineScope, effect)
 
             // --- LOOPBACKS (Produces Events) ---
@@ -665,6 +685,7 @@ class SideEffectEngine @Inject constructor(
         is AppEffect.PauseOdometer,
         is AppEffect.ResumeOdometer,
         is AppEffect.RecordShopRate,
+        is AppEffect.RecordItemsPerUnitRatio,
         is AppEffect.StartSession,
         is AppEffect.EndSession,
         is AppEffect.ProcessTipNotification,

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/recognition/matchers/ItemsUnitsDenominationParseTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/recognition/matchers/ItemsUnitsDenominationParseTest.kt
@@ -1,0 +1,55 @@
+package cloud.trotter.dashbuddy.core.pipeline.recognition.matchers
+
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.test.util.SessionReplay
+import cloud.trotter.dashbuddy.test.util.TestResourceLoader
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * #823 Phase 1 — the units-vs-items **denomination** survives the production parse. Feeds real
+ * offer captures through the production screen ruleset (via [SessionReplay]'s classifier, the same
+ * one [GoldenSnapshotRegressionTest] guards) and asserts [cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer.itemCountIsUnits]:
+ *
+ *  - a units-only render (`(32 units)`, the dev's fielded H-E-B shape) → `itemCountIsUnits == true`,
+ *    with [itemCount] still the platform-shown number (32 — the card shows what DoorDash said);
+ *  - an items•units render (`(4 items • 5 units)`) → `false` (the leading count is items).
+ *
+ * This closes the recognition→parse wiring the evaluator's ratio conversion depends on; the
+ * time-math itself is covered by `ShopTimeModelTest`.
+ */
+class ItemsUnitsDenominationParseTest {
+
+    private fun parseOffer(pathFromResources: String): ParsedFields.OfferFields {
+        val file = File("src/test/resources/$pathFromResources")
+        require(file.isFile) { "Missing snapshot: ${file.absolutePath}" }
+        val frame = SessionReplay.ReplayFrame(
+            file = file.name,
+            node = TestResourceLoader.loadNode(file),
+            capturedAtMs = 0L,
+            wire = Platform.DoorDash.wire,
+            captureId = null,
+        )
+        val obs: Observation.Screen = SessionReplay.replayRecognition(listOf(frame)).single()
+        return obs.parsed as? ParsedFields.OfferFields
+            ?: error("${file.name} did not parse as an offer — parsed as: ${obs.parsed}")
+    }
+
+    @Test
+    fun `a units-only offer parses as units-denominated with the platform-shown count`() {
+        val offer = parseOffer("snapshots/sessions/ghost_offer_2026_06_14/01_real_offer_heb_1630.json").parsedOffer
+        assertTrue("H-E-B '(32 units)' must read as units-denominated", offer.itemCountIsUnits)
+        assertEquals("the surfaced count stays the platform-shown units figure", 32, offer.itemCount)
+    }
+
+    @Test
+    fun `an items-and-units offer parses as items-denominated (leading count is items)`() {
+        val offer = parseOffer("snapshots/offer_popup/20260128_163448_533_OFFER_POPUP.json").parsedOffer
+        assertTrue("'(4 items • 5 units)' leads with items → not units-denominated", !offer.itemCountIsUnits)
+        assertEquals(4, offer.itemCount)
+    }
+}

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -3029,7 +3029,7 @@
         "intent": "offer",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=0e9b7f0d5d3885e6a37895cc7eefae3b69a2f16a6957932e0ffbcba647a81676, presentationKey=68ca7453f9213a289ab6f0e9a7c5cc2c678d970136eff5b1505f1bfdf3607f52, itemCount=0, payAmount=15.01, payTextRaw=null, distanceMiles=17.5, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=40, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Costco Wholesale (Sonterra Park), itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=0e9b7f0d5d3885e6a37895cc7eefae3b69a2f16a6957932e0ffbcba647a81676, presentationKey=68ca7453f9213a289ab6f0e9a7c5cc2c678d970136eff5b1505f1bfdf3607f52, itemCount=0, itemCountIsUnits=false, payAmount=15.01, payTextRaw=null, distanceMiles=17.5, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=40, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Costco Wholesale (Sonterra Park), itemCount=1, isItemCountEstimated=true, badges=[], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer/2026-07-21_18-38-16-682__uber__accessibility.window__offer__9e2877.json": {
@@ -3037,7 +3037,7 @@
         "intent": "offer",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=fc2cbdc99f2158deb74425dfaf2bf6c2b7395083e2fab646da70449fe5d9e05f, presentationKey=f787cc90ced093254b17cc4833814948e627a3e51e94251389729ef2a57565ef, itemCount=0, payAmount=10.08, payTextRaw=null, distanceMiles=12.3, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=30, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Buttermilk Sky Pie, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=fc2cbdc99f2158deb74425dfaf2bf6c2b7395083e2fab646da70449fe5d9e05f, presentationKey=f787cc90ced093254b17cc4833814948e627a3e51e94251389729ef2a57565ef, itemCount=0, itemCountIsUnits=false, payAmount=10.08, payTextRaw=null, distanceMiles=12.3, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=30, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Buttermilk Sky Pie, itemCount=1, isItemCountEstimated=true, badges=[], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer/2026-07-21_18-40-26-194__uber__accessibility.window__offer__2d8f1d.json": {
@@ -3045,7 +3045,7 @@
         "intent": "offer",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=554490d501c5d175c5a3aa235d53a57b6912ed72b7162dc68159d1972f9fa8bf, presentationKey=b7124711dcb138944ddaa29934aa29d42d8fa2c7ade9b9cdd558c6f1955386ad, itemCount=0, payAmount=8.54, payTextRaw=null, distanceMiles=12.8, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=33, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=BJ's Restaurant & Brewhouse (San Antonio #480), itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=554490d501c5d175c5a3aa235d53a57b6912ed72b7162dc68159d1972f9fa8bf, presentationKey=b7124711dcb138944ddaa29934aa29d42d8fa2c7ade9b9cdd558c6f1955386ad, itemCount=0, itemCountIsUnits=false, payAmount=8.54, payTextRaw=null, distanceMiles=12.8, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=33, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=BJ's Restaurant & Brewhouse (San Antonio #480), itemCount=1, isItemCountEstimated=true, badges=[], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer/2026-07-21_18-44-21-714__uber__accessibility.window__offer__3e789f.json": {
@@ -3053,7 +3053,7 @@
         "intent": "offer",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=b3dd7bb57085615c51d4de209190f9a34a35e855f691f69ebc9be536a176abb4, presentationKey=9eea16ddc80b8afb2e39480ef75bc32148fd7d517f0930ff438583733dfe1189, itemCount=0, payAmount=7.9, payTextRaw=null, distanceMiles=3.9, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=19, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Thai Buri (8728401), itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=b3dd7bb57085615c51d4de209190f9a34a35e855f691f69ebc9be536a176abb4, presentationKey=9eea16ddc80b8afb2e39480ef75bc32148fd7d517f0930ff438583733dfe1189, itemCount=0, itemCountIsUnits=false, payAmount=7.9, payTextRaw=null, distanceMiles=3.9, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=19, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Thai Buri (8728401), itemCount=1, isItemCountEstimated=true, badges=[], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_163448_533_OFFER_POPUP.json": {
@@ -3061,7 +3061,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=3ec891741cf8177c956bcaabb7912d18d0fa3cc94f8b8bcf390dc103b849eae2, presentationKey=e4325a89086d6f5595fd26f935323dfaf501e0b1df7d4ca2945db8d852a87204, itemCount=4, payAmount=8.15, payTextRaw=null, distanceMiles=5.8, distanceTextRaw=null, dueByTimeText=5:09 PM, dueByTimeMillis=1780333740000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=CVS, itemCount=4, isItemCountEstimated=false, badges=[RED_CARD])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=3ec891741cf8177c956bcaabb7912d18d0fa3cc94f8b8bcf390dc103b849eae2, presentationKey=e4325a89086d6f5595fd26f935323dfaf501e0b1df7d4ca2945db8d852a87204, itemCount=4, itemCountIsUnits=false, payAmount=8.15, payTextRaw=null, distanceMiles=5.8, distanceTextRaw=null, dueByTimeText=5:09 PM, dueByTimeMillis=1780333740000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=CVS, itemCount=4, isItemCountEstimated=false, badges=[RED_CARD], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_165601_985_OFFER_POPUP.json": {
@@ -3069,7 +3069,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=642140787888d068d91389c207e0e04d31072204747ceac37c12752f06193ba1, presentationKey=37b00b1091504b17700c98c0f6f728a8b140c22ed068e2e2d700dc03320321c7, itemCount=9, payAmount=12.25, payTextRaw=null, distanceMiles=5.1, distanceTextRaw=null, dueByTimeText=5:39 PM, dueByTimeMillis=1780335540000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=Dollar General, itemCount=9, isItemCountEstimated=false, badges=[RED_CARD])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=642140787888d068d91389c207e0e04d31072204747ceac37c12752f06193ba1, presentationKey=37b00b1091504b17700c98c0f6f728a8b140c22ed068e2e2d700dc03320321c7, itemCount=9, itemCountIsUnits=false, payAmount=12.25, payTextRaw=null, distanceMiles=5.1, distanceTextRaw=null, dueByTimeText=5:39 PM, dueByTimeMillis=1780335540000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=Dollar General, itemCount=9, isItemCountEstimated=false, badges=[RED_CARD], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_165606_061_OFFER_POPUP.json": {
@@ -3077,7 +3077,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=642140787888d068d91389c207e0e04d31072204747ceac37c12752f06193ba1, presentationKey=37b00b1091504b17700c98c0f6f728a8b140c22ed068e2e2d700dc03320321c7, itemCount=9, payAmount=12.25, payTextRaw=null, distanceMiles=5.1, distanceTextRaw=null, dueByTimeText=5:39 PM, dueByTimeMillis=1780335540000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=Dollar General, itemCount=9, isItemCountEstimated=false, badges=[RED_CARD])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=642140787888d068d91389c207e0e04d31072204747ceac37c12752f06193ba1, presentationKey=37b00b1091504b17700c98c0f6f728a8b140c22ed068e2e2d700dc03320321c7, itemCount=9, itemCountIsUnits=false, payAmount=12.25, payTextRaw=null, distanceMiles=5.1, distanceTextRaw=null, dueByTimeText=5:39 PM, dueByTimeMillis=1780335540000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=Dollar General, itemCount=9, isItemCountEstimated=false, badges=[RED_CARD], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_165612_046_OFFER_POPUP.json": {
@@ -3085,7 +3085,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=642140787888d068d91389c207e0e04d31072204747ceac37c12752f06193ba1, presentationKey=37b00b1091504b17700c98c0f6f728a8b140c22ed068e2e2d700dc03320321c7, itemCount=9, payAmount=12.25, payTextRaw=null, distanceMiles=5.1, distanceTextRaw=null, dueByTimeText=5:39 PM, dueByTimeMillis=1780335540000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=Dollar General, itemCount=9, isItemCountEstimated=false, badges=[RED_CARD])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=642140787888d068d91389c207e0e04d31072204747ceac37c12752f06193ba1, presentationKey=37b00b1091504b17700c98c0f6f728a8b140c22ed068e2e2d700dc03320321c7, itemCount=9, itemCountIsUnits=false, payAmount=12.25, payTextRaw=null, distanceMiles=5.1, distanceTextRaw=null, dueByTimeText=5:39 PM, dueByTimeMillis=1780335540000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=Dollar General, itemCount=9, isItemCountEstimated=false, badges=[RED_CARD], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_173308_715_OFFER_POPUP.json": {
@@ -3093,7 +3093,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=8c66a5d1d7b1abb0eb2a6cc15c22d118a18910237d942d4132ebefc38ee36ecf, presentationKey=d539030b696644980c7b060b066ad160751ffb8625561fb7ad896c5f1d5ab7e1, itemCount=0, payAmount=9.78, payTextRaw=null, distanceMiles=9.6, distanceTextRaw=null, dueByTimeText=6:00 PM, dueByTimeMillis=1780336800000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Peter Piper Pizza, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=8c66a5d1d7b1abb0eb2a6cc15c22d118a18910237d942d4132ebefc38ee36ecf, presentationKey=d539030b696644980c7b060b066ad160751ffb8625561fb7ad896c5f1d5ab7e1, itemCount=0, itemCountIsUnits=false, payAmount=9.78, payTextRaw=null, distanceMiles=9.6, distanceTextRaw=null, dueByTimeText=6:00 PM, dueByTimeMillis=1780336800000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Peter Piper Pizza, itemCount=1, isItemCountEstimated=true, badges=[], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_181353_816_OFFER_POPUP.json": {
@@ -3101,7 +3101,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=557b56c07af05fd45d36f3468acaa7fdc7f7f1d5cc922d8062779b86bebc323b, presentationKey=a3abb059ff9094ecd9e506061fd949fe12484d0e9969dbc4bb231e5d673bd77c, itemCount=0, payAmount=7.6, payTextRaw=null, distanceMiles=2.9, distanceTextRaw=null, dueByTimeText=6:32 PM, dueByTimeMillis=1780338720000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=True Texas BBQ, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=557b56c07af05fd45d36f3468acaa7fdc7f7f1d5cc922d8062779b86bebc323b, presentationKey=a3abb059ff9094ecd9e506061fd949fe12484d0e9969dbc4bb231e5d673bd77c, itemCount=0, itemCountIsUnits=false, payAmount=7.6, payTextRaw=null, distanceMiles=2.9, distanceTextRaw=null, dueByTimeText=6:32 PM, dueByTimeMillis=1780338720000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=True Texas BBQ, itemCount=1, isItemCountEstimated=true, badges=[], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_182525_934_OFFER_POPUP.json": {
@@ -3109,7 +3109,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=b436a4fe27c8cceb17c746a488e66816cfdb0fc396f4f461a6dc71406c77d350, presentationKey=e4325a89086d6f5595fd26f935323dfaf501e0b1df7d4ca2945db8d852a87204, itemCount=1, payAmount=5.0, payTextRaw=null, distanceMiles=4.5, distanceTextRaw=null, dueByTimeText=6:50 PM, dueByTimeMillis=1780339800000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=CVS, itemCount=1, isItemCountEstimated=false, badges=[RED_CARD])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=b436a4fe27c8cceb17c746a488e66816cfdb0fc396f4f461a6dc71406c77d350, presentationKey=e4325a89086d6f5595fd26f935323dfaf501e0b1df7d4ca2945db8d852a87204, itemCount=1, itemCountIsUnits=false, payAmount=5.0, payTextRaw=null, distanceMiles=4.5, distanceTextRaw=null, dueByTimeText=6:50 PM, dueByTimeMillis=1780339800000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=CVS, itemCount=1, isItemCountEstimated=false, badges=[RED_CARD], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_182536_960_OFFER_POPUP.json": {
@@ -3117,7 +3117,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=b436a4fe27c8cceb17c746a488e66816cfdb0fc396f4f461a6dc71406c77d350, presentationKey=e4325a89086d6f5595fd26f935323dfaf501e0b1df7d4ca2945db8d852a87204, itemCount=1, payAmount=5.0, payTextRaw=null, distanceMiles=4.5, distanceTextRaw=null, dueByTimeText=6:50 PM, dueByTimeMillis=1780339800000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=CVS, itemCount=1, isItemCountEstimated=false, badges=[RED_CARD])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=b436a4fe27c8cceb17c746a488e66816cfdb0fc396f4f461a6dc71406c77d350, presentationKey=e4325a89086d6f5595fd26f935323dfaf501e0b1df7d4ca2945db8d852a87204, itemCount=1, itemCountIsUnits=false, payAmount=5.0, payTextRaw=null, distanceMiles=4.5, distanceTextRaw=null, dueByTimeText=6:50 PM, dueByTimeMillis=1780339800000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=CVS, itemCount=1, isItemCountEstimated=false, badges=[RED_CARD], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_182617_556_OFFER_POPUP.json": {
@@ -3125,7 +3125,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=6dfe7dbc4fa70c5bc217f9dbfc76e9203359119daaf871683f66b45f6a17cba1, presentationKey=51b84cf1ff3a7facc040437ee360ffa404009125489df6c574530545076fddfb, itemCount=1, payAmount=6.85, payTextRaw=null, distanceMiles=6.4, distanceTextRaw=null, dueByTimeText=7:06 PM, dueByTimeMillis=1780340760000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=CVS, itemCount=1, isItemCountEstimated=false, badges=[RED_CARD]), ParsedOrder(orderIndex=1, orderType=PICKUP, storeName=Bill Miller BBQ, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=6dfe7dbc4fa70c5bc217f9dbfc76e9203359119daaf871683f66b45f6a17cba1, presentationKey=51b84cf1ff3a7facc040437ee360ffa404009125489df6c574530545076fddfb, itemCount=1, itemCountIsUnits=false, payAmount=6.85, payTextRaw=null, distanceMiles=6.4, distanceTextRaw=null, dueByTimeText=7:06 PM, dueByTimeMillis=1780340760000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=CVS, itemCount=1, isItemCountEstimated=false, badges=[RED_CARD], countUnit=ITEMS), ParsedOrder(orderIndex=1, orderType=PICKUP, storeName=Bill Miller BBQ, itemCount=1, isItemCountEstimated=true, badges=[], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_182655_860_OFFER_POPUP.json": {
@@ -3133,7 +3133,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=0dda70d10932eba701ef1d2df425fe01b33876a325ebcbfc3e3ed3e4e59e2b3b, presentationKey=6a96e0461b59a0f8371547e8258c8a8f6c9566541ad09eef07489cd706c692ba, itemCount=0, payAmount=5.95, payTextRaw=null, distanceMiles=4.4, distanceTextRaw=null, dueByTimeText=6:46 PM, dueByTimeMillis=1780339560000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Taco Bell, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=0dda70d10932eba701ef1d2df425fe01b33876a325ebcbfc3e3ed3e4e59e2b3b, presentationKey=6a96e0461b59a0f8371547e8258c8a8f6c9566541ad09eef07489cd706c692ba, itemCount=0, itemCountIsUnits=false, payAmount=5.95, payTextRaw=null, distanceMiles=4.4, distanceTextRaw=null, dueByTimeText=6:46 PM, dueByTimeMillis=1780339560000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Taco Bell, itemCount=1, isItemCountEstimated=true, badges=[], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_185925_772_OFFER_POPUP.json": {
@@ -3141,7 +3141,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=bb47312390e65ec432e318298828ec0a671c00ab3aa620a6c8fcb985781ef300, presentationKey=93c1998cb27ddae514e62e3f7d121192cb404c2e06c7c4e1ccb35e1bd9fd6476, itemCount=0, payAmount=5.45, payTextRaw=null, distanceMiles=2.8, distanceTextRaw=null, dueByTimeText=7:23 PM, dueByTimeMillis=1780341780000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Raising Cane's, itemCount=1, isItemCountEstimated=true, badges=[RED_CARD])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=bb47312390e65ec432e318298828ec0a671c00ab3aa620a6c8fcb985781ef300, presentationKey=93c1998cb27ddae514e62e3f7d121192cb404c2e06c7c4e1ccb35e1bd9fd6476, itemCount=0, itemCountIsUnits=false, payAmount=5.45, payTextRaw=null, distanceMiles=2.8, distanceTextRaw=null, dueByTimeText=7:23 PM, dueByTimeMillis=1780341780000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Raising Cane's, itemCount=1, isItemCountEstimated=true, badges=[RED_CARD], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_193825_010_OFFER_POPUP.json": {
@@ -3149,7 +3149,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=a7b89a7758c44f9fa0b6316623df9fd1019b7e03135096abe0a019b9dcb68bac, presentationKey=a47525e3cc17973d3b6458462aeb9c9f85d99b71460f830e6d6117653d25e691, itemCount=0, payAmount=12.15, payTextRaw=null, distanceMiles=10.7, distanceTextRaw=null, dueByTimeText=8:09 PM, dueByTimeMillis=1780344540000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Tarka Indian Kitchen, itemCount=1, isItemCountEstimated=true, badges=[]), ParsedOrder(orderIndex=1, orderType=PICKUP, storeName=Torchy's Tacos, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=a7b89a7758c44f9fa0b6316623df9fd1019b7e03135096abe0a019b9dcb68bac, presentationKey=a47525e3cc17973d3b6458462aeb9c9f85d99b71460f830e6d6117653d25e691, itemCount=0, itemCountIsUnits=false, payAmount=12.15, payTextRaw=null, distanceMiles=10.7, distanceTextRaw=null, dueByTimeText=8:09 PM, dueByTimeMillis=1780344540000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Tarka Indian Kitchen, itemCount=1, isItemCountEstimated=true, badges=[], countUnit=ITEMS), ParsedOrder(orderIndex=1, orderType=PICKUP, storeName=Torchy's Tacos, itemCount=1, isItemCountEstimated=true, badges=[], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_202519_909_OFFER_POPUP.json": {
@@ -3157,7 +3157,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=1e82bb40bb58a9011894dae8a0765062cd5cb529b3b4c353aaf25186f1498c09, presentationKey=e4325a89086d6f5595fd26f935323dfaf501e0b1df7d4ca2945db8d852a87204, itemCount=4, payAmount=10.25, payTextRaw=null, distanceMiles=6.6, distanceTextRaw=null, dueByTimeText=8:58 PM, dueByTimeMillis=1780347480000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=CVS, itemCount=4, isItemCountEstimated=false, badges=[RED_CARD])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=1e82bb40bb58a9011894dae8a0765062cd5cb529b3b4c353aaf25186f1498c09, presentationKey=e4325a89086d6f5595fd26f935323dfaf501e0b1df7d4ca2945db8d852a87204, itemCount=4, itemCountIsUnits=false, payAmount=10.25, payTextRaw=null, distanceMiles=6.6, distanceTextRaw=null, dueByTimeText=8:58 PM, dueByTimeMillis=1780347480000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=CVS, itemCount=4, isItemCountEstimated=false, badges=[RED_CARD], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup/523fd0d0.json": {
@@ -3165,7 +3165,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=8858bae42074b1148e63146e4bf2fbef69c85f539999d3731f99f2acbe779a9c, presentationKey=45e30710298a5e9f1533a654cccb5c47605114434d45296a73bb8d91689ff887, itemCount=11, payAmount=16.25, payTextRaw=null, distanceMiles=7.5, distanceTextRaw=null, dueByTimeText=4:21 PM, dueByTimeMillis=1780330860000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=Michaels, itemCount=11, isItemCountEstimated=false, badges=[RED_CARD])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=8858bae42074b1148e63146e4bf2fbef69c85f539999d3731f99f2acbe779a9c, presentationKey=45e30710298a5e9f1533a654cccb5c47605114434d45296a73bb8d91689ff887, itemCount=11, itemCountIsUnits=false, payAmount=16.25, payTextRaw=null, distanceMiles=7.5, distanceTextRaw=null, dueByTimeText=4:21 PM, dueByTimeMillis=1780330860000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=Michaels, itemCount=11, isItemCountEstimated=false, badges=[RED_CARD], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup/d3dc2b32.json": {
@@ -3173,7 +3173,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=8858bae42074b1148e63146e4bf2fbef69c85f539999d3731f99f2acbe779a9c, presentationKey=45e30710298a5e9f1533a654cccb5c47605114434d45296a73bb8d91689ff887, itemCount=11, payAmount=16.25, payTextRaw=null, distanceMiles=7.5, distanceTextRaw=null, dueByTimeText=4:21 PM, dueByTimeMillis=1780330860000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=Michaels, itemCount=11, isItemCountEstimated=false, badges=[RED_CARD])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=8858bae42074b1148e63146e4bf2fbef69c85f539999d3731f99f2acbe779a9c, presentationKey=45e30710298a5e9f1533a654cccb5c47605114434d45296a73bb8d91689ff887, itemCount=11, itemCountIsUnits=false, payAmount=16.25, payTextRaw=null, distanceMiles=7.5, distanceTextRaw=null, dueByTimeText=4:21 PM, dueByTimeMillis=1780330860000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=Michaels, itemCount=11, isItemCountEstimated=false, badges=[RED_CARD], countUnit=ITEMS)], rawExtractedTexts=null)"
         }
     },
     "offer_popup_confirm_decline/2026-02-06_14-00-00__OFFER_POPUP_CONFIRM_DECLINE__29001e4a.json": {

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
@@ -175,8 +175,11 @@ class StrategyRepository @Inject constructor(
         protectStatsMode,
         allowShopping,
         appPreferencesRepository.userEconomy,
-        dataSource.learnedShopRates,
-    ) { rules, protect, shop, economy, shopRates ->
+        // #823: combine the two per-platform learned-rate maps into one source so the outer combine
+        // stays within the 5-arg typed overload (shop pace + items:units ratio both live in the
+        // strategy store; both are consumed at eval time by EvaluationConfig.forPlatform).
+        combine(dataSource.learnedShopRates, dataSource.learnedItemsPerUnitRatios) { s, r -> s to r },
+    ) { rules, protect, shop, economy, (shopRates, itemsPerUnitRatios) ->
         EvaluationConfig(
             protectStatsMode = protect,
             rules = rules,
@@ -187,6 +190,8 @@ class StrategyRepository @Inject constructor(
             // Instacart shop). It lives in the strategy store, not the user-economy store, so it's never
             // reseeded by a vehicle-class change (#556).
             shopRates = shopRates,
+            // #823 Phase 1: same per-platform discipline for the items:units ratio.
+            itemsPerUnitRatios = itemsPerUnitRatios,
         )
     }.stateIn(scope, SharingStarted.Eagerly, null)
 
@@ -197,6 +202,14 @@ class StrategyRepository @Inject constructor(
      */
     suspend fun recordShopRate(platform: Platform, items: Int, minutes: Double) =
         dataSource.recordShopRate(platform, items, minutes)
+
+    /**
+     * #823 Phase 1: fold a completed units-shop's measured items:units ratio into [platform]'s learned
+     * ratio (atomic). Returns the post-fold [cloud.trotter.dashbuddy.domain.evaluation.LearnedItemsPerUnitRatio]
+     * so the caller can log the relearn trajectory (desk-observability, mirrors [recordShopRate]).
+     */
+    suspend fun recordItemsPerUnitRatio(platform: Platform, units: Int, items: Int) =
+        dataSource.recordItemsPerUnitRatio(platform, units, items)
 
     suspend fun clearPreferences() {
         Timber.w("Clearing Strategy Preferences")

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
@@ -9,6 +9,8 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import cloud.trotter.dashbuddy.core.datastore.di.StrategyPreferences
 import cloud.trotter.dashbuddy.core.datastore.strategy.dto.ScoringRuleDto
+import cloud.trotter.dashbuddy.domain.evaluation.ItemsPerUnitRatio
+import cloud.trotter.dashbuddy.domain.evaluation.LearnedItemsPerUnitRatio
 import cloud.trotter.dashbuddy.domain.evaluation.LearnedShopRate
 import cloud.trotter.dashbuddy.domain.evaluation.ShopRate
 import cloud.trotter.dashbuddy.domain.state.Platform
@@ -59,6 +61,16 @@ class StrategyDataSource @Inject constructor(
         doublePreferencesKey("learned_shop_items_per_min:${platform.wire}")
     private fun shopSamplesKey(platform: Platform) =
         intPreferencesKey("shop_rate_sample_count:${platform.wire}")
+
+    // #823 Phase 1: learned items:units ratio, keyed **per platform** (P8) exactly like the shop-rate
+    // keys above — a DoorDash-learned ratio can never convert an Uber shop's units. A measured value
+    // (not a user-set economy field), kept in the strategy store so a vehicle-class reseed can't touch
+    // it; folded into the evaluator's UserEconomy by StrategyRepository. Keys derive from
+    // [Platform.wire], so a new platform needs zero datastore change.
+    private fun itemsPerUnitRatioKey(platform: Platform) =
+        doublePreferencesKey("learned_items_per_unit_ratio:${platform.wire}")
+    private fun itemsPerUnitRatioSamplesKey(platform: Platform) =
+        intPreferencesKey("items_per_unit_ratio_sample_count:${platform.wire}")
 
     // #588 FIX 3b: the pre-#588 GLOBAL un-suffixed keys (one shared mean before shop-rate learning
     // went per-platform). Deliberately DROPPED, not migrated (#588 design decision — an old global
@@ -124,6 +136,20 @@ class StrategyDataSource @Inject constructor(
     }
 
     /**
+     * #823 Phase 1: the learned items:units ratio per platform (running mean + sample count). A
+     * platform with no recorded units-shops is omitted — the eval seam
+     * ([cloud.trotter.dashbuddy.domain.evaluation.EvaluationConfig.forPlatform]) owns the per-platform
+     * seed fallback, so a missing entry is the seed, never another platform's ratio.
+     */
+    val learnedItemsPerUnitRatios: Flow<Map<Platform, LearnedItemsPerUnitRatio>> = ds.data.map { prefs ->
+        Platform.entries.mapNotNull { platform ->
+            val avg = prefs[itemsPerUnitRatioKey(platform)]
+            val n = prefs[itemsPerUnitRatioSamplesKey(platform)] ?: 0
+            if (avg == null && n == 0) null else platform to LearnedItemsPerUnitRatio(avg, n)
+        }.toMap()
+    }
+
+    /**
      * #556/#588: fold one measured shop ([items] over [minutes] in-store) into [platform]'s running
      * mean, atomically (read-modify-write inside one edit, so back-to-back stacked shops can't race).
      * Out-of-band samples (below the [ShopRate] floors) are no-ops. Only [platform]'s key pair moves.
@@ -149,6 +175,29 @@ class StrategyDataSource @Inject constructor(
         // persisted: an in-band fold just wrote these keys; an out-of-band fold is a no-op and the
         // untouched keys ARE the prior pair ShopRate.fold would have returned.
         return LearnedShopRate(prefs[shopRateKey(platform)], prefs[shopSamplesKey(platform)] ?: 0)
+    }
+
+    /**
+     * #823 Phase 1: fold one measured units-shop ([units] quoted on the offer, [items] actually
+     * shopped) into [platform]'s learned items:units ratio, atomically (read-modify-write inside one
+     * edit). Out-of-band samples (below the [ItemsPerUnitRatio] floors) are no-ops. Only [platform]'s
+     * key pair moves. Returns the post-fold [LearnedItemsPerUnitRatio] (desk-observability, mirrors
+     * [recordShopRate]) — the running mean lives ONLY in this datastore, invisible to a post-dash
+     * data pull, so surfacing it lets the caller log the relearn trajectory.
+     */
+    suspend fun recordItemsPerUnitRatio(platform: Platform, units: Int, items: Int): LearnedItemsPerUnitRatio {
+        val prefs = ds.edit { p ->
+            val (avg, n) = ItemsPerUnitRatio.fold(
+                p[itemsPerUnitRatioKey(platform)], p[itemsPerUnitRatioSamplesKey(platform)] ?: 0, units, items,
+            )
+            if (avg != null) {
+                p[itemsPerUnitRatioKey(platform)] = avg
+                p[itemsPerUnitRatioSamplesKey(platform)] = n
+            }
+        }
+        return LearnedItemsPerUnitRatio(
+            prefs[itemsPerUnitRatioKey(platform)], prefs[itemsPerUnitRatioSamplesKey(platform)] ?: 0,
+        )
     }
 
     suspend fun setEvidenceMaster(enabled: Boolean) {

--- a/core/datastore/src/test/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSourceShopRateTest.kt
+++ b/core/datastore/src/test/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSourceShopRateTest.kt
@@ -127,7 +127,7 @@ class StrategyDataSourceShopRateTest {
         // DoorDash: five 39-item / 50-unit shops → 0.78 exactly, past the trust gate.
         var lastDd: cloud.trotter.dashbuddy.domain.evaluation.LearnedItemsPerUnitRatio? = null
         repeat(5) { lastDd = src.recordItemsPerUnitRatio(Platform.DoorDash, units = 50, items = 39) }
-        // Uber: three 30-item / 64-unit shops → 0.469 CLAMPED to 0.5.
+        // Uber: three 30-item / 64-unit shops → 0.46875, in-band above the 0.3 floor (F1).
         repeat(3) { src.recordItemsPerUnitRatio(Platform.Uber, units = 64, items = 30) }
         advanceUntilIdle()
 
@@ -135,8 +135,8 @@ class StrategyDataSourceShopRateTest {
         val ratios = src.learnedItemsPerUnitRatios.first()
         assertEquals(0.78, ratios.getValue(Platform.DoorDash).ratio!!, 1e-9)
         assertEquals(5, ratios.getValue(Platform.DoorDash).sampleCount)
-        // The below-band Uber samples fold at the clamped floor, not their raw 0.469.
-        assertEquals(ItemsPerUnitRatio.MIN_RATIO, ratios.getValue(Platform.Uber).ratio!!, 1e-9)
+        // The fielded H-E-B ratio folds at its exact value (0.46875), NOT the floor.
+        assertEquals(0.46875, ratios.getValue(Platform.Uber).ratio!!, 1e-9)
         assertEquals(3, ratios.getValue(Platform.Uber).sampleCount)
         // A platform that never recorded is absent — the eval seam owns the seed fallback.
         assertNull(ratios[Platform.Instacart])

--- a/core/datastore/src/test/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSourceShopRateTest.kt
+++ b/core/datastore/src/test/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSourceShopRateTest.kt
@@ -4,6 +4,7 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import cloud.trotter.dashbuddy.domain.evaluation.ItemsPerUnitRatio
 import cloud.trotter.dashbuddy.domain.evaluation.LearnedShopRate
 import cloud.trotter.dashbuddy.domain.evaluation.ShopRate
 import cloud.trotter.dashbuddy.domain.state.Platform
@@ -112,5 +113,55 @@ class StrategyDataSourceShopRateTest {
                 "under DoorDash or any other platform",
             src.learnedShopRates.first().isEmpty(),
         )
+    }
+
+    @Test
+    fun `items-units ratio learns per platform, clamps out-of-band samples, and one platform never moves another (#823)`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val ds = PreferenceDataStoreFactory.create(
+            scope = CoroutineScope(dispatcher + Job()),
+            produceFile = { File(tmp.root, "strategy_ratio.preferences_pb") },
+        )
+        val src = StrategyDataSource(ds)
+
+        // DoorDash: five 39-item / 50-unit shops → 0.78 exactly, past the trust gate.
+        var lastDd: cloud.trotter.dashbuddy.domain.evaluation.LearnedItemsPerUnitRatio? = null
+        repeat(5) { lastDd = src.recordItemsPerUnitRatio(Platform.DoorDash, units = 50, items = 39) }
+        // Uber: three 30-item / 64-unit shops → 0.469 CLAMPED to 0.5.
+        repeat(3) { src.recordItemsPerUnitRatio(Platform.Uber, units = 64, items = 30) }
+        advanceUntilIdle()
+
+        assertEquals(5, lastDd!!.sampleCount)
+        val ratios = src.learnedItemsPerUnitRatios.first()
+        assertEquals(0.78, ratios.getValue(Platform.DoorDash).ratio!!, 1e-9)
+        assertEquals(5, ratios.getValue(Platform.DoorDash).sampleCount)
+        // The below-band Uber samples fold at the clamped floor, not their raw 0.469.
+        assertEquals(ItemsPerUnitRatio.MIN_RATIO, ratios.getValue(Platform.Uber).ratio!!, 1e-9)
+        assertEquals(3, ratios.getValue(Platform.Uber).sampleCount)
+        // A platform that never recorded is absent — the eval seam owns the seed fallback.
+        assertNull(ratios[Platform.Instacart])
+
+        // Recording more Uber shops must not perturb DoorDash's entry.
+        src.recordItemsPerUnitRatio(Platform.Uber, units = 64, items = 30)
+        advanceUntilIdle()
+        val after = src.learnedItemsPerUnitRatios.first()
+        assertEquals("DoorDash untouched", 0.78, after.getValue(Platform.DoorDash).ratio!!, 1e-9)
+        assertEquals("DoorDash untouched", 5, after.getValue(Platform.DoorDash).sampleCount)
+    }
+
+    @Test
+    fun `a below-floor items-units sample is a no-op and creates no entry (#823)`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val ds = PreferenceDataStoreFactory.create(
+            scope = CoroutineScope(dispatcher + Job()),
+            produceFile = { File(tmp.root, "strategy_ratio2.preferences_pb") },
+        )
+        val src = StrategyDataSource(ds)
+
+        src.recordItemsPerUnitRatio(Platform.DoorDash, units = 0, items = 30) // no units
+        src.recordItemsPerUnitRatio(Platform.DoorDash, units = 50, items = ItemsPerUnitRatio.MIN_ITEMS - 1)
+        advanceUntilIdle()
+
+        assertTrue("no entry from noise", src.learnedItemsPerUnitRatios.first().isEmpty())
     }
 }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParsedFieldsFactory.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParsedFieldsFactory.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.core.pipeline.rules
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.ParsedTime
 import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.model.order.CountUnit
 import cloud.trotter.dashbuddy.domain.model.order.OrderBadge
 import cloud.trotter.dashbuddy.domain.model.order.OrderType
 import cloud.trotter.dashbuddy.domain.model.order.ParsedOrder
@@ -264,6 +265,14 @@ object ParsedFieldsFactory {
                 itemCount = o.int("itemCount") ?: 1,
                 isItemCountEstimated = o.int("itemCount") == null,
                 badges = badges,
+                // #823 Phase 1: which label the count was denominated by. UNITS only when the rule
+                // parsed "UNITS" (a units-only "(64 units)") AND a real count was read (not the
+                // estimated default) — an estimated/absent count is meaningless to denominate.
+                countUnit = if (o.int("itemCount") != null && o.str("itemCountUnit") == "UNITS") {
+                    CountUnit.UNITS
+                } else {
+                    CountUnit.ITEMS
+                },
             )
         }
 
@@ -311,6 +320,17 @@ object ParsedFieldsFactory {
                 itemCount = orders
                     .filter { it.orderType == OrderType.SHOP_FOR_ITEMS && !it.isItemCountEstimated }
                     .sumOf { it.itemCount },
+                // #823 Phase 1: the summed shop count is units-denominated iff there is at least one
+                // contributing (confirmed) shop order AND every one of them was units-denominated —
+                // the units-only shape this converts for the time estimate. A mixed stack (some items,
+                // some units) stays false → no ratio applied → unchanged behaviour (Phase 1 scopes the
+                // fielded units-only single-shop offer; mixing denominations in one summed number is a
+                // pre-existing shape this deliberately does not touch).
+                itemCountIsUnits = orders
+                    .filter { it.orderType == OrderType.SHOP_FOR_ITEMS && !it.isItemCountEstimated }
+                    .let { shopOrders ->
+                        shopOrders.isNotEmpty() && shopOrders.all { it.countUnit == CountUnit.UNITS }
+                    },
                 payAmount = payAmount,
                 distanceMiles = distance,
                 dueByTimeText = deliveryTimeText,

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformRegistry.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformRegistry.kt
@@ -100,6 +100,7 @@ object TransformRegistry {
             "parseCurrency" -> parseCurrency(value)
             "parseDistance" -> parseDistance(value)
             "parseItemCount" -> parseItemCount(value)
+            "parseItemCountUnit" -> parseItemCountUnit(value)
             "parseDeadline" -> parseDeadlineMillis(value)
             "parseTime" -> parseTimeTextToMillis(value)
             "parseDuration" -> parseDuration(value)
@@ -229,7 +230,7 @@ object TransformRegistry {
     // ========================================================================
 
     private val knownPlainTransforms = setOf(
-        "parseCurrency", "parseDistance", "parseItemCount", "parseDeadline",
+        "parseCurrency", "parseDistance", "parseItemCount", "parseItemCountUnit", "parseDeadline",
         "parseTime", "parseDuration", "parseHrMin", "parseMinutes", "parseLeadingInt",
         "parsePercent", "sha256", "normalizeCustomerName", "trim", "lower", "upper",
         "toDouble", "toInt", "stripDeadlinePrefix",
@@ -361,6 +362,20 @@ object TransformRegistry {
     private fun parseItemCount(text: String): Int? {
         return Regex("\\((\\d+)\\s*(?:item|order|unit)", RegexOption.IGNORE_CASE)
             .find(text)?.groupValues?.get(1)?.toIntOrNull()
+    }
+
+    /**
+     * Denomination of the FIRST count token [parseItemCount] reads (#823 Phase 1): "UNITS" when that
+     * count is bound to "unit(s)" (a units-only offer like "(64 units)" or "(1 unit)"), else "ITEMS"
+     * (an items figure — "(4 items)", or the leading "9 items" of "(9 items • 11 units)"). Anchored
+     * on the SAME `(<number><word>` shape as [parseItemCount] so the two never disagree about which
+     * token was read; returns null when no count token is present (leaves the field absent → the
+     * factory's ITEMS default). "order" reads as ITEMS (an order count is not a unit multiplier).
+     */
+    private fun parseItemCountUnit(text: String): String? {
+        val word = Regex("\\(\\d+\\s*(item|order|unit)", RegexOption.IGNORE_CASE)
+            .find(text)?.groupValues?.get(1)?.lowercase(Locale.ROOT) ?: return null
+        return if (word.startsWith("unit")) "UNITS" else "ITEMS"
     }
 
     /**

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformRegistryTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformRegistryTest.kt
@@ -142,4 +142,34 @@ class TransformRegistryTest {
         assertNull(TransformRegistry.apply("parseDeadline", "no time here"))
         assertNull(TransformRegistry.apply("parseTime", "garbage"))
     }
+
+    // #823 Phase 1 — item-count denomination. parseItemCountUnit reads the FIRST count token's label
+    // off the SAME node as parseItemCount, so the pair never disagrees about which number was read.
+
+    @Test
+    fun `parseItemCountUnit reads UNITS for a units-only render`() {
+        assertEquals("UNITS", TransformRegistry.apply("parseItemCountUnit", "(64 units)"))
+        assertEquals("UNITS", TransformRegistry.apply("parseItemCountUnit", "(1 unit)"))
+    }
+
+    @Test
+    fun `parseItemCountUnit reads ITEMS when the leading count is items`() {
+        assertEquals("ITEMS", TransformRegistry.apply("parseItemCountUnit", "(4 items)"))
+        // Items•units: parseItemCount grabs the leading "9", so its denomination is ITEMS.
+        assertEquals("ITEMS", TransformRegistry.apply("parseItemCountUnit", "(9 items • 11 units)"))
+    }
+
+    @Test
+    fun `parseItemCount and parseItemCountUnit agree on the token they read`() {
+        assertEquals(9, TransformRegistry.apply("parseItemCount", "(9 items • 11 units)"))
+        assertEquals("ITEMS", TransformRegistry.apply("parseItemCountUnit", "(9 items • 11 units)"))
+        assertEquals(64, TransformRegistry.apply("parseItemCount", "(64 units)"))
+        assertEquals("UNITS", TransformRegistry.apply("parseItemCountUnit", "(64 units)"))
+    }
+
+    @Test
+    fun `parseItemCountUnit returns null when no count token is present`() {
+        assertNull(TransformRegistry.apply("parseItemCountUnit", "H-E-B"))
+        assertNull(TransformRegistry.apply("parseItemCountUnit", "no count here"))
+    }
 }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -138,6 +138,22 @@ sealed class AppEffect {
         // per-platform-unique already, the wire prefix keeps the namespace disjoint (mirrors #438-B4).
         override val effectKey: String get() = "shop_rate:${platform.wire}:$taskId"
     }
+
+    /**
+     * #823 Phase 1: a units-denominated Shop & Deliver pickup just completed — fold its measured
+     * items:units ratio ([itemsShopped] actually shopped vs the offer's quoted [offerUnitCount]) into
+     * the learned per-platform ratio. Emitted alongside [RecordShopRate] only when the job's accepted
+     * offer was units-denominated. Idempotent per task (same keying discipline).
+     */
+    data class RecordItemsPerUnitRatio(
+        val platform: Platform,
+        val offerUnitCount: Int,
+        val itemsShopped: Int,
+        val jobId: String,
+        val taskId: String,
+    ) : AppEffect() {
+        override val effectKey: String get() = "items_per_unit_ratio:${platform.wire}:$taskId"
+    }
     /**
      * Evaluate the pending offer. [offerHash] rides the async round-trip so the result
      * can be correlated back — a replaced offer must never inherit the previous offer's

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/DeliveryCompletionEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/DeliveryCompletionEffects.kt
@@ -203,6 +203,11 @@ internal fun EffectMap.diffDeliveryCompletion(
             .any { it.jobId == closedJob.jobId && it.phase == TaskPhase.DROPOFF }
         if (!jobHadDropoff) {
             addAll(
+                // #823 F3a: no `ratioJob` — the items:units ratio is DELIBERATELY not learned on this
+                // pickup-only close-out (an abnormal completion that never reached a dropoff is not a
+                // trustworthy items:units sample). The shop PACE still folds here via RecordShopRate.
+                // (Structurally reinforced: `region` is `next`, whose activeJob != closedJob by the
+                // guard above, so even the old region-internal lookup could never have learned here.)
                 pickupConfirmSweepEffects(
                     sessionId, next, closedJob.jobId, obs,
                     jobOfferHashes = closedJob.parentOfferHashes,

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/JobAcceptFlow.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/JobAcceptFlow.kt
@@ -74,6 +74,10 @@ internal fun PlatformRegionStepper.acceptInputsFromPending(pending: PendingOffer
             netPay = eval?.netPayAmount,
             estMinutes = eval?.estimatedTimeMinutes ?: parsedOffer?.timeToCompleteMinutes?.toDouble(),
             distanceMiles = eval?.distanceMiles ?: parsedOffer?.distanceMiles,
+            // #823 Phase 1: capture the offer's quoted UNITS count when it was units-denominated, so
+            // the pickup-confirmed shop-rate site can pair it with the ground-truth items shopped and
+            // learn the items:units ratio. Null for an items-denominated / non-shop offer.
+            offerUnitCount = parsedOffer?.takeIf { it.itemCountIsUnits }?.itemCount,
             // The honest accept moment (the accept-click time); falls back to the consume frame.
             acceptedAt = acceptedAt ?: pending?.acceptClickAt ?: pending?.presentedAt ?: 0L,
         ),

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TaskEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TaskEffects.kt
@@ -10,6 +10,7 @@ import cloud.trotter.dashbuddy.domain.model.pay.displayLabel
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.TransitionTrigger
 import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.Job
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.PickupActivity
 import cloud.trotter.dashbuddy.domain.state.Platform
@@ -154,17 +155,16 @@ internal fun EffectMap.diffTask(
             // displaced prevTask + any earlier displaced pickups), each at its own completion
             // time, BEFORE the dropoff's DELIVERY_NAV_STARTED (CONFIRMED-before-NAV). Per-task
             // keys make this idempotent with the close-out sweep below.
+            // #159 FIX 9 / #823 F3: resolve the confirming job PREV-first (next's active job may have
+            // already swapped to a stacked next job on this edge, which would drop both the offer
+            // hashes AND the units-ratio sample); fall back to next's, then null when truly gone.
+            val sweepJob = prev.activeJob?.takeIf { it.jobId == prevTask.jobId }
+                ?: next.activeJob?.takeIf { it.jobId == prevTask.jobId }
             addAll(
                 pickupConfirmSweepEffects(
                     sessionId, next, prevTask.jobId, obs,
-                    // #159 FIX 9: source the job's offer hashes from the job matching prevTask.jobId in
-                    // PREV state first (next's active job may have already swapped to a stacked next job on
-                    // this edge, which would drop the hashes to empty); fall back to next's, then empty
-                    // only when the job is truly gone from both.
-                    jobOfferHashes = (
-                        prev.activeJob?.takeIf { it.jobId == prevTask.jobId }
-                            ?: next.activeJob?.takeIf { it.jobId == prevTask.jobId }
-                        )?.parentOfferHashes ?: emptyList(),
+                    jobOfferHashes = sweepJob?.parentOfferHashes ?: emptyList(),
+                    ratioJob = sweepJob,
                 ),
             )
             addAll(deliveryNavStartedEffects(sessionId, nextTask, obs))
@@ -324,17 +324,17 @@ internal fun EffectMap.pickupConfirmSweepEffects(
     // #159 D3: the job's contributing offer hashes, carried onto each PICKUP_CONFIRMED payload for the
     // offer↔job link. Passed by the caller (the job is in scope there); empty ⇒ temporal fallback (F12).
     jobOfferHashes: List<String> = emptyList(),
+    // #823 Phase 1 (F3): the job whose units-denominated offer teaches the items:units ratio, resolved
+    // by the CALLER (prev-first on the pickup→dropoff edge, where next's activeJob may already have
+    // swapped to a stacked job — mirrors the [jobOfferHashes] resolution). Null ⇒ no ratio learning.
+    // The close-out site (DeliveryCompletionEffects) passes null DELIBERATELY: a pickup-only close is
+    // an abnormal completion, not a units-ratio-learning surface — that path folds the shop PACE
+    // (RecordShopRate) but never the ratio. Do NOT switch this to `region.activeJob`: on both callers
+    // `region` is `next`, whose activeJob is null/other-job by construction there, so it would learn
+    // nothing on the normal edge AND silently open the close-out (suspicious-sample) path.
+    ratioJob: Job? = null,
 ): List<AppEffect> = buildList {
     if (jobId == null) return@buildList
-    // #823 Phase 1: resolve THIS job's units-denominated offer count for the items:units-ratio
-    // learning — only when the job is a SINGLE accepted offer that was units-denominated
-    // (`acceptedOffers.singleOrNull()`), so a stack (which offer's units pair with which pickup's
-    // items is ambiguous) contributes no sample. Null ⇒ no ratio learning (fail-safe: a missing
-    // sample beats a mis-attributed one, the MIN_SAMPLES philosophy).
-    val offerUnitCount = region.activeJob
-        ?.takeIf { it.jobId == jobId }
-        ?.acceptedOffers?.singleOrNull()
-        ?.offerUnitCount
     val lineage = (region.recentTasks + listOfNotNull(region.activeTask))
         // #736: a pickup the dasher UNASSIGNED (marker set, completedAt left null) is NOT a
         // confirmable pickup — exclude it so a job that closes over an abandoned-but-arrived pickup
@@ -343,6 +343,21 @@ internal fun EffectMap.pickupConfirmSweepEffects(
         // sweep, and this filter is what stops it re-minting.
         .filter { it.jobId == jobId && it.phase == TaskPhase.PICKUP && it.arrivedAt != null && it.unassignedAt == null }
         .distinctBy { it.taskId }
+    // #823 Phase 1: resolve THIS job's units-denominated offer count for the items:units-ratio
+    // learning. Two independent ambiguity guards, BOTH required:
+    //  (1) a SINGLE accepted offer that was units-denominated (`acceptedOffers.singleOrNull()`) — a
+    //      stack of offers can't say which offer's units pair with which pickup's items;
+    //  (2) at most ONE shopping pickup in the swept lineage (F2) — one units-denominated offer can
+    //      itself carry ≥2 shop orders at distinct stores → ≥2 SHOPPING pickups, each of which would
+    //      otherwise fold its OWN itemsShopped against the offer's SUMMED unit count → N biased-low
+    //      samples. When >1 shopping pickup sweeps, no per-pickup unit split exists, so learn nothing.
+    // Null ⇒ no ratio learning (fail-safe: a missing sample beats a mis-attributed one, the
+    // MIN_SAMPLES philosophy).
+    val singleShopPickup = lineage.count { it.activity == PickupActivity.SHOPPING } <= 1
+    val offerUnitCount = ratioJob
+        ?.takeIf { it.jobId == jobId && singleShopPickup }
+        ?.acceptedOffers?.singleOrNull()
+        ?.offerUnitCount
     for (task in lineage) {
         addAll(
             pickupConfirmedEffects(

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TaskEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TaskEffects.kt
@@ -326,6 +326,15 @@ internal fun EffectMap.pickupConfirmSweepEffects(
     jobOfferHashes: List<String> = emptyList(),
 ): List<AppEffect> = buildList {
     if (jobId == null) return@buildList
+    // #823 Phase 1: resolve THIS job's units-denominated offer count for the items:units-ratio
+    // learning — only when the job is a SINGLE accepted offer that was units-denominated
+    // (`acceptedOffers.singleOrNull()`), so a stack (which offer's units pair with which pickup's
+    // items is ambiguous) contributes no sample. Null ⇒ no ratio learning (fail-safe: a missing
+    // sample beats a mis-attributed one, the MIN_SAMPLES philosophy).
+    val offerUnitCount = region.activeJob
+        ?.takeIf { it.jobId == jobId }
+        ?.acceptedOffers?.singleOrNull()
+        ?.offerUnitCount
     val lineage = (region.recentTasks + listOfNotNull(region.activeTask))
         // #736: a pickup the dasher UNASSIGNED (marker set, completedAt left null) is NOT a
         // confirmable pickup — exclude it so a job that closes over an abandoned-but-arrived pickup
@@ -343,6 +352,7 @@ internal fun EffectMap.pickupConfirmSweepEffects(
                 platform = region.platform,
                 confirmedAt = task.completedAt ?: obs.timestamp,
                 jobOfferHashes = jobOfferHashes,
+                offerUnitCount = offerUnitCount,
             ),
         )
     }
@@ -362,6 +372,11 @@ private fun EffectMap.pickupConfirmedEffects(
     platform: Platform,
     confirmedAt: Long = obs.timestamp,
     jobOfferHashes: List<String> = emptyList(),
+    // #823 Phase 1: the job's units-denominated offer's quoted unit count, when unambiguous (a single
+    // units-only shop offer). Non-null ⇒ this shop's ground-truth items can teach the items:units
+    // ratio; null (items-denominated / stacked / absent) ⇒ no ratio sample. Resolved by the caller
+    // (which holds the job); see [pickupConfirmSweepEffects].
+    offerUnitCount: Int? = null,
 ): List<AppEffect> = buildList {
     add(
         logEffect(
@@ -397,6 +412,21 @@ private fun EffectMap.pickupConfirmedEffects(
                 taskId = prevTask.taskId,
             ),
         )
+        // #823 Phase 1: if the accepted offer was units-denominated, this shop's ground-truth items
+        // (shopItems) vs the quoted units teaches the per-platform items:units ratio. Guarded on an
+        // unambiguous single units offer by the caller (offerUnitCount non-null); the handler floors
+        // out-of-band samples.
+        if (offerUnitCount != null && offerUnitCount > 0) {
+            add(
+                AppEffect.RecordItemsPerUnitRatio(
+                    platform = platform,
+                    offerUnitCount = offerUnitCount,
+                    itemsShopped = shopItems,
+                    jobId = prevTask.jobId,
+                    taskId = prevTask.taskId,
+                ),
+            )
+        }
     }
 }
 

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -16,6 +16,7 @@ import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.pipeline.TransitionTrigger
+import cloud.trotter.dashbuddy.domain.state.AcceptedOfferEconomics
 import cloud.trotter.dashbuddy.domain.state.AppState
 import cloud.trotter.dashbuddy.domain.state.CrossPlatformRegion
 import cloud.trotter.dashbuddy.domain.state.DestructiveKind
@@ -1090,6 +1091,85 @@ class EffectMapTest {
             "the sample is idempotent per platform-scoped pickup task",
             "shop_rate:instacart:task-1", rec.effectKey,
         )
+    }
+
+    @Test
+    fun `a units-denominated single-shop offer emits RecordItemsPerUnitRatio pairing offer units with shopped items (#823)`() {
+        val (platform, _) = stateWithPlatform(platform = Platform.Instacart)
+        val session = Session("sess-1", startedAt = 100L)
+        val arrivedAt = 100_000L
+        val confirmAt = arrivedAt + 30 * 60_000L
+        // A units-only offer: (64 units) → offerUnitCount = 64 on the accepted economics.
+        val unitsJob = Job(
+            jobId = "job-1", offerStoreHint = emptyList(), parentOfferHash = "off-1", startedAt = 900L,
+            acceptedOffers = listOf(AcceptedOfferEconomics(offerHash = "off-1", offerUnitCount = 64, acceptedAt = 900L)),
+        )
+        val shopPickup = Task(
+            taskId = "task-1", jobId = "job-1", phase = TaskPhase.PICKUP, storeName = "H-E-B",
+            activity = PickupActivity.SHOPPING, itemsShopped = 30, arrivedAt = arrivedAt, startedAt = 900L,
+        )
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskPickupArrived),
+            platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = session, activeJob = unitsJob, activeTask = shopPickup)),
+        ))
+        val dropoff = Task(taskId = "task-2", jobId = "job-1", phase = TaskPhase.DROPOFF, startedAt = confirmAt)
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskDropoffNavigation),
+            platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = session,
+                activeJob = unitsJob, activeTask = dropoff, recentTasks = listOf(shopPickup.copy(completedAt = confirmAt)))),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(
+            flow = Flow.TaskDropoffNavigation, timestamp = confirmAt,
+            parsed = ParsedFields.TaskFields(phase = TaskPhase.DROPOFF, subFlow = TaskSubFlow.NAVIGATION),
+        ))
+
+        val rec = effects.filterIsInstance<AppEffect.RecordItemsPerUnitRatio>().single()
+        assertEquals(64, rec.offerUnitCount)
+        assertEquals(30, rec.itemsShopped)
+        assertEquals("task-1", rec.taskId)
+        assertEquals(platform, rec.platform)
+        assertEquals("items_per_unit_ratio:instacart:task-1", rec.effectKey)
+    }
+
+    @Test
+    fun `a units offer with TWO shopping pickups in the swept lineage folds NO ratio sample (#823 F2)`() {
+        // One units-denominated offer can carry ≥2 shop orders at distinct stores → ≥2 SHOPPING
+        // pickups, each of which would fold its own itemsShopped against the offer's SUMMED unit
+        // count (biased low). F2: when >1 shopping pickup sweeps, learn nothing.
+        val (platform, _) = stateWithPlatform(platform = Platform.Instacart)
+        val session = Session("sess-1", startedAt = 100L)
+        val arrivedAt = 100_000L
+        val confirmAt = arrivedAt + 30 * 60_000L
+        val unitsJob = Job(
+            jobId = "job-1", offerStoreHint = emptyList(), parentOfferHash = "off-1", startedAt = 900L,
+            acceptedOffers = listOf(AcceptedOfferEconomics(offerHash = "off-1", offerUnitCount = 64, acceptedAt = 900L)),
+        )
+        val shop1 = Task(taskId = "task-1", jobId = "job-1", phase = TaskPhase.PICKUP, storeName = "H-E-B",
+            activity = PickupActivity.SHOPPING, itemsShopped = 20, arrivedAt = arrivedAt, startedAt = 900L)
+        val shop2 = Task(taskId = "task-2", jobId = "job-1", phase = TaskPhase.PICKUP, storeName = "Sprouts",
+            activity = PickupActivity.SHOPPING, itemsShopped = 10, arrivedAt = arrivedAt + 60_000L, startedAt = 900L)
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskPickupArrived),
+            platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = session, activeJob = unitsJob, activeTask = shop2)),
+        ))
+        val dropoff = Task(taskId = "task-3", jobId = "job-1", phase = TaskPhase.DROPOFF, startedAt = confirmAt)
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskDropoffNavigation),
+            platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = session,
+                activeJob = unitsJob, activeTask = dropoff,
+                recentTasks = listOf(shop1.copy(completedAt = confirmAt), shop2.copy(completedAt = confirmAt)))),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(
+            flow = Flow.TaskDropoffNavigation, timestamp = confirmAt,
+            parsed = ParsedFields.TaskFields(phase = TaskPhase.DROPOFF, subFlow = TaskSubFlow.NAVIGATION),
+        ))
+
+        // The shop PACE still folds for each pickup (that's per-pickup honest), but NO ratio sample.
+        assertTrue("two shopping pickups → the ambiguous ratio is not learned",
+            effects.none { it is AppEffect.RecordItemsPerUnitRatio })
+        assertEquals("shop-pace still records per pickup", 2, effects.filterIsInstance<AppEffect.RecordShopRate>().size)
     }
 
     @Test

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/EvaluationConfig.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/EvaluationConfig.kt
@@ -33,6 +33,14 @@ data class EvaluationConfig(
      * never price an Instacart / Uber shop.
      */
     val shopRates: Map<Platform, LearnedShopRate> = emptyMap(),
+    /**
+     * #823 Phase 1: the learned **items:units ratio** per platform — the units→items-equivalent
+     * factor an offer's own platform selects at eval time via [forPlatform]. Keyed by [Platform]
+     * (never a global, P8), so a DoorDash-learned ratio can never convert an Uber shop's units. A
+     * platform absent from the map has no learned ratio yet and resolves to its
+     * [ItemsPerUnitRatioSeeds] seed.
+     */
+    val itemsPerUnitRatios: Map<Platform, LearnedItemsPerUnitRatio> = emptyMap(),
 ) {
     /**
      * #588: resolve THIS offer's [platform]'s learned pace + seed into [userEconomy], producing the
@@ -48,11 +56,18 @@ data class EvaluationConfig(
      */
     fun forPlatform(platform: Platform): EvaluationConfig {
         val learned = shopRates[platform]
+        val learnedRatio = itemsPerUnitRatios[platform]
         return copy(
             userEconomy = userEconomy.copy(
                 learnedShopItemsPerMinute = learned?.itemsPerMin,
                 shopRateSampleCount = learned?.sampleCount ?: 0,
                 shopSeedItemsPerMin = ShopRateSeeds.seedFor(platform),
+                // #823 Phase 1: resolve THIS platform's items:units ratio (learned + seed) into the
+                // economy, symmetric to the shop-pace resolution above. A platform with no samples
+                // yields its seed, never another platform's learned ratio.
+                learnedItemsPerUnitRatio = learnedRatio?.ratio,
+                itemsPerUnitRatioSampleCount = learnedRatio?.sampleCount ?: 0,
+                itemsPerUnitRatioSeed = ItemsPerUnitRatioSeeds.seedFor(platform),
             ),
         )
     }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/ItemsPerUnitRatio.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/ItemsPerUnitRatio.kt
@@ -42,22 +42,36 @@ object ItemsPerUnitRatioSeeds {
 
 /**
  * Folds measured (units-denominated) shops into the dasher's learned items:units ratio (#823
- * Phase 1). Pure and order-independent (a running incremental mean), the exact discipline of
- * [ShopRate] — a units-only offer quoted [units], the shop screen later reported [items] actually
- * shopped, and their ratio is one sample of "how many physical items a DoorDash unit is worth".
+ * Phase 1). Pure and order-independent (a running incremental mean) — a units-only offer quoted
+ * [units], the shop screen later reported [items] actually shopped, and their ratio is one sample of
+ * "how many physical items a DoorDash unit is worth". The learn signal is `itemsShopped:units`,
+ * dimensionally consistent with #556's pace numerator (itemsShopped/minute), so a
+ * `units × ratio` prediction estimates E[itemsShopped] — the exact quantity the pace model divides.
  *
- * Each sample's ratio is **clamped to [MIN_RATIO]..[MAX_RATIO]** before folding, so a single
- * outlier basket (a very-multi-pack order) can't drag the mean out of a sane band; the seed itself
- * lives inside that band. [MIN_SAMPLES] gates trusting the learned mean over the seed, exactly like
- * the shop-rate trust gate.
+ * Like [ShopRate] it has validity floors ([MIN_ITEMS], units > 0) and a [MIN_SAMPLES] trust gate,
+ * but it adds something ShopRate does NOT have — a **per-sample clamp** to [MIN_RATIO]..[MAX_RATIO]
+ * before folding, so a single stale/outlier sample (a mid-shop itemsShopped snapshot, or a
+ * very-multi-pack basket) can't drag the mean out of a plausible band. The band is asymmetric on
+ * purpose: [MAX_RATIO] = 1.0 is **structural** — a unit is a pack of ≥1 items, so items ≤ units and
+ * the ratio can never exceed 1. [MIN_RATIO] has **no** structural anchor; it is only outlier
+ * rejection, so it is set LOW (0.3): the sole fielded measurement (30 items / 64 units ≈ 0.47) sits
+ * below the old 0.5 floor, and a floor above the population center would clamp every sample and pin
+ * the learned mean AT the floor — the clamp would silently become the estimator and the learning
+ * would be dead weight. 0.3 admits the real multi-pack range while still rejecting a degenerate
+ * snapshot (e.g. 10/64 ≈ 0.16 → 0.3, not 0.16). The [UserEconomy.effectiveItemsPerUnitRatio] trust
+ * band rides these same constants (one SSOT, no second copy).
  */
 object ItemsPerUnitRatio {
 
     /** Min items shopped in a measured sample before it counts — a 1–2 item shop is noise. */
     const val MIN_ITEMS = 3
 
-    /** Sane band for the ratio (#823): a DoorDash unit is between half an item and one item. */
-    const val MIN_RATIO = 0.5
+    /**
+     * Plausible band for the ratio (#823). [MAX_RATIO] = 1.0 is structural (items ≤ units always);
+     * [MIN_RATIO] = 0.3 is outlier rejection only, set below the fielded ~0.47 so the floor never
+     * becomes the estimator (see class KDoc).
+     */
+    const val MIN_RATIO = 0.3
     const val MAX_RATIO = 1.0
 
     /** Measured units-shops required before the learned ratio overrides the seed. */

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/ItemsPerUnitRatio.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/ItemsPerUnitRatio.kt
@@ -1,0 +1,82 @@
+package cloud.trotter.dashbuddy.domain.evaluation
+
+import cloud.trotter.dashbuddy.domain.state.Platform
+
+/** The persisted learned items:units ratio: the running mean and the shops behind it (#823). */
+data class LearnedItemsPerUnitRatio(val ratio: Double?, val sampleCount: Int)
+
+/**
+ * The cold-start seed items:units ratio **per platform** (#823 Phase 1), mirroring [ShopRateSeeds]
+ * (#588). Until a platform has crossed [ItemsPerUnitRatio.MIN_SAMPLES] on its OWN measured
+ * units-denominated shops, the units→items-equivalent conversion for the Shop & Deliver time
+ * estimate falls back to that platform's seed here.
+ *
+ * The value is **data, not logic** (P8) — the shape is `Map<Platform, Double>`, so a second
+ * platform's own measured seed drops in as one map entry, never a `when (platform)`. Same
+ * `(platform, …)` key-space the #588 shop-rate seeds and #159's per-store tier inherit.
+ */
+object ItemsPerUnitRatioSeeds {
+
+    /**
+     * DoorDash's corpus-derived seed. The 2026-07 capture corpus's `(N items • M units)` pairs
+     * (63/79 ≈ 0.80, 22/31 ≈ 0.71, 9/11 ≈ 0.82) cluster at ≈ 0.75–0.81; 0.78 is the seeded midpoint
+     * (#823 desk analysis). This is the ONE anchor for that fact — every other comment/constant that
+     * wants "the DoorDash items:units seed" should point here, not re-declare the literal.
+     */
+    const val DOORDASH_CORPUS_SEED: Double = 0.78
+
+    /**
+     * Generic fallback ratio for a platform with no bespoke seed of its own. Today this ADOPTS
+     * [DOORDASH_CORPUS_SEED] wholesale — the only measured corpus we have — as a placeholder until
+     * that platform earns its own independently-measured entry.
+     */
+    const val DEFAULT: Double = DOORDASH_CORPUS_SEED
+
+    private val byPlatform: Map<Platform, Double> = mapOf(
+        Platform.DoorDash to DOORDASH_CORPUS_SEED,
+    )
+
+    /** The seed ratio for [platform] — its bespoke corpus entry, else the generic [DEFAULT]. */
+    fun seedFor(platform: Platform): Double = byPlatform[platform] ?: DEFAULT
+}
+
+/**
+ * Folds measured (units-denominated) shops into the dasher's learned items:units ratio (#823
+ * Phase 1). Pure and order-independent (a running incremental mean), the exact discipline of
+ * [ShopRate] — a units-only offer quoted [units], the shop screen later reported [items] actually
+ * shopped, and their ratio is one sample of "how many physical items a DoorDash unit is worth".
+ *
+ * Each sample's ratio is **clamped to [MIN_RATIO]..[MAX_RATIO]** before folding, so a single
+ * outlier basket (a very-multi-pack order) can't drag the mean out of a sane band; the seed itself
+ * lives inside that band. [MIN_SAMPLES] gates trusting the learned mean over the seed, exactly like
+ * the shop-rate trust gate.
+ */
+object ItemsPerUnitRatio {
+
+    /** Min items shopped in a measured sample before it counts — a 1–2 item shop is noise. */
+    const val MIN_ITEMS = 3
+
+    /** Sane band for the ratio (#823): a DoorDash unit is between half an item and one item. */
+    const val MIN_RATIO = 0.5
+    const val MAX_RATIO = 1.0
+
+    /** Measured units-shops required before the learned ratio overrides the seed. */
+    const val MIN_SAMPLES = 5
+
+    /** A measured sample is in-band (worth folding) only with real units + enough items shopped. */
+    fun isValidSample(units: Int, items: Int): Boolean = units > 0 && items >= MIN_ITEMS
+
+    /**
+     * Fold one measured units-shop ([items] actually shopped for a quoted-[units] offer) into the
+     * running mean ratio + sample count. Out-of-band samples are ignored (returns the prior pair
+     * unchanged). The per-sample ratio is clamped into [MIN_RATIO]..[MAX_RATIO]; the mean is
+     * incremental — `avg + (rate - avg) / n` — so it's stable and independent of fold order.
+     */
+    fun fold(prevAvg: Double?, prevN: Int, units: Int, items: Int): Pair<Double?, Int> {
+        if (!isValidSample(units, items)) return prevAvg to prevN
+        val ratio = (items.toDouble() / units.toDouble()).coerceIn(MIN_RATIO, MAX_RATIO)
+        val n = (prevN.coerceAtLeast(0)) + 1
+        val avg = if (prevAvg == null || prevN <= 0) ratio else prevAvg + (ratio - prevAvg) / n
+        return avg to n
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
@@ -30,9 +30,16 @@ class OfferEvaluator() {
         // offers estimated a 25-item grocery run at ~15 min → the ~$116/hr bug.
         val driveMinutes = dist * economy.avgMinutesPerMile
         val isShop = offer.orders.any { it.orderType.isShoppingOrder }
+        // #823 Phase 1: a units-denominated shop count (DoorDash "(64 units)") over-states the
+        // physical item count the #556 pace model is calibrated on, so convert units→items-equivalent
+        // (units × the learned per-platform items:units ratio) for the HANDLING term only. An
+        // items-denominated / estimated / non-shop count is unchanged (ratio not applied). Only the
+        // TIME estimate uses this; [items] (below, for scoring + the surfaced OfferEvaluation.itemCount)
+        // stays the platform-shown number — the card/TTS show what DoorDash said, not a faked items count.
+        val handlingItems = if (offer.itemCountIsUnits) items * economy.effectiveItemsPerUnitRatio else items
         val handlingMinutes = if (isShop) {
             val nonShopLegs = offer.orders.count { !it.orderType.isShoppingOrder }
-            maxOf(items / economy.effectiveShopItemsPerMinute, economy.basePickupMinutes) +
+            maxOf(handlingItems / economy.effectiveShopItemsPerMinute, economy.basePickupMinutes) +
                 nonShopLegs * economy.basePickupMinutes
         } else {
             economy.basePickupMinutes

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/UserEconomy.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/UserEconomy.kt
@@ -52,6 +52,25 @@ data class UserEconomy(
      */
     val shopSeedItemsPerMin: Double = DEFAULT_SHOP_ITEMS_PER_MIN,
 
+    /**
+     * Learned **items:units ratio** (#823 Phase 1) — how many physical items one DoorDash "unit" is
+     * worth, so a units-only offer (`(64 units)`) can be converted to an items-equivalent before the
+     * #556 shop-time pace divide. Null until enough units-shops are measured; the conversion falls
+     * back to [itemsPerUnitRatioSeed]. Like [learnedShopItemsPerMinute] this is a MEASURED value kept
+     * in the strategy store (never a user-set economy field, so a vehicle-class reseed can't touch
+     * it). Resolved per-platform by [EvaluationConfig.forPlatform].
+     */
+    val learnedItemsPerUnitRatio: Double? = null,
+    /** Number of measured units-shops behind [learnedItemsPerUnitRatio]; gates trusting it (#823). */
+    val itemsPerUnitRatioSampleCount: Int = 0,
+    /**
+     * The cold-start seed items:units ratio for the offer's platform (#823), used until this platform
+     * has its own [ItemsPerUnitRatio.MIN_SAMPLES] measured units-shops. Resolved from
+     * [ItemsPerUnitRatioSeeds] by [EvaluationConfig.forPlatform] at eval time; defaults to the generic
+     * corpus seed off-config so a hand-built economy (and every existing test) behaves as before.
+     */
+    val itemsPerUnitRatioSeed: Double = DEFAULT_ITEMS_PER_UNIT_RATIO,
+
     // Maintenance (paired: cost + interval/lifetime). Defaults are zero so a
     // hand-constructed UserEconomy is cost-free for tests. Production paths
     // populate these from the VehicleClass preset via the repository.
@@ -124,6 +143,20 @@ data class UserEconomy(
             ?.takeIf { shopRateSampleCount >= MIN_SHOP_SAMPLES && it > 0.0 }
             ?: shopSeedItemsPerMin
 
+    /**
+     * Items:units ratio for the units→items-equivalent conversion (#823 Phase 1): the learned ratio
+     * once [ItemsPerUnitRatio.MIN_SAMPLES] units-shops have been measured for this platform (and it
+     * is in the sane [ItemsPerUnitRatio.MIN_RATIO]..[ItemsPerUnitRatio.MAX_RATIO] band), else this
+     * platform's [itemsPerUnitRatioSeed]. Always > 0.
+     */
+    val effectiveItemsPerUnitRatio: Double
+        get() = learnedItemsPerUnitRatio
+            ?.takeIf {
+                itemsPerUnitRatioSampleCount >= ItemsPerUnitRatio.MIN_SAMPLES &&
+                    it in ItemsPerUnitRatio.MIN_RATIO..ItemsPerUnitRatio.MAX_RATIO
+            }
+            ?: itemsPerUnitRatioSeed
+
     fun isUserSet(field: EconomyField): Boolean = field in userSetFields
 
     /** True when at least one [EconomyField] is still at its class/default value. */
@@ -145,6 +178,13 @@ data class UserEconomy(
 
         /** Measured shops required before the learned pace overrides [DEFAULT_SHOP_ITEMS_PER_MIN]. */
         const val MIN_SHOP_SAMPLES = 5
+
+        /**
+         * Cold-start items:units ratio seed (#823 Phase 1) — how many physical items one DoorDash
+         * "unit" is worth. The domain default; production resolves the per-platform seed via
+         * [ItemsPerUnitRatioSeeds]. See that object for the corpus derivation (≈ 0.75–0.81 → 0.78).
+         */
+        const val DEFAULT_ITEMS_PER_UNIT_RATIO = ItemsPerUnitRatioSeeds.DOORDASH_CORPUS_SEED
         const val DEFAULT_ANNUAL_MI = 10_000.0
         const val DEFAULT_PHONE_PLAN_TOTAL = 80.0
         const val DEFAULT_PHONE_PLAN_LINES = 1

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/offer/ParsedOffer.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/offer/ParsedOffer.kt
@@ -37,6 +37,18 @@ data class ParsedOffer(
     /** For "Shop for items" orders, the number of items. Set to 1 for pickup order types. */
     val itemCount: Int = 1,
 
+    /**
+     * True when [itemCount] is a **units** count, not an item count (#823 Phase 1) — i.e. the
+     * contributing shop order(s) rendered a units-only quantity (`(64 units)`) with no items figure.
+     * The [OfferEvaluator] converts a units-denominated count into an items-equivalent (units ×
+     * learned per-platform ratio) for the #556 shop-time estimate; the offer card/TTS and the
+     * offer-model still surface [itemCount] verbatim (the platform-shown number). False for an
+     * items-denominated / estimated / non-shop offer, so those price exactly as before. Aggregated
+     * from the per-order [cloud.trotter.dashbuddy.domain.model.order.CountUnit] by
+     * `ParsedFieldsFactory`; `@Serializable` default keeps old snapshots decoding unchanged.
+     */
+    val itemCountIsUnits: Boolean = false,
+
     /** The numeric value of the guaranteed pay for the offer. */
     val payAmount: Double? = null,
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/order/CountUnit.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/order/CountUnit.kt
@@ -1,0 +1,26 @@
+package cloud.trotter.dashbuddy.domain.model.order
+
+/**
+ * How a shop order's count on the offer card is *denominated* (#823 Phase 1).
+ *
+ * DoorDash renders a Shop & Deliver order's quantity three ways — `(9 items • 11 units)`,
+ * `(4 items)`, and sometimes **units-only** `(64 units)`. The parse's item-count read grabs the
+ * first number regardless of its label ([cloud.trotter.dashbuddy.core-pipeline `parseItemCount`]),
+ * so a units-only offer silently feeds a *unit* count into the #556 shop-time model as if it were an
+ * item count — and units are not items (a 64-unit H-E-B basket is far fewer physical items, corpus
+ * pairs cluster items:units ≈ 0.75–0.81). This enum records which label the parsed count came from
+ * so the evaluator can convert a units-denominated count into an items-equivalent before the pace
+ * divide (see `OfferEvaluator` + `UserEconomy.effectiveItemsPerUnitRatio`).
+ *
+ * Recognition is **data, not code** (CLAUDE.md): the platform ruleset emits this as a parse-output
+ * string that `ParsedFieldsFactory` resolves via [valueOf]; there is no `when (platform)`.
+ * [ITEMS] is the neutral default — an items-denominated or estimated/absent count behaves exactly as
+ * before, so only the units-only shape changes anything.
+ */
+enum class CountUnit {
+    /** The count is a physical **item** count (`(4 items)`, or the items figure of `(9 items • 11 units)`). */
+    ITEMS,
+
+    /** The count is a **unit** count with no items figure present (`(64 units)`). */
+    UNITS,
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/order/CountUnit.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/order/CountUnit.kt
@@ -12,10 +12,12 @@ package cloud.trotter.dashbuddy.domain.model.order
  * so the evaluator can convert a units-denominated count into an items-equivalent before the pace
  * divide (see `OfferEvaluator` + `UserEconomy.effectiveItemsPerUnitRatio`).
  *
- * Recognition is **data, not code** (CLAUDE.md): the platform ruleset emits this as a parse-output
- * string that `ParsedFieldsFactory` resolves via [valueOf]; there is no `when (platform)`.
- * [ITEMS] is the neutral default — an items-denominated or estimated/absent count behaves exactly as
- * before, so only the units-only shape changes anything.
+ * Recognition is **data, not code** (CLAUDE.md): the platform ruleset emits a parse-output string
+ * that `ParsedFieldsFactory` resolves **fail-neutrally** — [UNITS] only on an exact `== "UNITS"`
+ * match (paired with a real, non-estimated count), everything else (including an unrecognized
+ * string) falls to [ITEMS]; there is no `valueOf` throw and no `when (platform)`. [ITEMS] is the
+ * neutral default — an items-denominated or estimated/absent count behaves exactly as before, so
+ * only the units-only shape changes anything.
  */
 enum class CountUnit {
     /** The count is a physical **item** count (`(4 items)`, or the items figure of `(9 items • 11 units)`). */

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/order/ParsedOrder.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/order/ParsedOrder.kt
@@ -17,4 +17,12 @@ data class ParsedOrder(
     val isItemCountEstimated: Boolean,
     /** The badge(s) associated with this order. */
     val badges: Set<OrderBadge>,
+    /**
+     * Which label [itemCount] was denominated by on the offer card (#823 Phase 1). [CountUnit.UNITS]
+     * only when the parsed count is a units-only figure (`(64 units)`); [CountUnit.ITEMS] for an
+     * items figure, an estimated/absent count, or a non-shop order. Default [CountUnit.ITEMS] so
+     * every existing construction and snapshot decodes unchanged (additive, `@Serializable` default);
+     * kept last so positional constructions stay valid.
+     */
+    val countUnit: CountUnit = CountUnit.ITEMS,
 )

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Job.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Job.kt
@@ -22,6 +22,14 @@ data class AcceptedOfferEconomics(
     val estMinutes: Double? = null,
     /** Quoted distance in miles. */
     val distanceMiles: Double? = null,
+    /**
+     * The offer's **units** count when it was units-denominated (#823 Phase 1) — non-null ⟺ the
+     * accepted offer rendered a units-only shop quantity (`(64 units)`). Carried from accept time so
+     * the pickup-confirmed shop-rate site can pair it with the ground-truth items actually shopped
+     * and fold one items:units-ratio learning sample. Null for an items-denominated / non-shop offer
+     * (no ratio to learn). Additive `@Serializable` default ⇒ old snapshots decode unchanged.
+     */
+    val offerUnitCount: Int? = null,
     val acceptedAt: Long,
 )
 

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/ItemsPerUnitRatioTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/ItemsPerUnitRatioTest.kt
@@ -38,9 +38,18 @@ class ItemsPerUnitRatioTest {
     }
 
     @Test
-    fun `a below-band sample is clamped to the floor before folding`() {
-        // The dev's H-E-B: 30 items shopped for a 64-unit offer → 0.469, below MIN_RATIO → 0.5.
+    fun `the fielded H-E-B ratio is in-band and folds at its exact value`() {
+        // The dev's H-E-B: 30 items shopped for a 64-unit offer → 0.46875, ABOVE the 0.3 floor
+        // (F1: the floor must not clamp the sole real measurement, else it becomes the estimator).
         val (avg, n) = ItemsPerUnitRatio.fold(null, 0, units = 64, items = 30)
+        assertEquals(0.46875, avg!!, 1e-9)
+        assertEquals(1, n)
+    }
+
+    @Test
+    fun `a degenerate below-floor sample is clamped to the floor before folding`() {
+        // A stale mid-shop snapshot: 10 items for a 64-unit offer → 0.156, below MIN_RATIO → 0.3.
+        val (avg, n) = ItemsPerUnitRatio.fold(null, 0, units = 64, items = 10)
         assertEquals(ItemsPerUnitRatio.MIN_RATIO, avg!!, 1e-9)
         assertEquals(1, n)
     }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/ItemsPerUnitRatioTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/ItemsPerUnitRatioTest.kt
@@ -1,0 +1,63 @@
+package cloud.trotter.dashbuddy.domain.evaluation
+
+import cloud.trotter.dashbuddy.domain.state.Platform
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #823 Phase 1 — the learned items:units ratio fold + seeds. Mirrors [ShopRate]'s discipline: a pure
+ * incremental mean, out-of-band samples ignored, per-sample clamp to a sane band, per-platform seed.
+ */
+class ItemsPerUnitRatioTest {
+
+    @Test
+    fun `seed is the corpus midpoint and defaults per platform`() {
+        assertEquals(0.78, ItemsPerUnitRatioSeeds.DOORDASH_CORPUS_SEED, 0.0)
+        assertEquals(0.78, ItemsPerUnitRatioSeeds.seedFor(Platform.DoorDash), 0.0)
+        // A platform with no bespoke entry resolves to the generic default (never a foreign seed).
+        assertEquals(ItemsPerUnitRatioSeeds.DEFAULT, ItemsPerUnitRatioSeeds.seedFor(Platform.Uber), 0.0)
+    }
+
+    @Test
+    fun `first in-band sample seeds the mean at its own clamped ratio`() {
+        // 63 items shopped for a 79-unit offer → 0.797, in band.
+        val (avg, n) = ItemsPerUnitRatio.fold(prevAvg = null, prevN = 0, units = 79, items = 63)
+        assertEquals(63.0 / 79.0, avg!!, 1e-9)
+        assertEquals(1, n)
+    }
+
+    @Test
+    fun `the running mean is incremental and fold-order independent`() {
+        // Two samples: 0.797 (63/79) then 0.71 (22/31); mean = (0.797 + 0.710)/2.
+        var pair = ItemsPerUnitRatio.fold(null, 0, units = 79, items = 63)
+        pair = ItemsPerUnitRatio.fold(pair.first, pair.second, units = 31, items = 22)
+        val expected = (63.0 / 79.0 + 22.0 / 31.0) / 2.0
+        assertEquals(expected, pair.first!!, 1e-9)
+        assertEquals(2, pair.second)
+    }
+
+    @Test
+    fun `a below-band sample is clamped to the floor before folding`() {
+        // The dev's H-E-B: 30 items shopped for a 64-unit offer → 0.469, below MIN_RATIO → 0.5.
+        val (avg, n) = ItemsPerUnitRatio.fold(null, 0, units = 64, items = 30)
+        assertEquals(ItemsPerUnitRatio.MIN_RATIO, avg!!, 1e-9)
+        assertEquals(1, n)
+    }
+
+    @Test
+    fun `an above-band sample is clamped to the ceiling`() {
+        // 40 items for 30 units → 1.33 → clamped to MAX_RATIO.
+        val (avg, _) = ItemsPerUnitRatio.fold(null, 0, units = 30, items = 40)
+        assertEquals(ItemsPerUnitRatio.MAX_RATIO, avg!!, 1e-9)
+    }
+
+    @Test
+    fun `out-of-band samples (no units, too few items) fold nothing`() {
+        assertNull(ItemsPerUnitRatio.fold(null, 0, units = 0, items = 30).first)
+        assertEquals(0, ItemsPerUnitRatio.fold(null, 0, units = 0, items = 30).second)
+        // Below MIN_ITEMS (a 1–2 item shop is noise): unchanged.
+        val prior = 0.8 to 3
+        assertEquals(prior, ItemsPerUnitRatio.fold(0.8, 3, units = 50, items = 2))
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/ShopTimeModelTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/ShopTimeModelTest.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.domain.evaluation
 
 import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.model.order.CountUnit
 import cloud.trotter.dashbuddy.domain.model.order.OrderType
 import cloud.trotter.dashbuddy.domain.model.order.ParsedOrder
 import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
@@ -25,6 +26,14 @@ class ShopTimeModelTest {
     private fun offer(pay: Double, dist: Double, itemCount: Int, type: OrderType) = ParsedOffer(
         offerHash = "h", payAmount = pay, distanceMiles = dist, itemCount = itemCount,
         orders = listOf(ParsedOrder(0, type, "Store", itemCount, false, emptySet())),
+    )
+
+    // #823 Phase 1: a units-denominated shop offer (`(N units)`) — same shape, itemCountIsUnits=true.
+    private fun unitsOffer(pay: Double, dist: Double, units: Int) = ParsedOffer(
+        offerHash = "h", payAmount = pay, distanceMiles = dist, itemCount = units, itemCountIsUnits = true,
+        orders = listOf(
+            ParsedOrder(0, OrderType.SHOP_FOR_ITEMS, "Store", units, false, emptySet(), CountUnit.UNITS),
+        ),
     )
 
     @Test
@@ -100,5 +109,74 @@ class ShopTimeModelTest {
         // a sub-floor 2-item / 0.5-min blip is ignored (no poisoning)
         val (avg2, n2) = ShopRate.fold(avg, n, 2, 0.5)
         assertEquals(2, n2); assertEquals(0.9, avg2!!, 1e-9)
+    }
+
+    // ===================================================================================
+    // #823 Phase 1 — units→items-equivalent conversion for the shop-time estimate.
+    // ===================================================================================
+
+    @Test
+    fun `a units-denominated offer converts units to items-equivalent for the time estimate (seed)`() {
+        // The dev's H-E-B: $34.45, 10.1 mi, "(64 units)". drive 10.1*2.5=25.25; seed ratio 0.78 →
+        // 64*0.78=49.92 items-equiv; shop 49.92/0.8=62.4. est = 87.65 (vs the raw-64 → 105.25 bug).
+        val r = evaluator.evaluate(unitsOffer(34.45, 10.1, 64), config)
+        assertEquals(25.25 + (64 * 0.78) / 0.8, r.estimatedTimeMinutes, 0.01)
+        assertEquals(87.65, r.estimatedTimeMinutes, 0.01)
+    }
+
+    @Test
+    fun `the same count denominated in ITEMS is unchanged (no ratio applied)`() {
+        // itemCountIsUnits=false → the raw 64 feeds the pace divide exactly as before #823.
+        val r = evaluator.evaluate(offer(34.45, 10.1, 64, OrderType.SHOP_FOR_ITEMS), config)
+        assertEquals(25.25 + 64 / 0.8, r.estimatedTimeMinutes, 0.01)
+        assertEquals(105.25, r.estimatedTimeMinutes, 0.01)
+    }
+
+    @Test
+    fun `a units offer surfaces the platform-shown count, not a faked items number`() {
+        // The card/TTS read OfferEvaluation.itemCount — it must stay the units figure DoorDash showed
+        // (64), never the ratio-scaled 49.92. Only the TIME estimate uses the conversion.
+        val r = evaluator.evaluate(unitsOffer(34.45, 10.1, 64), config)
+        assertEquals(64.0, r.itemCount, 0.0)
+    }
+
+    @Test
+    fun `a learned per-platform ratio overrides the seed once past the trust gate`() {
+        val cfg = config.copy(
+            itemsPerUnitRatios = mapOf(
+                Platform.DoorDash to LearnedItemsPerUnitRatio(0.5, ItemsPerUnitRatio.MIN_SAMPLES),
+            ),
+        )
+        // 64*0.5=32 items-equiv; shop 32/0.8=40; drive 25.25. est = 65.25.
+        val r = evaluator.evaluate(unitsOffer(34.45, 10.1, 64), cfg.forPlatform(Platform.DoorDash))
+        assertEquals(25.25 + (64 * 0.5) / 0.8, r.estimatedTimeMinutes, 0.01)
+    }
+
+    @Test
+    fun `effectiveItemsPerUnitRatio gates the learned value on samples and band, else the seed`() {
+        val warm = economy.copy(learnedItemsPerUnitRatio = 0.6, itemsPerUnitRatioSampleCount = ItemsPerUnitRatio.MIN_SAMPLES)
+        assertEquals(0.6, warm.effectiveItemsPerUnitRatio, 0.0)
+        // Below the sample floor → seed.
+        val cold = economy.copy(learnedItemsPerUnitRatio = 0.6, itemsPerUnitRatioSampleCount = 2)
+        assertEquals(UserEconomy.DEFAULT_ITEMS_PER_UNIT_RATIO, cold.effectiveItemsPerUnitRatio, 0.0)
+        // Out-of-band learned value (should be impossible via the clamped fold, but the gate is
+        // defence-in-depth) → seed.
+        val oob = economy.copy(learnedItemsPerUnitRatio = 1.5, itemsPerUnitRatioSampleCount = ItemsPerUnitRatio.MIN_SAMPLES)
+        assertEquals(UserEconomy.DEFAULT_ITEMS_PER_UNIT_RATIO, oob.effectiveItemsPerUnitRatio, 0.0)
+        // Never learned → seed.
+        assertEquals(UserEconomy.DEFAULT_ITEMS_PER_UNIT_RATIO, economy.effectiveItemsPerUnitRatio, 0.0)
+    }
+
+    @Test
+    fun `forPlatform resolves a platform with no ratio samples to its seed, never another platform's (#823 P8)`() {
+        val cfg = config.copy(
+            itemsPerUnitRatios = mapOf(
+                Platform.DoorDash to LearnedItemsPerUnitRatio(0.6, ItemsPerUnitRatio.MIN_SAMPLES + 2),
+            ),
+        )
+        assertEquals(0.6, cfg.forPlatform(Platform.DoorDash).userEconomy.effectiveItemsPerUnitRatio, 0.0)
+        val ic = cfg.forPlatform(Platform.Instacart).userEconomy
+        assertEquals(ItemsPerUnitRatioSeeds.seedFor(Platform.Instacart), ic.effectiveItemsPerUnitRatio, 0.0)
+        assertEquals(0, ic.itemsPerUnitRatioSampleCount)
     }
 }

--- a/matchers/rules/doordash/offer.json5
+++ b/matchers/rules/doordash/offer.json5
@@ -214,6 +214,17 @@
                 "read": "text",
                 "transform": "parseItemCount"
               },
+              "itemCountUnit": {
+                // #823 Phase 1: denomination of the count above — "UNITS" for a units-only
+                // "(64 units)" render, "ITEMS" otherwise. Read from the SAME node as itemCount so
+                // the pair can never disagree about which token was read; the evaluator uses it to
+                // convert a units count to an items-equivalent for the #556 shop-time estimate only.
+                "find": {
+                  "hasIdSuffix": "display_name_secondary"
+                },
+                "read": "text",
+                "transform": "parseItemCountUnit"
+              },
               "isRedCard": {
                 "presence": {
                   "exists": {


### PR DESCRIPTION
## #823 Phase 1 — learned items:units ratio for units-denominated shop offers

Closes the offer-side of #823 **Phase 1 only** (dev-scoped 2026-07-23). Phases 2 (arrival
re-evaluation) and 3 (offer-time list peek) are **out of scope** and stay as designed/deferred.

DoorDash shop offers sometimes state `(N units)` instead of `(N items)`. The #556 shop-time
model divides an item count by the dasher's pace; a units-only offer (the fielded 64-unit H-E-B,
seq 554) fed 64 → ~80 min handling and roughly halved the displayed $/hr. Phase 1 converts a
units-denominated count to an items-equivalent (`units × a learned per-platform ratio`, seed
**0.78**) for the **time estimate only**.

### Investigation findings — where the denomination lived (it didn't)
- `TransformRegistry.parseItemCount` grabs the **first number** after `(` regardless of whether
  it is followed by `item`/`order`/`unit`, and records **nothing** about the label. So a units-only
  `(64 units)` silently parsed `itemCount=64` as if items — the denomination did **not** survive.
- `ParsedOffer.itemCount` (the evaluator's input) is the summed shop-order count; no denomination.
- **The minimal shape-change (data enrichment, per the build brief):** a parse-side enum
  `CountUnit { ITEMS, UNITS }` on `ParsedOrder.countUnit` (parsed by a new `parseItemCountUnit`
  transform reading the **same** node as `parseItemCount`, so the two can never disagree about which
  token they read), aggregated to a new offer-level boolean `ParsedOffer.itemCountIsUnits`. All
  additive with `@Serializable` defaults — no offer-model/card restructuring, existing parses
  unchanged.

### Consumption-point change (evaluation-side)
`OfferEvaluator` applies the ratio at the exact #556 consumption point — the shop-handling term
becomes `(items × effectiveItemsPerUnitRatio) ÷ pace` **only when `offer.itemCountIsUnits`**. An
items-denominated / estimated / non-shop offer is byte-for-byte unchanged (ratio not applied).
`items` used for scoring and stamped into `OfferEvaluation.itemCount` stays the **raw** count.

### Bubble / read-side
A units-denominated offer keeps displaying **what the platform said** (the units figure) — the
ratio is applied only to the internal TIME estimate. `OfferEvaluation.itemCount` is left as the raw
count (test: `a units offer surfaces the platform-shown count, not a faked items number`); no UI
touched.

### Learning design (mirrors #556/#588, keyed per-Platform — P8)
- New `ItemsPerUnitRatio` domain fold + `ItemsPerUnitRatioSeeds` (seed 0.78, DoorDash entry;
  generic default for others) + `LearnedItemsPerUnitRatio`. Per-sample ratio **clamped to
  [0.3, 1.0]**; incremental running mean, n-counted, `MIN_SAMPLES=5` trust gate. Like `ShopRate`
  it has validity floors + a trust gate, but it adds something `ShopRate` does **not** — a
  **per-sample clamp** (`MAX=1.0` structural since items ≤ units; `MIN=0.3` is outlier rejection
  only, set below the fielded ~0.47 so the floor never becomes the estimator — see F1 below).
- Persisted per-platform in the strategy DataStore under `learned_items_per_unit_ratio:<wire>` /
  `items_per_unit_ratio_sample_count:<wire>` (keys derive from `Platform.wire`, zero datastore
  change for a new platform). Surfaced through `EvaluationConfig.itemsPerUnitRatios` and resolved by
  `forPlatform` into `UserEconomy.effectiveItemsPerUnitRatio` — symmetric to the #588 shop-pace
  resolution; a DoorDash-learned ratio can never convert an Uber shop's units.
- **Learn trigger:** a units-denominated accept carries its unit count on
  `AcceptedOfferEconomics.offerUnitCount` (additive nullable). At the pickup-confirmed shop-rate
  site the sweep resolves it from the job (only for a **single, unambiguous** units offer —
  `acceptedOffers.singleOrNull()`; stacks fold **no** sample, fail-safe) and emits
  `AppEffect.RecordItemsPerUnitRatio` alongside `RecordShopRate`. The handler folds it via the
  repository. Recovery-suppressed like `RecordShopRate` (persists a learned value) + effect-key
  idempotent.

### Golden delta
`approved-parse-output.json` regenerated deliberately — **additive-only**: every prior offer gains
`itemCountIsUnits=false` and every order `countUnit=ITEMS`; **no existing value changed** (proven by
stripping the two new tokens from the new side → byte-identical to the old side). The offer_popup
golden corpus has no units-only DoorDash shop frame, so nothing flips to `true` there.

### Tests
- `TransformRegistryTest` — `parseItemCountUnit` UNITS/ITEMS/null + agreement with `parseItemCount`.
- `ItemsUnitsDenominationParseTest` (new) — end-to-end through the production ruleset: the fielded
  units-only H-E-B `(32 units)` fixture → `itemCountIsUnits=true`, `itemCount=32`; an
  `(4 items • 5 units)` offer → `false`, `itemCount=4`.
- `ShopTimeModelTest` — units offer time uses `units×ratio` (seed + learned); items offer unchanged;
  `OfferEvaluation.itemCount` stays raw; `effectiveItemsPerUnitRatio` sample/band gating; per-platform
  `forPlatform` resolution.
- `ItemsPerUnitRatioTest` (new) — fold math, per-sample clamp, MIN_SAMPLES/seed, out-of-band no-ops.
- `StrategyDataSourceShopRateTest` — per-platform ratio learning, clamp, cross-platform isolation,
  below-floor no-op.
- Full `testDebugUnitTest :domain:test` green; `AllMatchersSuite` green.

### Residuals
- **Seed vs. learn-signal basis:** the 0.78 seed is derived from offer-displayed `items:units`
  pairs (≈0.75–0.81); the learn signal is `shopped-items:units`, which for the H-E-B basket was
  ~0.47 (in-band after F1's 0.3 floor). These can diverge by basket; the ratio narrows the worst distortion,
  Phase 2's arrival re-evaluation is what closes it. Clamp bounds outlier influence.
- Mixed-denomination stacks (some items, some units in one summed count) stay `itemCountIsUnits=false`
  → no ratio applied → unchanged pre-existing behaviour (Phase 1 scopes the fielded units-only shape).
- Phases 2 & 3 out of scope (dev decision 2026-07-23).

### Design-goal review
- **1 UDF:** ratio resolved into the pure economy off `obs.timestamp`-driven state; the learn effect
  fires at the `EffectMap` edge (`RecordItemsPerUnitRatio`), never inside a reducer. Conforms.
- **3 SRP:** new `ItemsPerUnitRatio.kt` / `CountUnit.kt` are small, focused; no file grew toward the
  ceiling.
- **5 SSOT:** the ratio has one owner (`ItemsPerUnitRatioSeeds` seed + the strategy-store learned
  value → `UserEconomy.effectiveItemsPerUnitRatio`); the seed literal lives once. `parseItemCountUnit`
  reuses the exact `parseItemCount` shape so the two never drift.
- **6 Security/privacy:** touches recognition + effects + a new INFO log. The `RecordItemsPerUnitRatio`
  INFO line carries only counts, the ratio, and `platform.wire` (a registry token) — **no raw
  store/customer text** (PII-safe by construction, #551 P7). No new capture/PII surface; the parse
  field is numeric-denomination metadata.
- **8 Platform-agnostic core:** no platform literal in logic. The ratio is DoorDash-observed but
  stored/keyed per-`Platform` exactly like the #588 shop-rate seeds (`ItemsPerUnitRatioSeeds` is a
  `Map<Platform, Double>`, the datastore keys derive from `Platform.wire`, `forPlatform` resolves
  it). New effect data flows through typed state, not a magic string + `when`.

### Adversarial review
Fable review returned **APPROVE-WITH-FIXES** — the learn signal (shopped-items:units) was
adjudicated **correct** (dimensionally consistent with #556's `itemsShopped/minute` numerator, so
`units × ratio` estimates `E[itemsShopped]`); the learning half stands. All findings applied in
commit `1776aa7e`:
- **F1 (required):** `MIN_RATIO` 0.5 → **0.3**. `MAX=1.0` is structural (items ≤ units); the 0.5
  floor had no anchor and sat above the only fielded measurement (30/64 ≈ 0.469), so it would clamp
  every sample and pin the mean at the floor — the clamp becomes the estimator, learning dies. 0.3
  keeps outlier rejection while admitting the real multi-pack range. KDoc rewritten; the
  `effectiveItemsPerUnitRatio` trust band rides the same SSOT constants. Three clamp-expectation
  tests updated (30/64 now in-band → 0.46875 exact).
- **F2 (required):** the learn guard was single-**offer**, not single-shop-**pickup** — one units
  offer with ≥2 shop orders sweeps ≥2 SHOPPING pickups, each folding its own `itemsShopped` against
  the offer's **summed** units (N biased-low). Added a second sweep-site guard: skip the fold when
  the lineage has >1 SHOPPING pickup. New `EffectMapTest` cases for both shapes.
- **F3a (docs):** documented that the close-out sweep structurally never learns (region=next,
  activeJob≠closedJob) and that a pickup-only close is deliberately not a ratio surface.
- **F3b (fix):** the pickup→dropoff sweep now resolves the ratio job **prev-first** (mirroring
  `jobOfferHashes`) so a legitimate sample isn't lost on the #159 FIX-9 stacked-job swap edge;
  close-out passes `ratioJob = null` deliberately.
- **F4 (nit):** `CountUnit` KDoc corrected — the resolution is a fail-neutral `== "UNITS"`, not
  `valueOf`.

Full `testDebugUnitTest :domain:test` + `AllMatchersSuite` green after the fixes. **Not merged**
(builder does not merge).

