### PR TITLE
test(security): #590 Phase-1 remainder — scanner/backstop parity property + mapper bounded-ingestion property + text cap

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScanner.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScanner.kt
@@ -7,13 +7,16 @@ import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
  * Scans a [UiNode] tree for sensitive keywords (PII, financial data).
  *
  * Used by [InboxProcessorTest] to prevent accidental commits of raw
- * banking/identity data in snapshot files. The keyword list is the
- * production [SensitiveTextMarkers] SSOT (#432) — test toxicity and the
- * runtime UNKNOWN-capture scrub agree by construction.
+ * banking/identity data in snapshot files.
+ *
+ * SSOT PARITY (#590): the marker/shape decision DELEGATES to the production
+ * fail-closed backstop [SensitiveTextMarkers.findMarker], so the commit gate is
+ * provably ≥ the runtime UNKNOWN-capture scrub — `findMarker(tree)!=null ⇒
+ * scan(tree).isToxic` (pinned by `SnapshotSecurityScannerParityTest`). The scanner
+ * adds only the corpus-gate EXTRA pin/gate shapes (#803) on top; it never
+ * re-implements the keyword list, so the two copies can't diverge.
  */
 object SnapshotSecurityScanner {
-
-    private val SENSITIVE_KEYWORDS = SensitiveTextMarkers.KEYWORDS
 
     /**
      * Regex SHAPES that mark PII a bare keyword can't (the #803 blind class). Each
@@ -49,6 +52,23 @@ object SnapshotSecurityScanner {
 
     fun scan(node: UiNode): ScanResult {
         val triggers = mutableListOf<Pair<String, String>>()
+
+        // SSOT PARITY (#590): delegate the marker/shape decision to the production
+        // fail-closed backstop rather than re-implementing its keyword list. This is
+        // the load-bearing guarantee `findMarker(tree)!=null ⇒ scan.isToxic`:
+        //  - it scans the whole tree's `allText` (text AND contentDescription), so a
+        //    desc-borne marker the old per-node `node.text` walk missed is caught;
+        //  - it NFKC-normalizes both sides, so homoglyph/whitespace-mutated markers hit;
+        //  - it scans the space-joined blob, so a marker split across sibling nodes rejoins;
+        //  - it owns the SSN/card-PAN shapes the scanner never had.
+        // A future marker addition lands here automatically — the two copies can't diverge.
+        SensitiveTextMarkers.findMarker(node)?.let { marker ->
+            triggers.add(node.allText.joinToString(" ") to "sensitive-marker:$marker")
+        }
+
+        // Scanner-specific EXTRA corpus-gate shapes NOT in the production backstop
+        // (the #803 id-less instructions-body pin/gate class). Kept on top of parity,
+        // never in place of it.
         walkAndFind(node, triggers)
         return ScanResult(isToxic = triggers.isNotEmpty(), triggers = triggers)
     }
@@ -69,16 +89,18 @@ object SnapshotSecurityScanner {
         println("     ACTION: Redact these values in the JSON file immediately.")
     }
 
+    /**
+     * Walk the tree for the scanner-specific EXTRA shapes (#803 pin/gate). Marker/
+     * keyword parity is owned by the [SensitiveTextMarkers.findMarker] delegation in
+     * [scan]; this only adds the corpus-gate shapes the production backstop doesn't
+     * carry. Scans both text and contentDescription so a shape hiding in a desc node
+     * is caught too (parity discipline extended to the extras).
+     */
     private fun walkAndFind(node: UiNode, results: MutableList<Pair<String, String>>) {
-        val text = node.text ?: ""
-        val keyword = SENSITIVE_KEYWORDS.firstOrNull { text.contains(it, ignoreCase = true) }
-
-        if (keyword != null) {
-            results.add(text to keyword)
-        }
-        // #803: keyword-invisible PII shapes (e.g. a "pin 4821" fragment).
-        SENSITIVE_SHAPES.firstOrNull { (re, _) -> re.containsMatchIn(text) }?.let { (_, label) ->
-            results.add(text to label)
+        for (field in listOfNotNull(node.text, node.contentDescription)) {
+            SENSITIVE_SHAPES.firstOrNull { (re, _) -> re.containsMatchIn(field) }?.let { (_, label) ->
+                results.add(field to label)
+            }
         }
         node.children.forEach { walkAndFind(it, results) }
     }

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScannerParityTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScannerParityTest.kt
@@ -1,0 +1,176 @@
+package cloud.trotter.dashbuddy.test.util
+
+import cloud.trotter.dashbuddy.core.pipeline.SensitiveTextMarkers
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.checkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #590 — SSOT PARITY between the test-side corpus commit gate
+ * ([SnapshotSecurityScanner.scan]) and the runtime fail-closed backstop
+ * ([SensitiveTextMarkers.findMarker]).
+ *
+ * The scanner is what stops a raw banking/identity screen from being committed
+ * into the golden corpus; the backstop is what drops the same screen from an
+ * on-device UNKNOWN capture. If the scanner is WEAKER than the backstop, a fixture
+ * the runtime would refuse to keep can still land in the repo — the exact #362-class
+ * divergence-bug (two hand-maintained copies of "what is toxic" drift apart).
+ *
+ * The invariant: **for every tree, `findMarker(tree) != null ⇒ scan(tree).isToxic`.**
+ * The scanner must catch *at least* everything the production backstop catches.
+ *
+ * Red-first observation (pre-fix, `scan` walking `node.text` with a plain
+ * `contains(..., ignoreCase = true)` + only the pin/gate shapes):
+ *  - a marker in a node's **contentDescription** (which `findMarker` scans via
+ *    `allText`, but the old per-node `scan` never read) → findMarker HIT, scan CLEAN;
+ *  - an **SSN / card PAN** shape (in `findMarker.SHAPE_PATTERNS`, absent from the
+ *    scanner) → findMarker HIT, scan CLEAN;
+ *  - a **homoglyph/whitespace-mutated** marker (NBSP / zero-width / fullwidth — which
+ *    `findMarker` normalizes, but the old plain `contains` missed) → findMarker HIT,
+ *    scan CLEAN;
+ *  - a marker **split across two adjacent sibling nodes** (`findMarker` scans the
+ *    space-joined `allText`, the old per-node scan never rejoined) → findMarker HIT,
+ *    scan CLEAN.
+ * Each class made the implication FALSE, so this suite starts red.
+ *
+ * The fix brings the scanner to SSOT parity by DELEGATING the marker decision to
+ * `SensitiveTextMarkers.findMarker` (not by duplicating its list), keeping the
+ * scanner-specific EXTRA pin/gate corpus-gate shapes on top. Delegation is what makes
+ * a future marker addition impossible to diverge.
+ */
+class SnapshotSecurityScannerParityTest {
+
+    // Representative spread of production markers + the two shapes findMarker owns.
+    private val toxicTokens: List<String> = listOf(
+        "Bank Account",
+        "Routing Number",
+        "Social Security",
+        "DasherDirect",
+        "Available Balance",
+        "CVV",
+        "Transfer to bank",
+        "123-45-6789",       // SSN shape
+        "4111 1111 1111 1111", // card PAN shape
+    )
+
+    // Benign filler so the toxic token is not the whole tree.
+    private val benign = listOf(
+        "Pickup from Chipotle", "Deliver by 7:45 PM", "\$7.50", "3.2 mi", "Accept", "Decline",
+    )
+
+    // ---- Homoglyph / whitespace mutations (findMarker normalizes; old scan didn't) ----
+    private fun nbsp(s: String) = s.replace(' ', ' ')
+    private fun zeroWidth(s: String) = s.toCharArray().joinToString("​")
+    private fun fullwidth(s: String) = s.map { c ->
+        when (c) {
+            in '0'..'9' -> ('０'.code + (c - '0')).toChar()
+            in 'a'..'z' -> ('ａ'.code + (c - 'a')).toChar()
+            in 'A'..'Z' -> ('Ａ'.code + (c - 'A')).toChar()
+            ' ' -> '　' // ideographic space (NFKC-folds to a normal space)
+            else -> c
+        }
+    }.joinToString("")
+    private fun identity(s: String) = s
+
+    private val mutations: List<(String) -> String> = listOf(::identity, ::nbsp, ::zeroWidth, ::fullwidth)
+
+    /** Placements that exercise the parity gaps: text node, desc node, sibling-split. */
+    private enum class Placement { TEXT, DESC, SPLIT_SIBLINGS }
+
+    private fun buildTree(token: String, placement: Placement): UiNode = when (placement) {
+        Placement.TEXT ->
+            UiNode(children = listOf(UiNode(text = benign[0]), UiNode(text = token))).restoreParents()
+        Placement.DESC ->
+            UiNode(children = listOf(UiNode(text = benign[1]), UiNode(contentDescription = token)))
+                .restoreParents()
+        Placement.SPLIT_SIBLINGS -> {
+            val idx = token.indexOf(' ')
+            val kids = if (idx < 0) {
+                listOf(UiNode(text = token))
+            } else {
+                listOf(UiNode(text = token.substring(0, idx)), UiNode(text = token.substring(idx + 1)))
+            }
+            UiNode(children = kids).restoreParents()
+        }
+    }
+
+    private val treeArb: Arb<UiNode> = arbitrary { rs ->
+        val token = toxicTokens[rs.random.nextInt(toxicTokens.size)]
+        val mutated = mutations[rs.random.nextInt(mutations.size)](token)
+        val placement = Placement.entries[rs.random.nextInt(Placement.entries.size)]
+        buildTree(mutated, placement)
+    }
+
+    @Test
+    fun `property - scanner catches everything the production backstop catches`() = runTest {
+        checkAll(600, treeArb) { tree ->
+            val markerHit = SensitiveTextMarkers.findMarker(tree)
+            if (markerHit != null) {
+                assertTrue(
+                    "SSOT PARITY VIOLATION: findMarker hit <$markerHit> on\n$tree\n" +
+                        "but SnapshotSecurityScanner.scan reported CLEAN — a toxic screen the " +
+                        "runtime would drop could be committed to the corpus.",
+                    SnapshotSecurityScanner.scan(tree).isToxic,
+                )
+            }
+        }
+    }
+
+    // ---- Crisp named cases (each isolates one pre-fix gap for the red-first log) ----
+
+    @Test
+    fun `marker in contentDescription is toxic`() {
+        val tree = UiNode(contentDescription = "Routing Number 021000021").restoreParents()
+        assertNotNull("backstop must hit a desc-borne marker", SensitiveTextMarkers.findMarker(tree))
+        assertTrue("scanner must match the backstop on desc", SnapshotSecurityScanner.scan(tree).isToxic)
+    }
+
+    @Test
+    fun `SSN shape is toxic`() {
+        val tree = UiNode(text = "SSN 123-45-6789 on file").restoreParents()
+        assertNotNull(SensitiveTextMarkers.findMarker(tree))
+        assertTrue(SnapshotSecurityScanner.scan(tree).isToxic)
+    }
+
+    @Test
+    fun `card PAN shape is toxic`() {
+        val tree = UiNode(text = "4111 1111 1111 1111").restoreParents()
+        assertNotNull(SensitiveTextMarkers.findMarker(tree))
+        assertTrue(SnapshotSecurityScanner.scan(tree).isToxic)
+    }
+
+    @Test
+    fun `homoglyph-mutated marker is toxic`() {
+        val tree = UiNode(text = nbsp("Available Balance")).restoreParents()
+        assertNotNull(SensitiveTextMarkers.findMarker(tree))
+        assertTrue(SnapshotSecurityScanner.scan(tree).isToxic)
+    }
+
+    @Test
+    fun `marker split across sibling nodes is toxic`() {
+        val tree = UiNode(children = listOf(UiNode(text = "Bank"), UiNode(text = "Account"))).restoreParents()
+        assertNotNull(SensitiveTextMarkers.findMarker(tree))
+        assertTrue(SnapshotSecurityScanner.scan(tree).isToxic)
+    }
+
+    // ---- The scanner-specific EXTRA (pin/gate) must SURVIVE the delegation refactor ----
+
+    @Test
+    fun `scanner keeps its pin and gate corpus-gate shapes after delegating markers`() {
+        val pinTree = UiNode(text = "Leave at door. pin 1234 to enter").restoreParents()
+        val pinScan = SnapshotSecurityScanner.scan(pinTree)
+        assertTrue("pin shape still toxic", pinScan.isToxic)
+        assertTrue(
+            "pin-code-shape trigger preserved",
+            pinScan.triggers.any { it.second == "pin-code-shape" },
+        )
+        // findMarker does NOT own the pin shape — this is a scanner-only extra, proving
+        // the delegation did not REPLACE the scanner's own checks.
+        // (no assertion on findMarker here: it may legitimately be null for a bare pin code)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,14 @@ subprojects {
     // gated: CI runs JDK 21, where --sun-misc-unsafe-memory-access doesn't exist (23+)
     // and the notices don't fire anyway.
     tasks.withType<Test>().configureEach {
+        // #590 property tests are memory-hungry by design — the recursion-fuzz suite
+        // builds 100k-deep JSON structures and the mapper/classify fuzzers churn large
+        // Mockito-inline mock graphs — and share one forked worker. Gradle's default
+        // 512m test heap sat right at the edge (RuleCompileRecursionPropertyTest OOM'd
+        // once a sibling fuzzer's footprint landed in the same JVM). Raise it so the
+        // whole module fits deterministically; version-independent, so CI (JDK 21) gets
+        // the same headroom.
+        maxHeapSize = "2g"
         if (JavaVersion.current() >= JavaVersion.VERSION_24) {
             jvmArgs("--enable-native-access=ALL-UNNAMED", "--sun-misc-unsafe-memory-access=allow")
         }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapper.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapper.kt
@@ -47,6 +47,16 @@ internal class TreeBudget(
     companion object {
         const val MAX_TREE_DEPTH = 60
         const val MAX_TREE_NODES = 4_000
+
+        /**
+         * Per-string ingestion cap (#590). Third-party text is untrusted: a node
+         * reporting a 100 000-char `text` would ride verbatim into the [UiNode] and
+         * the serialized capture envelope. Legitimate screen text nodes (labels,
+         * addresses, instruction bodies) never approach 4 KiB; the cap truncates a
+         * pathological string while leaving every real screen untouched. Applied to
+         * `text`, `contentDescription`, and `stateDescription` at conversion.
+         */
+        const val MAX_TEXT_LENGTH = 4_096
     }
 }
 

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapper.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapper.kt
@@ -65,7 +65,11 @@ internal class TreeBudget(
          * the serialized capture envelope. Legitimate screen text nodes (labels,
          * addresses, instruction bodies) never approach 4 KiB; the cap truncates a
          * pathological string while leaving every real screen untouched. Applied to
-         * `text`, `contentDescription`, and `stateDescription` at conversion.
+         * EVERY serialized string field — `text`, `contentDescription`,
+         * `stateDescription`, `viewIdResourceName`, `className` — at conversion (#590
+         * review F2: ids/classnames are tiny for legit frames and `matchesId` is an
+         * `endsWith` on short snippets, so the cap is behavior-free there while
+         * closing the same balloon-capture threat for a hostile mocked value).
          */
         const val MAX_TEXT_LENGTH = 4_096
     }
@@ -103,13 +107,18 @@ private fun convert(
     var nullChildren = 0
     val children = ArrayList<UiNode>(childCount.coerceAtMost(TreeBudget.MAX_TREE_NODES))
     for (i in 0 until childCount) {
-        // Breadth short-circuit (#590): once the NODE budget is exhausted, no further
-        // child can be admitted, so stop issuing getChild() binder IPC. Without this
-        // a node reporting a hostile childCount (e.g. 50 000, or Int.MAX_VALUE) drives
-        // one IPC per reported child even though the tree is already full. Keyed on
-        // nodesExhausted (not truncated) so a deep branch hitting the depth cap does
-        // NOT suppress this node's still-admissible shallower siblings.
-        if (budget.nodesExhausted) break
+        // Breadth short-circuit (#590): stop issuing getChild() binder IPC once no
+        // further child could be kept, so a node reporting a hostile childCount (e.g.
+        // 50 000, or Int.MAX_VALUE) can't drive one IPC per reported child. TWO bounds:
+        //  - nodesExhausted (not truncated) once the NODE budget is spent — but this
+        //    only flips when children MATERIALIZE and consume budget, so a hostile fan
+        //    of ALL-NULL children (getChild(i)==null never calls admit(), a FIELDED
+        //    shape — see the 👻 NULL CHILDREN log) would still spin every index;
+        //  - i >= MAX_TREE_NODES caps the loop index itself, so even an all-null fan
+        //    issues at most MAX_TREE_NODES binder calls (#590 review F1).
+        // nodesExhausted stays keyed on node budget (not truncated) so a deep branch
+        // hitting the depth cap does NOT suppress this node's shallower siblings.
+        if (budget.nodesExhausted || i >= TreeBudget.MAX_TREE_NODES) break
 
         val childAccNode = node.getChild(i)
         if (childAccNode != null) {
@@ -139,8 +148,8 @@ private fun convert(
         stateDescription = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             node.stateDescription?.toString()?.capText()
         } else null,
-        viewIdResourceName = node.viewIdResourceName,
-        className = node.className?.toString(),
+        viewIdResourceName = node.viewIdResourceName?.capText(),
+        className = node.className?.toString()?.capText(),
         isClickable = node.isClickable,
         isEnabled = node.isEnabled,
         isChecked = node.checked,

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapper.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapper.kt
@@ -24,6 +24,17 @@ internal class TreeBudget(
     var truncated = false
         private set
 
+    /**
+     * True once the NODE budget is spent — no node can be admitted at ANY depth
+     * from here on. Distinct from [truncated], which also flips when a single deep
+     * branch hits the depth cap (a local cut that leaves shallower siblings
+     * admissible). The mapper's breadth short-circuit keys on THIS so a deep branch
+     * never suppresses an admissible sibling, but an exhausted budget stops all
+     * further getChild() IPC.
+     */
+    val nodesExhausted: Boolean
+        get() = nodes >= maxNodes
+
     /** True if a node at [depth] may be ingested; flags truncation otherwise. */
     fun admit(depth: Int): Boolean {
         if (depth > maxDepth || nodes >= maxNodes) {
@@ -73,6 +84,14 @@ fun AccessibilityNodeInfo?.toUiNode(): UiNode? {
     return root.restoreParents()
 }
 
+/**
+ * Text-length cap (#590): a pathological node text can't ride verbatim into the
+ * [UiNode] / capture envelope. `take` is safe on any String and a no-op below the
+ * cap, so every real screen string is untouched.
+ */
+private fun String.capText(): String =
+    if (length <= TreeBudget.MAX_TEXT_LENGTH) this else take(TreeBudget.MAX_TEXT_LENGTH)
+
 private fun convert(
     node: AccessibilityNodeInfo,
     depth: Int,
@@ -82,8 +101,16 @@ private fun convert(
 
     val childCount = node.childCount
     var nullChildren = 0
-    val children = ArrayList<UiNode>(childCount)
+    val children = ArrayList<UiNode>(childCount.coerceAtMost(TreeBudget.MAX_TREE_NODES))
     for (i in 0 until childCount) {
+        // Breadth short-circuit (#590): once the NODE budget is exhausted, no further
+        // child can be admitted, so stop issuing getChild() binder IPC. Without this
+        // a node reporting a hostile childCount (e.g. 50 000, or Int.MAX_VALUE) drives
+        // one IPC per reported child even though the tree is already full. Keyed on
+        // nodesExhausted (not truncated) so a deep branch hitting the depth cap does
+        // NOT suppress this node's still-admissible shallower siblings.
+        if (budget.nodesExhausted) break
+
         val childAccNode = node.getChild(i)
         if (childAccNode != null) {
             convert(childAccNode, depth + 1, budget)?.let(children::add)
@@ -107,10 +134,10 @@ private fun convert(
     node.getBoundsInScreen(bounds)
 
     return UiNode(
-        text = node.text?.toString(),
-        contentDescription = node.contentDescription?.toString(),
+        text = node.text?.toString()?.capText(),
+        contentDescription = node.contentDescription?.toString()?.capText(),
         stateDescription = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            node.stateDescription?.toString()
+            node.stateDescription?.toString()?.capText()
         } else null,
         viewIdResourceName = node.viewIdResourceName,
         className = node.className?.toString(),

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapperPropertyTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapperPropertyTest.kt
@@ -1,0 +1,229 @@
+package cloud.trotter.dashbuddy.core.pipeline.accessibility.mapper
+
+import android.view.accessibility.AccessibilityNodeInfo
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import io.kotest.property.Arb
+import io.kotest.property.RandomSource
+import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.checkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * #590 — BOUNDED INGESTION of untrusted third-party accessibility trees, as a
+ * property over generated mock node graphs. Generalizes the example-based
+ * [TreeBudgetTest] onto the real [toUiNode] mapper.
+ *
+ * Third-party trees are untrusted input: every `getChild(i)` is a binder IPC and
+ * the converted tree is serialized into the capture envelope, so a pathological or
+ * redesigned target UI must not be able to stack-overflow the service, balloon
+ * captures, or spin unbounded IPC. For ANY mock node graph the mapper must hold:
+ *  1. resulting **depth ≤ [TreeBudget.MAX_TREE_DEPTH]** (deep chains truncated);
+ *  2. resulting **node count ≤ [TreeBudget.MAX_TREE_NODES]** (wide/dense fans truncated);
+ *  3. every mapped **text/desc/state length ≤ [TreeBudget.MAX_TEXT_LENGTH]**;
+ *  4. it **never throws** on hostile input;
+ *  5. total **`getChild()` IPC is bounded by the caps** — a node reporting a huge
+ *     `childCount` cannot force one IPC per reported child.
+ *
+ * Red-first observations (pre-fix):
+ *  - (3) NO text-size cap existed — a 100 000-char text node mapped verbatim, so the
+ *    100k string rode straight into the [UiNode] and the capture envelope. `RED`.
+ *  - (5) the child loop ran `for (i in 0 until childCount)` with NO breadth
+ *    short-circuit after the budget was exhausted — a node reporting `childCount =
+ *    50 000` triggered 50 000 `getChild()` binder calls even though only ~4 000 nodes
+ *    could ever be admitted. `RED`.
+ * Depth (1) and node-count (2) caps already existed and are regression-guarded here.
+ *
+ * Pinned to SDK 36: the mapper reads the tri-state `getChecked():int` (API 36) and
+ * `getStateDescription()` (API 30), so the Robolectric shadow must supply both.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [36])
+class AccessibilityNodeMapperPropertyTest {
+
+    // ---- Mock AccessibilityNodeInfo factory (counts getChild IPC) ---------------
+
+    /**
+     * Build a mock node with fixed [children]. `getChild(i)` returns the i-th child
+     * (or null out of range) and increments [ipc]. All other accessors default
+     * (null text/id/class, false flags), overridden per-arg.
+     */
+    private fun node(
+        ipc: AtomicInteger,
+        children: List<AccessibilityNodeInfo> = emptyList(),
+        text: String? = null,
+        desc: String? = null,
+        state: String? = null,
+    ): AccessibilityNodeInfo {
+        val m = mock<AccessibilityNodeInfo>()
+        whenever(m.childCount).thenReturn(children.size)
+        whenever(m.getChild(anyInt())).thenAnswer { inv ->
+            ipc.incrementAndGet()
+            children.getOrNull(inv.getArgument(0))
+        }
+        whenever(m.text).thenReturn(text)
+        whenever(m.contentDescription).thenReturn(desc)
+        whenever(m.stateDescription).thenReturn(state)
+        return m
+    }
+
+    /**
+     * A node that REPORTS [fanCount] children but hands the SAME shared [leaf] for
+     * every index — models a hostile `childCount` without materializing millions of
+     * mocks. Total `getChild` calls == the IPC the mapper actually issues.
+     */
+    private fun wideFan(ipc: AtomicInteger, fanCount: Int, leaf: AccessibilityNodeInfo): AccessibilityNodeInfo {
+        val m = mock<AccessibilityNodeInfo>()
+        whenever(m.childCount).thenReturn(fanCount)
+        whenever(m.getChild(anyInt())).thenAnswer {
+            ipc.incrementAndGet()
+            leaf
+        }
+        whenever(m.text).thenReturn("root")
+        return m
+    }
+
+    /** Eager deep chain of [depth] single-child nodes (cheap; each node is one mock). */
+    private fun chain(ipc: AtomicInteger, depth: Int, text: String? = "n"): AccessibilityNodeInfo {
+        var cur = node(ipc, text = text)
+        repeat(depth) { cur = node(ipc, children = listOf(cur), text = text) }
+        return cur
+    }
+
+    // ---- Tree measurements ------------------------------------------------------
+
+    private fun maxDepthIndex(n: UiNode, d: Int = 0): Int =
+        if (n.children.isEmpty()) d else n.children.maxOf { maxDepthIndex(it, d + 1) }
+
+    private fun allNodes(n: UiNode): Sequence<UiNode> =
+        sequenceOf(n) + n.children.asSequence().flatMap { allNodes(it) }
+
+    private fun assertWithinCaps(root: UiNode?) {
+        if (root == null) return
+        val nodes = allNodes(root).toList()
+        assertTrue(
+            "depth ${maxDepthIndex(root)} exceeds MAX_TREE_DEPTH=${TreeBudget.MAX_TREE_DEPTH}",
+            maxDepthIndex(root) <= TreeBudget.MAX_TREE_DEPTH,
+        )
+        assertTrue(
+            "node count ${nodes.size} exceeds MAX_TREE_NODES=${TreeBudget.MAX_TREE_NODES}",
+            nodes.size <= TreeBudget.MAX_TREE_NODES,
+        )
+        for (n in nodes) {
+            n.text?.let {
+                assertTrue(
+                    "text length ${it.length} exceeds MAX_TEXT_LENGTH=${TreeBudget.MAX_TEXT_LENGTH}",
+                    it.length <= TreeBudget.MAX_TEXT_LENGTH,
+                )
+            }
+            n.contentDescription?.let {
+                assertTrue("desc length ${it.length} exceeds MAX_TEXT_LENGTH", it.length <= TreeBudget.MAX_TEXT_LENGTH)
+            }
+            n.stateDescription?.let {
+                assertTrue("state length ${it.length} exceeds MAX_TEXT_LENGTH", it.length <= TreeBudget.MAX_TEXT_LENGTH)
+            }
+        }
+    }
+
+    /** Generous-but-finite IPC bound: every admitted node examines at most its own
+     * children before the budget short-circuit, and admitted nodes ≤ MAX_TREE_NODES. */
+    private val ipcBound = TreeBudget.MAX_TREE_NODES + TreeBudget.MAX_TREE_DEPTH + 16
+
+    // ---- Adversarial text pool for the generated trees --------------------------
+
+    private fun textArb(rs: RandomSource): String? = when (rs.random.nextInt(12)) {
+        0 -> "x".repeat(100_000)                 // (3) oversized — must be capped
+        1 -> "y".repeat(4_500)                   // just over the cap
+        2 -> null
+        3 -> "   "
+        4 -> "\uD800 lone-surrogate"
+        else -> "node-${rs.random.nextInt(1000)}"
+    }
+
+    /** Eager bounded mock tree: depth ≤ [maxDepth], total nodes ≤ [budget]. */
+    private fun buildTree(rs: RandomSource, maxDepth: Int, budget: IntArray, ipc: AtomicInteger): AccessibilityNodeInfo {
+        budget[0]--
+        val childCount = if (maxDepth <= 0 || budget[0] <= 0) 0 else rs.random.nextInt(4)
+        val children = (0 until childCount).mapNotNull {
+            if (budget[0] <= 0) null else buildTree(rs, maxDepth - 1, budget, ipc)
+        }
+        return node(ipc, children = children, text = textArb(rs), desc = textArb(rs))
+    }
+
+    /** One generated case: the mock root + the IPC counter it increments. */
+    private class TreeCase(val root: AccessibilityNodeInfo, val ipc: AtomicInteger)
+
+    private val treeArb: Arb<TreeCase> = arbitrary { rs ->
+        // depth up to 90 (can exceed MAX_TREE_DEPTH), materialization budget 500 (cheap).
+        val ipc = AtomicInteger(0)
+        val root = buildTree(rs, maxDepth = 90, budget = intArrayOf(500), ipc = ipc)
+        TreeCase(root, ipc)
+    }
+
+    // ---- Property: any generated tree stays within every cap, never throws ------
+
+    @Test
+    fun `property - generated trees stay within depth-node-text caps, bound IPC, never throw`() = runTest {
+        checkAll(300, treeArb) { case ->
+            val mapped = case.root.toUiNode()   // must not throw
+            assertWithinCaps(mapped)
+            assertTrue(
+                "getChild IPC ${case.ipc.get()} exceeds bound $ipcBound",
+                case.ipc.get() <= ipcBound,
+            )
+        }
+    }
+
+    // ---- Targeted adversarial cases (crisp red-first evidence) -------------------
+
+    @Test
+    fun `oversized text node is truncated to the text cap`() {
+        val ipc = AtomicInteger(0)
+        val root = node(
+            ipc,
+            text = "x".repeat(100_000),
+            desc = "d".repeat(100_000),
+            state = "s".repeat(100_000),
+        )
+        assertWithinCaps(root.toUiNode())
+    }
+
+    @Test
+    fun `hostile childCount does not force one IPC per reported child`() {
+        val ipc = AtomicInteger(0)
+        val leaf = node(ipc, text = "leaf")
+        val root = wideFan(ipc, fanCount = 50_000, leaf = leaf)
+        val mapped = root.toUiNode()
+        assertWithinCaps(mapped)
+        assertTrue(
+            "getChild IPC ${ipc.get()} for a 50 000-fan node is not bounded by the caps " +
+                "(bound=$ipcBound) — the breadth short-circuit is missing",
+            ipc.get() <= ipcBound,
+        )
+    }
+
+    @Test
+    fun `deep chain is truncated at the depth cap`() {
+        val ipc = AtomicInteger(0)
+        val mapped = chain(ipc, depth = 200).toUiNode()
+        assertWithinCaps(mapped)
+        assertTrue(
+            "depth ${maxDepthIndex(mapped!!)} should be capped at MAX_TREE_DEPTH",
+            maxDepthIndex(mapped) <= TreeBudget.MAX_TREE_DEPTH,
+        )
+    }
+
+    @Test
+    fun `null root maps to null`() {
+        val src: AccessibilityNodeInfo? = null
+        assertTrue(src.toUiNode() == null)
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapperPropertyTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapperPropertyTest.kt
@@ -62,6 +62,8 @@ class AccessibilityNodeMapperPropertyTest {
         text: String? = null,
         desc: String? = null,
         state: String? = null,
+        viewId: String? = null,
+        className: String? = null,
     ): AccessibilityNodeInfo {
         val m = mock<AccessibilityNodeInfo>()
         whenever(m.childCount).thenReturn(children.size)
@@ -72,6 +74,8 @@ class AccessibilityNodeMapperPropertyTest {
         whenever(m.text).thenReturn(text)
         whenever(m.contentDescription).thenReturn(desc)
         whenever(m.stateDescription).thenReturn(state)
+        whenever(m.viewIdResourceName).thenReturn(viewId)
+        whenever(m.className).thenReturn(className)
         return m
     }
 
@@ -86,6 +90,23 @@ class AccessibilityNodeMapperPropertyTest {
         whenever(m.getChild(anyInt())).thenAnswer {
             ipc.incrementAndGet()
             leaf
+        }
+        whenever(m.text).thenReturn("root")
+        return m
+    }
+
+    /**
+     * A node that REPORTS [fanCount] children but every `getChild(i)` returns NULL —
+     * the fielded stale-child shape (the 👻 NULL CHILDREN case). A null child never
+     * calls admit(), so the node budget never fills; only the loop-index bound can
+     * stop the IPC. Counts every getChild call.
+     */
+    private fun nullFan(ipc: AtomicInteger, fanCount: Int): AccessibilityNodeInfo {
+        val m = mock<AccessibilityNodeInfo>()
+        whenever(m.childCount).thenReturn(fanCount)
+        whenever(m.getChild(anyInt())).thenAnswer {
+            ipc.incrementAndGet()
+            null
         }
         whenever(m.text).thenReturn("root")
         return m
@@ -129,6 +150,12 @@ class AccessibilityNodeMapperPropertyTest {
             }
             n.stateDescription?.let {
                 assertTrue("state length ${it.length} exceeds MAX_TEXT_LENGTH", it.length <= TreeBudget.MAX_TEXT_LENGTH)
+            }
+            n.viewIdResourceName?.let {
+                assertTrue("viewId length ${it.length} exceeds MAX_TEXT_LENGTH", it.length <= TreeBudget.MAX_TEXT_LENGTH)
+            }
+            n.className?.let {
+                assertTrue("className length ${it.length} exceeds MAX_TEXT_LENGTH", it.length <= TreeBudget.MAX_TEXT_LENGTH)
             }
         }
     }
@@ -193,8 +220,28 @@ class AccessibilityNodeMapperPropertyTest {
             text = "x".repeat(100_000),
             desc = "d".repeat(100_000),
             state = "s".repeat(100_000),
+            viewId = "v".repeat(100_000),   // #590 review F2 — id/className also serialized
+            className = "c".repeat(100_000),
         )
         assertWithinCaps(root.toUiNode())
+    }
+
+    @Test
+    fun `hostile all-null childCount does not force one IPC per reported child`() {
+        // The #590 review F1 probe: a node reporting a huge childCount whose children
+        // all resolve to null (the fielded stale-child shape). nodesExhausted never
+        // flips (null children never consume budget), so only the loop-index bound
+        // stops the binder IPC. Pre-F1 this drove exactly `fanCount` getChild calls.
+        val ipc = AtomicInteger(0)
+        val root = nullFan(ipc, fanCount = 200_000)
+        val mapped = root.toUiNode()
+        println("[#590 F1] all-null fan(200000) → getChild IPC = ${ipc.get()} (cap MAX_TREE_NODES=${TreeBudget.MAX_TREE_NODES})")
+        assertWithinCaps(mapped)
+        assertTrue(
+            "getChild IPC ${ipc.get()} for a 200 000 all-null fan is not bounded by the caps " +
+                "(bound=$ipcBound) — the loop-index short-circuit is missing (F1)",
+            ipc.get() <= ipcBound,
+        )
     }
 
     @Test

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapperPropertyTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapperPropertyTest.kt
@@ -162,9 +162,10 @@ class AccessibilityNodeMapperPropertyTest {
     private class TreeCase(val root: AccessibilityNodeInfo, val ipc: AtomicInteger)
 
     private val treeArb: Arb<TreeCase> = arbitrary { rs ->
-        // depth up to 90 (can exceed MAX_TREE_DEPTH), materialization budget 500 (cheap).
+        // depth up to 75 (exceeds MAX_TREE_DEPTH=60), materialization budget 120 —
+        // kept lean so the Mockito-inline mock graph doesn't pressure the shared worker.
         val ipc = AtomicInteger(0)
-        val root = buildTree(rs, maxDepth = 90, budget = intArrayOf(500), ipc = ipc)
+        val root = buildTree(rs, maxDepth = 75, budget = intArrayOf(120), ipc = ipc)
         TreeCase(root, ipc)
     }
 
@@ -172,7 +173,7 @@ class AccessibilityNodeMapperPropertyTest {
 
     @Test
     fun `property - generated trees stay within depth-node-text caps, bound IPC, never throw`() = runTest {
-        checkAll(300, treeArb) { case ->
+        checkAll(200, treeArb) { case ->
             val mapped = case.root.toUiNode()   // must not throw
             assertWithinCaps(mapped)
             assertTrue(


### PR DESCRIPTION
Closes the final two Phase-1 items of #590 (security property tests over untrusted-input boundaries). Each 🔴 item lands its property test **red first**, then the minimal fix closes it green — visible as separate `test(...)`→`fix(...)` commits.

## Item 1 — 🔴 Test scanner ≥ production backstop (SSOT parity)

`SnapshotSecurityScanner.scan` (the corpus commit gate) was **weaker** than the runtime `SensitiveTextMarkers.findMarker` it mirrors: it walked `node.text` with a plain `contains(ignoreCase=true)` + only the pin/gate shapes.

**Property:** `findMarker(tree) != null ⇒ scan(tree).isToxic` over trees seeded with marker/shape tokens in **text AND desc** positions (`SnapshotSecurityScannerParityTest`, 600 iters + 5 crisp named cases).

**Red-first evidence** (`06f010a2`, against unfixed scanner — 6/7 fail):
```
marker in contentDescription is toxic FAILED
SSN shape is toxic FAILED
card PAN shape is toxic FAILED
homoglyph-mutated marker is toxic FAILED
marker split across sibling nodes is toxic FAILED
property - scanner catches everything the production backstop catches FAILED
```
(the 7th — the pin/gate scanner-extra case — passes, proving the scanner-only checks are intact.)

**Parity mechanism — delegation, not duplication (`2f4beb37`):** `scan` now calls `SensitiveTextMarkers.findMarker(node)` for the marker/shape decision instead of re-implementing the keyword list, then keeps the scanner-specific **EXTRA** pin/gate corpus-gate shapes (#803) on top (now also scanning `contentDescription`). Because the keyword list is no longer copied, a future marker addition lands in the SSOT automatically — the two copies can't drift (#356 doctrine). 7/7 green.

**Corpus impact:** none. AllMatchersSuite + `GoldenSnapshotRegressionTest` + the replay corpus-cleanliness suites (`MultiPickupSingleCustomerReplayTest`, `TwoPickupStackReplayTest`) + `UnknownScreenAnalysisTest` all stay green — **no committed fixture trips the strengthened scanner**. No flagged fixtures, no exception list needed.

## Item 2 — Mapper bounded ingestion (property + the two missing caps)

`AccessibilityNodeMapper.toUiNode` had depth/node caps (`TreeBudget`) but no text-length cap and no breadth short-circuit; `TreeBudgetTest` was example-based only.

**Property** (`AccessibilityNodeMapperPropertyTest`, Robolectric @Config sdk=36, 200 iters + targeted adversarial cases over mock `AccessibilityNodeInfo` graphs): for any graph — depth ≤ cap, nodes ≤ cap, every mapped text/desc/state length ≤ `MAX_TEXT_LENGTH`, never throws, and total `getChild()` IPC bounded by the caps (counted via the mock).

**Red-first evidence** (`e3c345ec`, SDK-36 shadow — 3/5 fail):
```
oversized text node is truncated to the text cap FAILED   (text-length assertion — no cap existed)
hostile childCount does not force one IPC per reported child FAILED   (50 000-fan → 50 000 getChild IPC; no short-circuit)
property - ...caps... FAILED   (on the oversized-text draw)
```
(depth-cap and null-root cases already pass — those caps pre-exist.)

**Fixes (`5a304c4b`):**
- **Text cap** — `MAX_TEXT_LENGTH = 4096`, truncating `text`/`contentDescription`/`stateDescription` via `capText()`. Choice: real screen strings (labels, addresses, instruction bodies) never approach 4 KiB, so no legitimate frame changes; a pathological 100k-char node can no longer ride verbatim into the `UiNode`/capture envelope.
- **Breadth short-circuit** — the child loop breaks once `TreeBudget.nodesExhausted`, so a hostile `childCount` (50 000 … `Int.MAX_VALUE`) no longer drives one `getChild()` binder IPC per reported child. Keyed on a **new precise `nodesExhausted` signal** (`nodes >= maxNodes`), **not** `truncated`: a deep branch that trips the depth cap flags `truncated` but must still admit this node's shallower siblings (the existing `TreeBudgetTest` intent), whereas an exhausted node budget admits nothing further at any depth and stops all remaining breadth — propagating up through each ancestor's loop guard. `ArrayList` pre-size is also coerced to the node cap.

5/5 green; `TreeBudgetTest` unchanged/green.

## Infra (`cd55729f`)

The #590 property/fuzz suite shares one forked test worker; the recursion-fuzz test builds 100k-deep JSON and the mapper/classify fuzzers churn large Mockito-inline mock graphs. Gradle's default **512m** test heap sat at the edge — `RuleCompileRecursionPropertyTest` OOM'd deterministically once the new mapper test's footprint landed in the same JVM. Raised `maxHeapSize` to **2g** on all test tasks (version-independent → CI JDK 21 gets the same headroom) and trimmed the mapper property (200 iters / 120-node budget) to be a good citizen. No other boundary test touched.

## Test plan
- `export JAVA_HOME=/usr/lib/jvm/java-25; ./gradlew testDebugUnitTest :domain:test` → **BUILD SUCCESSFUL**.
- `./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` → green.
- Red-first evidence reproduced per item above (test commit fails, fix commit passes).

## Security/privacy posture
Both items **strengthen** fail-closed controls and neither touches recognition/parse output. Item 1 makes the corpus commit gate provably ≥ the runtime scrub (no raw banking/identity screen can be committed that the device would drop). Item 2 tightens bounded ingestion of untrusted third-party trees (text-size DoS + unbounded binder IPC). No new trust, no new plaintext path.

### Design-goal review
- **#5 SSOT** — Item 1 removes a hand-maintained copy of the marker list; the scanner now derives its verdict from the one owner (`SensitiveTextMarkers`).
- **#6 Security & privacy** — both fixes are fail-closed hardening of untrusted-input boundaries (bounded ingestion, no-leak commit gate).
- **#8 Platform-agnostic** — no platform literals; the marker SSOT and tree caps are platform-neutral.
- **#3 SRP** — the mapper's text cap is a small local helper; the short-circuit is a one-line guard on a precise budget signal.

### Adversarial review — fable security pass (fixes in `2351744d`)
APPROVE-WITH-FIXES; both required fixes landed on-branch:
- **F1 (MEDIUM, probe-proven):** the breadth short-circuit keyed only on `nodesExhausted`, which flips only when children *materialize* and consume budget — a `getChild(i)` returning **null** never calls `admit()`, so a node reporting `childCount=200_000` with all-null children (a fielded stale-child shape — the `👻 NULL CHILDREN` log) drove exactly 200,000 binder IPCs. Fixed by also breaking on `i >= TreeBudget.MAX_TREE_NODES`; added a `nullFan` test case (fanCount 200_000, all `getChild→null`) asserting IPC ≤ cap. **Measured: 200,000 → 4000.**
- **F2 (LOW, probe-proven):** `viewIdResourceName`/`className` were uncapped — now routed through `capText()` (behavior-free for real frames; `matchesId` is `endsWith` on short snippets), asserted in the oversized-text case.
- **F3 (observation, not a required fix):** `stateDescription` is now capped + serialized but is invisible to both `findMarker` and the scanner — a **pre-existing** scrub blind field, tracked as **#835** (the `stateDescription` scrub-gap issue), not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

