### PR TITLE
feature(matchers): #786 Uber decline click rule (offer-card dismiss X)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/UberDeclineClickRuleTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/UberDeclineClickRuleTest.kt
@@ -1,0 +1,133 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.state.OfferIntent
+import cloud.trotter.dashbuddy.test.util.TestResourceLoader
+import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * #786 — regression teeth for `uber.click.decline_offer` against REAL device click envelopes.
+ *
+ * Fixtures live under `src/test/resources/clicks/uber/` (deliberately NOT under `snapshots/`,
+ * whose sub-directories are screen-intent goldens enumerated by `GoldenSnapshotRegressionTest`).
+ * Each is a verbatim `click_context.v1` envelope — `payload = {node, screenTarget}` — so the test
+ * feeds the production [TestRulesetFactory][cloud.trotter.dashbuddy.test.util.TestRulesetFactory]
+ * click ruleset exactly what the runtime classifier sees.
+ *
+ * Provenance:
+ *  - `2026-07-23_18-45-24-*` / `2026-07-24_18-43-18-*` — two dasher DECLINE taps on the focused
+ *    Uber offer card (106x106 anonymous childless `android.widget.Button`, `screenTarget: "offer"`).
+ *    Verbatim, unedited — these envelopes carry no text/desc/id at all, so there is nothing to
+ *    redact.
+ *  - `2026-07-21_18-39-25-*` — the ACCEPT interaction from the same surface: the offer
+ *    `androidx.cardview.widget.CardView` itself, whose subtree carries "Match". This is the
+ *    NEGATIVE pin — the whole separability argument for the rule. The card's dropoff cross-street
+ *    line was replaced with the corpus's standing placeholder ("Sample St & Sample Ave, San
+ *    Antonio"); merchant/pay/time text is driver-owned data and is kept verbatim.
+ */
+class UberDeclineClickRuleTest {
+
+    private val fixtures = File("src/test/resources/clicks/uber")
+
+    private data class ClickFixture(val name: String, val node: UiNode, val screenTarget: String?)
+
+    private fun load(name: String): ClickFixture {
+        val file = File(fixtures, name)
+        assertTrue("missing fixture: ${file.absolutePath}", file.exists())
+        val payload = Json.parseToJsonElement(file.readText()).jsonObject.getValue("payload").jsonObject
+        return ClickFixture(
+            name = name,
+            node = TestResourceLoader.nodeFromElement(payload.getValue("node")),
+            screenTarget = payload["screenTarget"]?.jsonPrimitive?.content,
+        )
+    }
+
+    private fun classify(fixture: ClickFixture) =
+        TestRulesetFactory.clickRuleset.matchFirst(fixture.node, screenTarget = fixture.screenTarget)
+
+    private val declineTaps = listOf(
+        "2026-07-23_18-45-24-066__uber__accessibility.click__UNKNOWN__7e26a0.json",
+        "2026-07-24_18-43-18-986__uber__accessibility.click__UNKNOWN__0e1a01.json",
+    )
+
+    private val acceptCardTap =
+        "2026-07-21_18-39-25-627__uber__accessibility.click__UNKNOWN__015073.json"
+
+    // =========================================================================
+    // Positive: the anonymous childless Button on the offer card IS the decline commit
+    // =========================================================================
+
+    @Test
+    fun `real Uber offer-card dismiss taps classify as decline_offer`() {
+        for (name in declineTaps) {
+            val fixture = load(name)
+            assertEquals("$name: fixture must be an offer-screen click", "offer", fixture.screenTarget)
+            val match = classify(fixture)
+            assertEquals(
+                "$name: expected the #786 decline-commit rule to claim this tap",
+                "uber.click.decline_offer",
+                match?.ruleId,
+            )
+            assertEquals(
+                "$name: must carry the decline-COMMIT intent (latches declineCommittedAt, #594)",
+                OfferIntent.DECLINE,
+                match?.intent,
+            )
+        }
+    }
+
+    @Test
+    fun `the decline node really is anonymous, childless and Button-classed`() {
+        // Pins the field evidence the rule anchors on — if a future capture refresh changes the
+        // node's shape, this fails loudly next to the rule instead of silently widening it.
+        for (name in declineTaps) {
+            val node = load(name).node
+            assertEquals("$name: class", "android.widget.Button", node.className)
+            assertEquals("$name: must be clickable", true, node.isClickable)
+            assertTrue("$name: must carry no view id", node.viewIdResourceName.isNullOrBlank())
+            assertTrue("$name: must be a leaf", node.children.isEmpty())
+            assertTrue("$name: must carry no text of any kind", node.allText.isEmpty())
+        }
+    }
+
+    // =========================================================================
+    // Negative: the accept interaction (CardView, subtree-labelled) must NEVER decline
+    // =========================================================================
+
+    @Test
+    fun `the CardView accept tap does NOT match the decline rule`() {
+        val fixture = load(acceptCardTap)
+        assertEquals("fixture must be an offer-screen click", "offer", fixture.screenTarget)
+        val match = classify(fixture)
+        assertNotEquals(
+            "the accept CardView tap must never be claimed by the decline rule — " +
+                "a false decline latch would kill the accepted offer (#594 commit precedence)",
+            "uber.click.decline_offer",
+            match?.ruleId,
+        )
+        assertNotEquals(
+            "the accept CardView tap must never carry the decline intent",
+            OfferIntent.DECLINE,
+            match?.intent,
+        )
+    }
+
+    @Test
+    fun `the accept tap is structurally separable — non-leaf CardView with a labelled subtree`() {
+        val node = load(acceptCardTap).node
+        assertEquals("androidx.cardview.widget.CardView", node.className)
+        assertTrue("the accept tap is NOT a leaf", node.children.isNotEmpty())
+        assertTrue(
+            "the accept tap's subtree carries the accept label",
+            node.allText.any { it.equals("Match", ignoreCase = true) || it.equals("Accept", ignoreCase = true) },
+        )
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/UberDeclineClickRuleTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/UberDeclineClickRuleTest.kt
@@ -9,31 +9,54 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
 
 /**
- * #786 — regression teeth for `uber.click.decline_offer` against REAL device click envelopes.
+ * #786 — regression teeth for `uber.click.decline_offer` against REAL device click envelopes,
+ * plus per-predicate mutation coverage.
  *
  * Fixtures live under `src/test/resources/clicks/uber/` (deliberately NOT under `snapshots/`,
  * whose sub-directories are screen-intent goldens enumerated by `GoldenSnapshotRegressionTest`).
- * Each is a verbatim `click_context.v1` envelope — `payload = {node, screenTarget}` — so the test
- * feeds the production [TestRulesetFactory][cloud.trotter.dashbuddy.test.util.TestRulesetFactory]
- * click ruleset exactly what the runtime classifier sees.
+ * Each is a `click_context.v1` envelope — `payload = {node, screenTarget}` — so the test feeds the
+ * production [TestRulesetFactory] click ruleset exactly what the runtime classifier sees.
  *
  * Provenance:
- *  - `2026-07-23_18-45-24-*` / `2026-07-24_18-43-18-*` — two dasher DECLINE taps on the focused
- *    Uber offer card (106x106 anonymous childless `android.widget.Button`, `screenTarget: "offer"`).
+ *  - `2026-07-23_18-45-24-*` / `2026-07-24_18-43-18-*` — real DECLINE taps on the focused Uber
+ *    offer card (106x106 anonymous childless `android.widget.Button`, `screenTarget: "offer"`).
  *    Verbatim, unedited — these envelopes carry no text/desc/id at all, so there is nothing to
  *    redact.
- *  - `2026-07-21_18-39-25-*` — the ACCEPT interaction from the same surface: the offer
- *    `androidx.cardview.widget.CardView` itself, whose subtree carries "Match". This is the
- *    NEGATIVE pin — the whole separability argument for the rule. The card's dropoff cross-street
- *    line was replaced with the corpus's standing placeholder ("Sample St & Sample Ave, San
- *    Antonio"); merchant/pay/time text is driver-owned data and is kept verbatim.
+ *  - `2026-07-21_18-39-25-*` — the real ACCEPT interaction from the same surface: the offer
+ *    `androidx.cardview.widget.CardView` itself, whose subtree carries "Match". The card's dropoff
+ *    cross-street line was replaced with the corpus's standing placeholder ("Sample St & Sample
+ *    Ave, San Antonio"); merchant/pay/time text is driver-owned and kept verbatim.
+ *  - `synthetic__nag_not_now__*` / `synthetic__nag_settings__*` — click-shaped envelopes built
+ *    around the two Button nodes lifted VERBATIM from the fielded permission-nag capture
+ *    `accessibility.window/offer/2026-07-23_19-41-54-465__…__11cc18.json`: an **offer-classified**
+ *    frame carrying a nag sheet whose "Settings"/"Not now" buttons are leaf, id-less and clickable
+ *    — i.e. they satisfy every predicate in the rule EXCEPT the own-text-empty guard. Only the
+ *    envelope wrapper is synthetic; the nodes are real. Android system strings, zero PII.
  */
 class UberDeclineClickRuleTest {
+
+    private companion object {
+        const val RULE_ID = "uber.click.decline_offer"
+
+        val DECLINE_TAPS = listOf(
+            "2026-07-23_18-45-24-066__uber__accessibility.click__UNKNOWN__7e26a0.json",
+            "2026-07-24_18-43-18-986__uber__accessibility.click__UNKNOWN__0e1a01.json",
+        )
+
+        const val ACCEPT_CARD_TAP =
+            "2026-07-21_18-39-25-627__uber__accessibility.click__UNKNOWN__015073.json"
+
+        val NAG_BUTTONS = listOf(
+            "synthetic__nag_not_now__from_2026-07-23_19-41-54-465.json",
+            "synthetic__nag_settings__from_2026-07-23_19-41-54-465.json",
+        )
+    }
 
     private val fixtures = File("src/test/resources/clicks/uber")
 
@@ -50,16 +73,10 @@ class UberDeclineClickRuleTest {
         )
     }
 
-    private fun classify(fixture: ClickFixture) =
-        TestRulesetFactory.clickRuleset.matchFirst(fixture.node, screenTarget = fixture.screenTarget)
+    private fun match(node: UiNode, screenTarget: String?) =
+        TestRulesetFactory.clickRuleset.matchFirst(node, screenTarget = screenTarget)
 
-    private val declineTaps = listOf(
-        "2026-07-23_18-45-24-066__uber__accessibility.click__UNKNOWN__7e26a0.json",
-        "2026-07-24_18-43-18-986__uber__accessibility.click__UNKNOWN__0e1a01.json",
-    )
-
-    private val acceptCardTap =
-        "2026-07-21_18-39-25-627__uber__accessibility.click__UNKNOWN__015073.json"
+    private fun classify(fixture: ClickFixture) = match(fixture.node, fixture.screenTarget)
 
     // =========================================================================
     // Positive: the anonymous childless Button on the offer card IS the decline commit
@@ -67,19 +84,19 @@ class UberDeclineClickRuleTest {
 
     @Test
     fun `real Uber offer-card dismiss taps classify as decline_offer`() {
-        for (name in declineTaps) {
+        for (name in DECLINE_TAPS) {
             val fixture = load(name)
             assertEquals("$name: fixture must be an offer-screen click", "offer", fixture.screenTarget)
-            val match = classify(fixture)
+            val result = classify(fixture)
             assertEquals(
                 "$name: expected the #786 decline-commit rule to claim this tap",
-                "uber.click.decline_offer",
-                match?.ruleId,
+                RULE_ID,
+                result?.ruleId,
             )
             assertEquals(
                 "$name: must carry the decline-COMMIT intent (latches declineCommittedAt, #594)",
                 OfferIntent.DECLINE,
-                match?.intent,
+                result?.intent,
             )
         }
     }
@@ -88,46 +105,157 @@ class UberDeclineClickRuleTest {
     fun `the decline node really is anonymous, childless and Button-classed`() {
         // Pins the field evidence the rule anchors on — if a future capture refresh changes the
         // node's shape, this fails loudly next to the rule instead of silently widening it.
-        for (name in declineTaps) {
+        for (name in DECLINE_TAPS) {
             val node = load(name).node
             assertEquals("$name: class", "android.widget.Button", node.className)
             assertEquals("$name: must be clickable", true, node.isClickable)
             assertTrue("$name: must carry no view id", node.viewIdResourceName.isNullOrBlank())
             assertTrue("$name: must be a leaf", node.children.isEmpty())
+            assertTrue("$name: must carry no own text", node.text.isNullOrBlank())
             assertTrue("$name: must carry no text of any kind", node.allText.isEmpty())
         }
     }
 
     // =========================================================================
-    // Negative: the accept interaction (CardView, subtree-labelled) must NEVER decline
+    // Negative 1: the accept interaction (CardView, subtree-labelled) must NEVER decline
     // =========================================================================
 
     @Test
     fun `the CardView accept tap does NOT match the decline rule`() {
-        val fixture = load(acceptCardTap)
+        val fixture = load(ACCEPT_CARD_TAP)
         assertEquals("fixture must be an offer-screen click", "offer", fixture.screenTarget)
-        val match = classify(fixture)
+        val result = classify(fixture)
         assertNotEquals(
             "the accept CardView tap must never be claimed by the decline rule — " +
                 "a false decline latch would kill the accepted offer (#594 commit precedence)",
-            "uber.click.decline_offer",
-            match?.ruleId,
+            RULE_ID,
+            result?.ruleId,
         )
         assertNotEquals(
             "the accept CardView tap must never carry the decline intent",
             OfferIntent.DECLINE,
-            match?.intent,
+            result?.intent,
         )
     }
 
     @Test
     fun `the accept tap is structurally separable — non-leaf CardView with a labelled subtree`() {
-        val node = load(acceptCardTap).node
+        val node = load(ACCEPT_CARD_TAP).node
         assertEquals("androidx.cardview.widget.CardView", node.className)
         assertTrue("the accept tap is NOT a leaf", node.children.isNotEmpty())
         assertTrue(
             "the accept tap's subtree carries the accept label",
-            node.allText.any { it.equals("Match", ignoreCase = true) || it.equals("Accept", ignoreCase = true) },
+            node.allText.any {
+                it.equals("Match", ignoreCase = true) || it.equals("Accept", ignoreCase = true)
+            },
+        )
+    }
+
+    // =========================================================================
+    // Negative 2: unrelated chrome on an offer-CLASSIFIED frame (the review's blocking HIGH)
+    // =========================================================================
+
+    @Test
+    fun `permission-nag buttons on an offer-classified frame do NOT match`() {
+        // These are leaf, id-less, clickable android.widget.Buttons on screenTarget "offer" — they
+        // satisfy every predicate in the rule except "own text is empty". Without that guard a
+        // "Not now" tap would latch an irreversible false decline on a live pending offer.
+        for (name in NAG_BUTTONS) {
+            val fixture = load(name)
+            val node = fixture.node
+            assertEquals("$name: same class as the X", "android.widget.Button", node.className)
+            assertEquals("$name: same clickability as the X", true, node.isClickable)
+            assertTrue("$name: same id-lessness as the X", node.viewIdResourceName.isNullOrBlank())
+            assertTrue("$name: same leafness as the X", node.children.isEmpty())
+            assertTrue("$name: but it IS labelled", !node.text.isNullOrBlank())
+            assertEquals("$name: and it is on an offer-classified frame", "offer", fixture.screenTarget)
+
+            assertNotEquals(
+                "$name: labelled chrome on an offer frame must never be claimed as a decline",
+                RULE_ID,
+                classify(fixture)?.ruleId,
+            )
+        }
+    }
+
+    // =========================================================================
+    // Mutation coverage: every structural predicate is INDIVIDUALLY load-bearing
+    // =========================================================================
+
+    /**
+     * Each mutation changes exactly ONE attribute of the real decline node (or its screen scope)
+     * and must break the match, so deleting the corresponding predicate from the rule turns exactly
+     * one of these red. No predicate can be dropped silently.
+     *
+     * The `hasAnyText` Accept/Match guards are deliberately NOT listed: on a LEAF node `allText`
+     * can only ever contain that node's own text, so those guards are strictly subsumed by the
+     * own-text-empty predicate for every shape `isLeaf: true` admits. They are kept as
+     * belt-and-suspenders for a hypothetical non-leaf variant and documented as such in the rule —
+     * claiming mutation coverage for them would be theater.
+     */
+    @Test
+    fun `every structural predicate is individually load-bearing`() {
+        val base = load(DECLINE_TAPS.first())
+        assertEquals("precondition: the unmutated node matches", RULE_ID, match(base.node, base.screenTarget)?.ruleId)
+
+        val mutants: List<Triple<String, UiNode, String?>> = listOf(
+            Triple(
+                "isClickable: a non-clickable twin",
+                base.node.copy(isClickable = false),
+                base.screenTarget,
+            ),
+            Triple(
+                "hasNoId: an id-bearing X variant",
+                base.node.copy(viewIdResourceName = "com.ubercab.driver:id/dismiss_button"),
+                base.screenTarget,
+            ),
+            Triple(
+                "hasClassName: an ImageButton-classed twin",
+                base.node.copy(className = "android.widget.ImageButton"),
+                base.screenTarget,
+            ),
+            Triple(
+                // The injected child is itself text-free, so own-text/allText stay empty and
+                // leafness is the ONLY attribute that differs from the real X.
+                "isLeaf: a Button wrapping a (text-free) child",
+                base.node.copy(children = listOf(UiNode(className = "android.widget.ImageView"))),
+                base.screenTarget,
+            ),
+            Triple(
+                "own text empty: the fielded nag-sheet label",
+                base.node.copy(text = "Not now"),
+                base.screenTarget,
+            ),
+            Triple(
+                "screenIs: the same node tapped on the awaiting_offer board",
+                base.node,
+                "awaiting_offer",
+            ),
+            Triple(
+                "screenIs: the same node tapped mid-trip",
+                base.node,
+                "active_trip",
+            ),
+        )
+
+        for ((label, node, screenTarget) in mutants) {
+            assertNotEquals(
+                "mutation '$label' must NOT be claimed by $RULE_ID — that predicate is not load-bearing",
+                RULE_ID,
+                match(node, screenTarget)?.ruleId,
+            )
+        }
+    }
+
+    @Test
+    fun `the anonymous X on a non-offer screen falls through to UNKNOWN entirely`() {
+        // Not merely "not a decline": no other click rule claims it either, so it stays an UNKNOWN
+        // click — the safe direction, where a missed decline degrades to OFFER_TIMEOUT rather than
+        // fabricating one.
+        val base = load(DECLINE_TAPS.first())
+        assertNull(
+            "the bare X on active_trip must match no click rule at all",
+            match(base.node, "active_trip"),
         )
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatchersSuite.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatchersSuite.kt
@@ -43,8 +43,11 @@ import org.junit.runners.Suite
  *   ruleset compiles and the core predicates behave.
  * - [TriageRulesTest] — synthetic fixtures for rules added from capture triage.
  * - [UberDeclineClickRuleTest] — #786: real device click envelopes pin `uber.click.decline_offer`
- *   onto the offer card's anonymous childless dismiss Button, and pin the accept CardView tap
- *   (subtree-labelled, non-leaf) as NOT matching it — the separability the rule rests on.
+ *   onto the offer card's anonymous childless dismiss Button, and pin BOTH the accept CardView tap
+ *   (subtree-labelled, non-leaf) and the fielded permission-nag "Settings"/"Not now" buttons
+ *   (labelled, but otherwise predicate-identical to the X) as NOT matching it — the separability
+ *   the rule rests on. Plus per-predicate mutation coverage, so no predicate can be dropped
+ *   silently.
  * - [DefaultRulesIntegrationTest] — end-to-end rule compilation/wiring.
  * - [NotificationClassifierTest] / [ClickClassifierTest] — classifier behavior.
  * - [CaptureRedactionCorpusTest] — the #598/#620 redact predicates mask injected

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatchersSuite.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatchersSuite.kt
@@ -13,6 +13,7 @@ import cloud.trotter.dashbuddy.core.pipeline.rules.NotificationRulesetTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.ParseOutputGoldenTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.ScreenRulesetTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.TriageRulesTest
+import cloud.trotter.dashbuddy.core.pipeline.rules.UberDeclineClickRuleTest
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
 
@@ -41,6 +42,9 @@ import org.junit.runners.Suite
  * - [ScreenRulesetTest] / [ClickRulesetTest] / [NotificationRulesetTest] — the
  *   ruleset compiles and the core predicates behave.
  * - [TriageRulesTest] — synthetic fixtures for rules added from capture triage.
+ * - [UberDeclineClickRuleTest] — #786: real device click envelopes pin `uber.click.decline_offer`
+ *   onto the offer card's anonymous childless dismiss Button, and pin the accept CardView tap
+ *   (subtree-labelled, non-leaf) as NOT matching it — the separability the rule rests on.
  * - [DefaultRulesIntegrationTest] — end-to-end rule compilation/wiring.
  * - [NotificationClassifierTest] / [ClickClassifierTest] — classifier behavior.
  * - [CaptureRedactionCorpusTest] — the #598/#620 redact predicates mask injected
@@ -64,6 +68,7 @@ import org.junit.runners.Suite
     OfferPipelineTest::class,
     ScreenRulesetTest::class,
     ClickRulesetTest::class,
+    UberDeclineClickRuleTest::class,
     NotificationRulesetTest::class,
     TriageRulesTest::class,
     DefaultRulesIntegrationTest::class,

--- a/app/src/test/resources/clicks/uber/2026-07-21_18-39-25-627__uber__accessibility.click__UNKNOWN__015073.json
+++ b/app/src/test/resources/clicks/uber/2026-07-21_18-39-25-627__uber__accessibility.click__UNKNOWN__015073.json
@@ -1,0 +1,442 @@
+{
+    "captureId": "0ac64887-5819-4629-aa80-6bb130c8308e",
+    "pipelineId": "accessibility.click",
+    "schemaId": "click_context.v1",
+    "timestamp": 1784677165619,
+    "platform": "uber",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "node": {
+            "class": "androidx.cardview.widget.CardView",
+            "isClickable": true,
+            "isEnabled": true,
+            "bounds": {
+                "left": 36,
+                "top": 1472,
+                "right": 1044,
+                "bottom": 2305
+            },
+            "children": [
+                {
+                    "class": "android.widget.LinearLayout",
+                    "isEnabled": true,
+                    "bounds": {
+                        "left": 36,
+                        "top": 1472,
+                        "right": 1044,
+                        "bottom": 2305
+                    },
+                    "children": [
+                        {
+                            "class": "android.widget.LinearLayout",
+                            "isEnabled": true,
+                            "bounds": {
+                                "left": 36,
+                                "top": 1472,
+                                "right": 1044,
+                                "bottom": 1813
+                            },
+                            "children": [
+                                {
+                                    "class": "android.widget.FrameLayout",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                        "left": 72,
+                                        "top": 1502,
+                                        "right": 1008,
+                                        "bottom": 1786
+                                    },
+                                    "children": [
+                                        {
+                                            "class": "android.widget.LinearLayout",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                                "left": 72,
+                                                "top": 1502,
+                                                "right": 1008,
+                                                "bottom": 1786
+                                            },
+                                            "children": [
+                                                {
+                                                    "class": "android.view.ViewGroup",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                        "left": 72,
+                                                        "top": 1502,
+                                                        "right": 1008,
+                                                        "bottom": 1580
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "class": "android.widget.LinearLayout",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                                "left": 72,
+                                                                "top": 1502,
+                                                                "right": 317,
+                                                                "bottom": 1580
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "class": "android.widget.ImageView",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                        "left": 90,
+                                                                        "top": 1523,
+                                                                        "right": 126,
+                                                                        "bottom": 1559
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "text": "Delivery",
+                                                                    "class": "android.widget.TextView",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                        "left": 144,
+                                                                        "top": 1502,
+                                                                        "right": 317,
+                                                                        "bottom": 1580
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "class": "android.widget.LinearLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                        "left": 72,
+                                                        "top": 1580,
+                                                        "right": 330,
+                                                        "bottom": 1708
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "text": "$6.44",
+                                                            "class": "android.widget.TextView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                                "left": 72,
+                                                                "top": 1580,
+                                                                "right": 330,
+                                                                "bottom": 1708
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "class": "android.view.ViewGroup",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                        "left": 72,
+                                                        "top": 1708,
+                                                        "right": 1008,
+                                                        "bottom": 1786
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "class": "android.widget.LinearLayout",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                                "left": 72,
+                                                                "top": 1708,
+                                                                "right": 513,
+                                                                "bottom": 1786
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "text": "Includes expected tip",
+                                                                    "class": "android.widget.TextView",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                        "left": 72,
+                                                                        "top": 1708,
+                                                                        "right": 513,
+                                                                        "bottom": 1786
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "class": "android.widget.ImageView",
+                            "isEnabled": true,
+                            "bounds": {
+                                "left": 36,
+                                "top": 1813,
+                                "right": 1044,
+                                "bottom": 1815
+                            }
+                        },
+                        {
+                            "class": "android.widget.FrameLayout",
+                            "isEnabled": true,
+                            "bounds": {
+                                "left": 36,
+                                "top": 1815,
+                                "right": 1044,
+                                "bottom": 1924
+                            },
+                            "children": [
+                                {
+                                    "class": "android.widget.LinearLayout",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                        "left": 72,
+                                        "top": 1842,
+                                        "right": 1008,
+                                        "bottom": 1906
+                                    },
+                                    "children": [
+                                        {
+                                            "class": "android.widget.LinearLayout",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                                "left": 72,
+                                                "top": 1842,
+                                                "right": 559,
+                                                "bottom": 1906
+                                            },
+                                            "children": [
+                                                {
+                                                    "class": "android.widget.ImageView",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                        "left": 72,
+                                                        "top": 1847,
+                                                        "right": 125,
+                                                        "bottom": 1900
+                                                    }
+                                                },
+                                                {
+                                                    "text": "26 min (8.5 mi) total",
+                                                    "class": "android.widget.TextView",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                        "left": 143,
+                                                        "top": 1842,
+                                                        "right": 559,
+                                                        "bottom": 1906
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "class": "android.widget.ImageView",
+                            "isEnabled": true,
+                            "bounds": {
+                                "left": 36,
+                                "top": 1924,
+                                "right": 1044,
+                                "bottom": 1926
+                            }
+                        },
+                        {
+                            "class": "android.widget.FrameLayout",
+                            "isEnabled": true,
+                            "bounds": {
+                                "left": 36,
+                                "top": 1926,
+                                "right": 1044,
+                                "bottom": 2145
+                            },
+                            "children": [
+                                {
+                                    "class": "android.widget.LinearLayout",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                        "left": 72,
+                                        "top": 1944,
+                                        "right": 1008,
+                                        "bottom": 2127
+                                    },
+                                    "children": [
+                                        {
+                                            "class": "android.widget.LinearLayout",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                                "left": 72,
+                                                "top": 1944,
+                                                "right": 1008,
+                                                "bottom": 2127
+                                            },
+                                            "children": [
+                                                {
+                                                    "class": "android.widget.LinearLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                        "left": 72,
+                                                        "top": 1944,
+                                                        "right": 1008,
+                                                        "bottom": 2015
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "class": "android.widget.ImageView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                                "left": 72,
+                                                                "top": 1953,
+                                                                "right": 125,
+                                                                "bottom": 2006
+                                                            }
+                                                        },
+                                                        {
+                                                            "class": "android.widget.LinearLayout",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                                "left": 143,
+                                                                "top": 1951,
+                                                                "right": 1008,
+                                                                "bottom": 2007
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "class": "android.widget.LinearLayout",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                        "left": 143,
+                                                                        "top": 1951,
+                                                                        "right": 676,
+                                                                        "bottom": 2007
+                                                                    },
+                                                                    "children": [
+                                                                        {
+                                                                            "text": "Sonic (2314 Thousand Oaks)",
+                                                                            "class": "android.widget.TextView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                                "left": 143,
+                                                                                "top": 1951,
+                                                                                "right": 676,
+                                                                                "bottom": 2007
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "class": "android.widget.LinearLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                        "left": 72,
+                                                        "top": 2015,
+                                                        "right": 1008,
+                                                        "bottom": 2127
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "class": "android.widget.ImageView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                                "left": 72,
+                                                                "top": 2024,
+                                                                "right": 125,
+                                                                "bottom": 2077
+                                                            }
+                                                        },
+                                                        {
+                                                            "class": "android.widget.LinearLayout",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                                "left": 143,
+                                                                "top": 2015,
+                                                                "right": 1008,
+                                                                "bottom": 2127
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "class": "android.widget.LinearLayout",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                        "left": 143,
+                                                                        "top": 2015,
+                                                                        "right": 1008,
+                                                                        "bottom": 2127
+                                                                    },
+                                                                    "children": [
+                                                                        {
+                                                                            "text": "Sample St & Sample Ave, San Antonio",
+                                                                            "class": "android.widget.TextView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                                "left": 143,
+                                                                                "top": 2015,
+                                                                                "right": 1008,
+                                                                                "bottom": 2127
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "text": "Match",
+                            "class": "android.widget.Button",
+                            "isClickable": true,
+                            "isEnabled": true,
+                            "bounds": {
+                                "left": 72,
+                                "top": 2163,
+                                "right": 1008,
+                                "bottom": 2269
+                            }
+                        }
+                    ]
+                },
+                {
+                    "class": "android.widget.Button",
+                    "isClickable": true,
+                    "isEnabled": true,
+                    "bounds": {
+                        "left": 902,
+                        "top": 1502,
+                        "right": 1008,
+                        "bottom": 1608
+                    }
+                }
+            ]
+        },
+        "screenTarget": "offer"
+    }
+}

--- a/app/src/test/resources/clicks/uber/2026-07-23_18-45-24-066__uber__accessibility.click__UNKNOWN__7e26a0.json
+++ b/app/src/test/resources/clicks/uber/2026-07-23_18-45-24-066__uber__accessibility.click__UNKNOWN__7e26a0.json
@@ -1,0 +1,39 @@
+{
+    "captureId": "a0a00eda-dcf8-4e85-b79f-d653c772caac",
+    "pipelineId": "accessibility.click",
+    "schemaId": "click_context.v1",
+    "timestamp": 1784850324065,
+    "platform": "uber",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "node": {
+            "class": "android.widget.Button",
+            "isClickable": true,
+            "isEnabled": true,
+            "bounds": {
+                "left": 902,
+                "top": 1741,
+                "right": 1008,
+                "bottom": 1847
+            }
+        },
+        "screenTarget": "offer"
+    }
+}

--- a/app/src/test/resources/clicks/uber/2026-07-24_18-43-18-986__uber__accessibility.click__UNKNOWN__0e1a01.json
+++ b/app/src/test/resources/clicks/uber/2026-07-24_18-43-18-986__uber__accessibility.click__UNKNOWN__0e1a01.json
@@ -1,0 +1,39 @@
+{
+    "captureId": "5c099d51-614a-4700-a206-8bdbe47fa5b5",
+    "pipelineId": "accessibility.click",
+    "schemaId": "click_context.v1",
+    "timestamp": 1784936598985,
+    "platform": "uber",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "node": {
+            "class": "android.widget.Button",
+            "isClickable": true,
+            "isEnabled": true,
+            "bounds": {
+                "left": 902,
+                "top": 1729,
+                "right": 1008,
+                "bottom": 1835
+            }
+        },
+        "screenTarget": "offer"
+    }
+}

--- a/app/src/test/resources/clicks/uber/synthetic__nag_not_now__from_2026-07-23_19-41-54-465.json
+++ b/app/src/test/resources/clicks/uber/synthetic__nag_not_now__from_2026-07-23_19-41-54-465.json
@@ -1,0 +1,40 @@
+{
+ "captureId": "synthetic-786-nag-not_now",
+ "pipelineId": "accessibility.click",
+ "schemaId": "click_context.v1",
+ "timestamp": 1784853714451,
+ "platform": "uber",
+ "ruleId": null,
+ "classificationName": "UNKNOWN",
+ "metadata": {
+  "engineVersion": 1,
+  "rulesetFormatVersion": 2,
+  "pipelineVersions": {
+   "accessibility": 1,
+   "accessibility.window": 1,
+   "accessibility.click": 1,
+   "accessibility.long_click": 1,
+   "accessibility.scroll": 1,
+   "accessibility.focus": 1,
+   "notification": 1
+  },
+  "stateMachineApiVersion": "1.0",
+  "appVersion": "0.230.0",
+  "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+ },
+ "payload": {
+  "node": {
+   "text": "Not now",
+   "class": "android.widget.Button",
+   "isClickable": true,
+   "isEnabled": true,
+   "bounds": {
+    "left": 36,
+    "top": 2187,
+    "right": 1044,
+    "bottom": 2311
+   }
+  },
+  "screenTarget": "offer"
+ }
+}

--- a/app/src/test/resources/clicks/uber/synthetic__nag_settings__from_2026-07-23_19-41-54-465.json
+++ b/app/src/test/resources/clicks/uber/synthetic__nag_settings__from_2026-07-23_19-41-54-465.json
@@ -1,0 +1,40 @@
+{
+ "captureId": "synthetic-786-nag-settings",
+ "pipelineId": "accessibility.click",
+ "schemaId": "click_context.v1",
+ "timestamp": 1784853714451,
+ "platform": "uber",
+ "ruleId": null,
+ "classificationName": "UNKNOWN",
+ "metadata": {
+  "engineVersion": 1,
+  "rulesetFormatVersion": 2,
+  "pipelineVersions": {
+   "accessibility": 1,
+   "accessibility.window": 1,
+   "accessibility.click": 1,
+   "accessibility.long_click": 1,
+   "accessibility.scroll": 1,
+   "accessibility.focus": 1,
+   "notification": 1
+  },
+  "stateMachineApiVersion": "1.0",
+  "appVersion": "0.230.0",
+  "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+ },
+ "payload": {
+  "node": {
+   "text": "Settings",
+   "class": "android.widget.Button",
+   "isClickable": true,
+   "isEnabled": true,
+   "bounds": {
+    "left": 36,
+    "top": 2045,
+    "right": 1044,
+    "bottom": 2169
+   }
+  },
+  "screenTarget": "offer"
+ }
+}

--- a/matchers/rules/uber.json5
+++ b/matchers/rules/uber.json5
@@ -1177,6 +1177,55 @@
       }
     },
     {
+      // #786 — the offer card's dismiss "X". Field-confirmed (2026-07-23/24 pulls, five on-disk
+      // click envelopes) as an ANONYMOUS CHILDLESS Button: text/id/desc all null, no children,
+      // 106x106 at the focused card's top-right. Uber shows NO confirm sheet, so one tap COMMITS
+      // the decline — hence the decline-COMMIT intent, which latches
+      // PendingOffer.declineCommittedAt through the existing #594 machinery (DoorDash's
+      // confirm-sheet rule proves that chain; no state-machine change is needed here).
+      //
+      // Separability from the ACCEPT interaction is STRUCTURAL, not geometric: the accept tap
+      // arrives as the offer CardView itself (2026-07-21 18:39:25 capture) — a non-leaf
+      // androidx.cardview.widget.CardView whose subtree carries the "Match"/"Accept" label. So
+      // class-exact + isLeaf + hasNoId already exclude it three ways over; the text guards are
+      // belt-and-suspenders that keep the exclusion honest if a future variant ships a non-leaf
+      // decline node. Deliberately NO bounds/geometry predicates — those would bake this device's
+      // pixels into rule data.
+      //
+      // Scoped to screenIs "offer" (the focused offer card). The Trip Radar board's 80x80 sibling X
+      // lands on UNKNOWN screens and is therefore out of scope until #251 recognizes the board.
+      "id": "uber.click.decline_offer",
+      "priority": 6,
+      "screenIs": "offer",
+      "intent": "decline_offer",
+      "require": {
+        "all": [
+          {
+            "isClickable": true
+          },
+          {
+            "hasNoId": true
+          },
+          {
+            "hasClassName": "android.widget.Button"
+          },
+          {
+            "isLeaf": true
+          },
+          {
+            "not": {
+              "hasAnyText": "Accept"
+            }
+          },
+          {
+            "not": {
+              "hasAnyText": "Match"
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "uber.click.go_online",
       "priority": 10,
       "intent": "go_online",

--- a/matchers/rules/uber.json5
+++ b/matchers/rules/uber.json5
@@ -1177,20 +1177,39 @@
       }
     },
     {
-      // #786 — the offer card's dismiss "X". Field-confirmed (2026-07-23/24 pulls, five on-disk
-      // click envelopes) as an ANONYMOUS CHILDLESS Button: text/id/desc all null, no children,
-      // 106x106 at the focused card's top-right. Uber shows NO confirm sheet, so one tap COMMITS
-      // the decline — hence the decline-COMMIT intent, which latches
-      // PendingOffer.declineCommittedAt through the existing #594 machinery (DoorDash's
-      // confirm-sheet rule proves that chain; no state-machine change is needed here).
+      // #786 — the offer card's dismiss "X". Field-confirmed (2026-07-23/24 pulls, on-disk click
+      // envelopes) as an ANONYMOUS CHILDLESS Button: text/id/desc all null, no children, 106x106 at
+      // the focused card's top-right. Uber shows NO confirm sheet, so one tap COMMITS the decline —
+      // hence the decline-COMMIT intent, which latches PendingOffer.declineCommittedAt through the
+      // existing #594 machinery (DoorDash's confirm-sheet rule proves that chain; no state-machine
+      // change is needed here).
+      //
+      // (a) THE PRIMARY GUARD IS "own text is empty" — `not hasTextMatchesRegex "\S"`. The X is
+      // content-free; every LABELLED id-less leaf Button fails it. This is load-bearing, not
+      // decorative: an offer-CLASSIFIED frame can carry unrelated chrome, and the fielded
+      // 2026-07-23_19-41-54 capture is exactly that — a permission-nag sheet over the offer whose
+      // "Settings" and "Not now" Buttons are leaf, id-less and clickable, i.e. they satisfy every
+      // OTHER predicate here. Click source nodes DO carry their text when they have any (the
+      // fielded "Continue to next stop" click proves it), so without this predicate a "Not now" tap
+      // would latch an IRREVERSIBLE false decline. The Accept/Match guards below are kept as
+      // belt-and-suspenders (and to document intent), but they are no longer the defense.
       //
       // Separability from the ACCEPT interaction is STRUCTURAL, not geometric: the accept tap
       // arrives as the offer CardView itself (2026-07-21 18:39:25 capture) — a non-leaf
       // androidx.cardview.widget.CardView whose subtree carries the "Match"/"Accept" label. So
-      // class-exact + isLeaf + hasNoId already exclude it three ways over; the text guards are
-      // belt-and-suspenders that keep the exclusion honest if a future variant ships a non-leaf
-      // decline node. Deliberately NO bounds/geometry predicates — those would bake this device's
-      // pixels into rule data.
+      // class-exact + isLeaf + hasNoId exclude it three ways over. Deliberately NO bounds/geometry
+      // predicates — those would bake this device's pixels into rule data.
+      //
+      // (b) DOCUMENTED RESIDUAL — a DESC-bearing icon button. The predicate vocabulary has no
+      // desc-regex ("is the contentDescription non-empty") predicate, only equality/contains
+      // against a known literal, so an id-less leaf Button carrying only a contentDescription
+      // would still match. No such node has been fielded on this surface; closing it means adding
+      // a predicate to :core:pipeline, not editing rule data.
+      //
+      // (c) NOT EXPRESSIBLE — "the screen must also carry an Accept sibling". Click rules match the
+      // clicked node alone; the screen tree is not in scope for a click predicate, and screenIs is
+      // the only screen-level coupling available. That is a pipeline matter and is deliberately
+      // NOT built here.
       //
       // Scoped to screenIs "offer" (the focused offer card). The Trip Radar board's 80x80 sibling X
       // lands on UNKNOWN screens and is therefore out of scope until #251 recognizes the board.
@@ -1211,6 +1230,11 @@
           },
           {
             "isLeaf": true
+          },
+          {
+            "not": {
+              "hasTextMatchesRegex": "\\S"
+            }
           },
           {
             "not": {


### PR DESCRIPTION
Closes #786.

## What

One new click rule, `uber.click.decline_offer`, in `matchers/rules/uber.json5` — the offer card's
dismiss **X**. Uber shows **no confirm sheet**, so one tap is a committed decline; the rule therefore
carries the decline-**COMMIT** intent (`decline_offer`), which latches `PendingOffer.declineCommittedAt`
through the existing #594 machinery.

```json5
{
  "id": "uber.click.decline_offer",
  "priority": 6,
  "screenIs": "offer",
  "intent": "decline_offer",
  "require": {
    "all": [
      { "isClickable": true },
      { "hasNoId": true },
      { "hasClassName": "android.widget.Button" },
      { "isLeaf": true },
      { "not": { "hasTextMatchesRegex": "\\S" } },
      { "not": { "hasAnyText": "Accept" } },
      { "not": { "hasAnyText": "Match" } }
    ]
  }
}
```

**Zero `:core:state` / `:core:pipeline` / `:domain` changes.** `decline_offer` is already the
enumerated `OfferIntent.DECLINE`, and the classifier → `latchOfferClick` → `declineCommittedAt` →
`EffectMap.resolveOfferOutcome` chain is entirely intent-driven with no platform branch (DoorDash's
confirm-sheet rule proves the chain end-to-end). Nothing else needed wiring.

## Separability evidence (why this can't be geometry)

The decline X and the accept interaction are separable **in the existing predicate vocabulary**. The
X arrives as an **anonymous childless `android.widget.Button`** — `text`/`id`/`desc` all null, no
children, 106×106 at the focused card's top-right. The **accept** tap, by contrast, arrives as the
offer **`androidx.cardview.widget.CardView` itself** — non-leaf, and its subtree carries the
`"Match"` / `"Accept"` label (`captures/uber/accessibility.click/UNKNOWN/2026-07-21_18-39-25-*.json`,
immediately preceding a driven trip). So `hasClassName` exact + `isLeaf` + `hasNoId` exclude the
accept path three independent ways. **No bounds/geometry predicates** — those would bake this
device's pixels into rule data and violate the anchors-are-platform-chrome doctrine.

The **own-text-empty** predicate (`not hasTextMatchesRegex "\S"`) is the *primary* guard, added by
the adversarial review (see below): the X is content-free, and every labelled button fails it.

### Sweep — what the predicate actually claims in the field

Across **all 50** Uber click envelopes in the 07-19 → 07-24 pulls, 13 are anonymous childless
Buttons. The rule claims **6** of them — every one on `screenTarget: "offer"`:

| screenTarget | anonymous childless Buttons | claimed |
|---|---|---|
| `offer` | 6 | **6** |
| `awaiting_offer` | 4 | 0 |
| `photo_capture` | 2 | 0 |
| `idle_map` | 1 | 0 |

Of the **5 dev-confirmed X taps** listed on the issue, **4 are claimed**. The fifth
(`2026-07-23_19-26-04`) recorded `screenTarget: "awaiting_offer"` and is **not** claimed — the
classifier's last screen for that platform was the board, not the focused card. That is a
**missed decline → stays `OFFER_TIMEOUT`**, the safe direction, and it means the recovery ceiling is
marginally lower than the raw witnessed-click rate suggests.

Zero of the 6 offer-screen CardView taps, and zero Buttons on any other screen, are claimed.

## Known risk — the watch condition

If an accept tap ever arrives as a **childless anonymous Button**, this rule would latch a *decline*
on an *accept*, and the #594 commit precedence (`declineCommittedAt` checked FIRST in
`resolveOfferOutcome`, and a committed decline never survives in `OfferLifecycle`) would kill the
accepted survivor. Fielded evidence says the accept arrives as a labeled-subtree CardView, but that
evidence is **n=1–2 sightings** and the accept path itself is still field-unvalidated (#826 — zero
Uber accepts occurred in the 07-25 pull window).

**The field-validation guard is: an Uber dash with a REAL accept must produce `OFFER_ACCEPTED` + a
costed job, never `OFFER_DECLINED`.** If a real accept shows up as a decline, this rule is the first
suspect and should be reverted pending a capture of the true accept node shape.

## Expected recovery

~36–40% of Uber offer resolutions show a witnessed anonymous click within 3 s (52/144 in the pull) —
those stop being `OFFER_TIMEOUT` and become honest `OFFER_DECLINED`, minus the `awaiting_offer`-scoped
share noted in the sweep above. The remaining ~60% have **no witness of any kind** (swipe-dismiss
emits no clickable event; the board can rotate its focused card; requests get taken by other drivers)
and stay `OFFER_TIMEOUT` pending #251. Note the rule *also* recovers declines that never reached
disk: UNKNOWN-click capture dedup suppresses repeats, but `FrameGate.admit` returns true
unconditionally for known-target clicks, so classification bypasses the suppressor entirely — 62
anonymous clicks were seen pre-gate vs 24 on disk.

## Residuals — deliberately not fixed here

1. **Trip Radar board X (out of scope → #251).** The board card's 80×80 sibling X lands on
   **UNKNOWN** screens (the board isn't recognized), so `screenIs: "offer"` does not claim it. Board
   dismissal stays unwitnessed until #251 recognizes the board — and the resolution-honesty question
   of what an un-witnessed disappearance should record belongs to that design.
2. **MED — the click's `screenTarget` is the platform's LAST classified screen, with no TTL.** The
   fielded staleness window is ~1.4–2.6 s. An anonymous childless X tapped *elsewhere* inside that
   window can therefore present as `screenTarget: "offer"` and latch a decline on a still-pending
   offer; `active_trip` is known to carry predicate-matching X's. The blast radius is bounded by a
   live `pendingOffer` having to exist at that moment, and the failure is a *false decline* rather
   than a false accept. **This is not fixable in rule data** — a screen-target TTL is a
   `:core:pipeline` change — and it should be weighed in the #826 / #251 designs.
3. **A desc-bearing icon button.** The predicate vocabulary has no "contentDescription is non-empty"
   regex predicate (only equality/contains against a known literal), so an id-less leaf Button
   carrying *only* a `contentDescription` would still match. None has been fielded on this surface;
   closing it means adding a predicate to `:core:pipeline`, not editing rule data.
4. **"The screen must also carry an Accept sibling"** is not expressible for click rules — a click
   predicate sees the clicked node alone, and `screenIs` is the only screen-level coupling
   available. Pipeline matter; deliberately not built.

## Tests

New `UberDeclineClickRuleTest` (added to `AllMatchersSuite`), driven by **real device click
envelopes** committed under `app/src/test/resources/clicks/uber/` — deliberately NOT under
`snapshots/`, whose sub-directories are screen-intent goldens enumerated by
`GoldenSnapshotRegressionTest`. **7 cases, all green:**

- **positive** — both decline envelopes classify as `uber.click.decline_offer` / `OfferIntent.DECLINE`.
- **shape pin** — those nodes really are Button-classed, clickable, id-less, leaf, text-less.
- **negative (accept)** — the CardView accept tap must NOT match the rule or carry the decline intent.
- **shape pin** — that accept tap is a non-leaf CardView with an accept-labelled subtree.
- **negative (chrome)** — the permission-nag "Settings"/"Not now" buttons, which are
  predicate-identical to the X *except* for being labelled, must NOT match.
- **mutation coverage** — seven single-attribute mutants of the real decline node, each of which
  must break the match.
- **fall-through** — the bare X on `active_trip` matches **no** click rule at all.

### Predicate-deletion verification

The mutation test's teeth were verified by actually stripping each predicate from the rule and
re-running. Every deletion turns the suite **red**:

| predicate dropped | result |
|---|---|
| `isClickable` | CAUGHT |
| `hasNoId` | CAUGHT |
| `hasClassName` | CAUGHT |
| `isLeaf` | CAUGHT |
| own-text-empty (`not hasTextMatchesRegex "\S"`) | CAUGHT |

`screenIs` is covered by construction (the two screen-scope mutants + the `active_trip`
fall-through case). The `hasAnyText` Accept/Match guards are **deliberately not** claimed as
mutation-covered: on a leaf node `allText` can only contain that node's own text, so they are
strictly subsumed by the own-text-empty predicate for every shape `isLeaf: true` admits. They are
kept as belt-and-suspenders for a hypothetical non-leaf variant and documented as such in the rule —
claiming coverage for them would be theater.

`./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` green; the whole `replay.*` package
green. `ParseOutputGoldenTest` is **unchanged and needed no regen** — a click rule declares no `parse`
block, so it contributes nothing to the parse golden (`approved-parse-output.json` untouched in the
diff).

## Fixture provenance + PII

| fixture | source | edits |
|---|---|---|
| `2026-07-23_18-45-24-066__…__7e26a0.json` | `logs/2026/07/25` click capture | none — verbatim |
| `2026-07-24_18-43-18-986__…__0e1a01.json` | `logs/2026/07/25` click capture | none — verbatim |
| `2026-07-21_18-39-25-627__…__015073.json` | `logs/2026/07/22` click capture | dropoff cross-street replaced |
| `synthetic__nag_not_now__from_2026-07-23_19-41-54-465.json` | node lifted from the `19-41-54` **screen** capture | envelope wrapper synthetic; node verbatim |
| `synthetic__nag_settings__from_2026-07-23_19-41-54-465.json` | node lifted from the `19-41-54` **screen** capture | envelope wrapper synthetic; node verbatim |

The two **decline** envelopes carry **zero** text, contentDescription, and view ids — the node is
anonymous by construction, so there is literally nothing to redact. The **accept CardView** envelope's
subtree carries `"Delivery"`, `"$6.44"`, `"Includes expected tip"`, `"26 min (8.5 mi) total"`,
`"Sonic (2314 Thousand Oaks)"`, `"Match"` — all merchant/economics data, driver-owned, kept verbatim
per the existing corpus convention — plus one **customer dropoff cross-street line**, which was
replaced with the corpus's standing placeholder `"Sample St & Sample Ave, San Antonio"` (the same form
already used in `snapshots/offer/2026-07-21_18-38-01-*`). The two **nag** fixtures carry only the
Android system strings `"Settings"` and `"Not now"`. Verified across all five: no raw customer
address, name, or gate/PIN text in any committed fixture.

### Design-goal review

- **P8 (platform-agnostic core)** — the entire change is **ruleset data**; no Kotlin logic touched, no
  `Platform` literal, no `when` on a wire string. The rule anchors on **structural platform chrome
  only** (class / clickability / leafness / id-absence / text-emptiness) with no merchant-, store-, or
  geometry-specific key. New vocabulary check: **none introduced** — `decline_offer` is the
  already-enumerated `OfferIntent.DECLINE`, so nothing needed adding to `StateMachineContract`. The
  acceptance test holds: this Uber capability ships with **zero** `:core:state` / `:core:pipeline` /
  `:domain` edits.
- **P6 (security & privacy)** — **no new capture surface and no new actuation.** A click rule only
  *classifies* an event the pipeline already receives; it declares no `parse` block, so it derives,
  hashes, and stores **nothing**, and it declares no `bind` target, so it grants the `RuleAction`
  registry no new tap capability (rules cannot declare actuation at all, #425). Trusted: nothing new —
  the clicked node is the same untrusted third-party input. The one added predicate is a regex; it is
  a **constant** `\S` compiled at rule-compile time against a single node's own text, not a
  rule-supplied pattern over attacker-sized input, so it adds no ReDoS or unbounded-ingestion surface.
  Net privacy effect is *positive*: a decline click that previously fell through to the UNKNOWN
  envelope path (written to disk for triage) is now **recognized**, and recognized clicks are not
  UNKNOWN-captured. Committed fixtures were manually PII-swept (table above).
- **P5 (SSOT)** — the test asserts against `OfferIntent.DECLINE`, not a `"decline_offer"` string
  literal, so the fixture pin and the state machine read the same constant.
- **P3 (single responsibility)** — one rule, one intent, one screen scope; the new test file covers
  exactly this rule rather than being appended to the synthetic `ClickRulesetTest`.

No log sites added (P7 untouched), no UI (Reactive UI rules untouched), no reducer/effect change
(P1 untouched).

### Adversarial review

Fable-tier independent review: **APPROVE-WITH-FIXES**, one blocking HIGH. All findings applied in
`6203ac5d`.

- **HIGH (blocking) — the predicate matched TEXT-BEARING anonymous buttons.** The original rule only
  excluded `Accept`/`Match` text, so *any other* labelled id-less leaf Button on an
  offer-**classified** frame satisfied it. Fielded, not hypothetical: the
  `accessibility.window/offer/2026-07-23_19-41-54-465__…__11cc18.json` capture is an offer-classified
  frame carrying a **permission-nag sheet** whose `"Settings"` and `"Not now"` Buttons are leaf,
  id-less and clickable. Click source nodes DO carry their text when they have any (the fielded
  `"Continue to next stop"` click proves it), so a `"Not now"` tap would have arrived labelled,
  matched, and latched an **irreversible false decline** on a live pending offer.
  **FIXED** — added `{ "not": { "hasTextMatchesRegex": "\\S" } }` as the primary guard; the
  Accept/Match guards are retained as belt-and-suspenders and documented as such in the rule comment,
  alongside residuals 3 and 4 above.
- **Test teeth.** The sole negative (the CardView) was excluded by three predicates at once, so
  dropping any single predicate still passed green. **FIXED** — the two nag-button fixtures make the
  text guard individually load-bearing, and the mutation case covers the rest; every predicate
  deletion is now verified to turn the suite red (table above).
- **Sweep count correction.** Restated with the precise per-screen breakdown above, including the
  dev-confirmed X tap that records `screenTarget: "awaiting_offer"` and is deliberately not claimed.
- **MED — stale `screenTarget` window.** Recorded as residual 2 above and routed to the #826 / #251
  designs; not fixable in rule data.
