### PR TITLE
fix(privacy): #860 redact the dropoff Building Name value at the capture edge

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -185,6 +185,79 @@ class CaptureRedactionCorpusTest {
         )
     }
 
+    /**
+     * #860 — the dropoff address block's `Building Name` VALUE (an apartment-complex
+     * name) shipped RAW in the recognized envelope. Every sibling field in that block
+     * was already covered (street/city/zip by the id-less numeric shapes, `Entry code`
+     * / `Apt/Suite` values by the `^#?\s?\d{1,4}[A-Za-z]?$` entry, the instruction body
+     * by the `dasher_instruction_*` ids) but a building name has no id, no digits and
+     * no stable text shape, so no predicate named it — and `CustomerTextMarkers` has no
+     * marker prefix here, so the backstop is structurally blind to it too. The fix
+     * anchors on the LABEL sibling (`hasPrecedingSiblingText`).
+     *
+     * Node shape is ground truth from a real 2026-07-23 device capture: a parent
+     * `android.view.View` whose children are six id-less TextViews in
+     * label/value/label/value/label/value order, `Building Name` last. NOTHING from
+     * that capture is reproduced here — the label is app chrome, and every value below
+     * is invented.
+     *
+     * Teeth: deleting the rule's Building-Name redact entry turns this RED.
+     */
+    @Test
+    fun `dropoff_pre_arrival redact masks the Building Name value, keeps the label (#860)`() {
+        val rule = TestRulesetFactory.screenRuleset.ruleById("doordash.screen.dropoff_pre_arrival")!!
+
+        fun addressBlock(buildingName: String) = UiNode(
+            className = "android.view.View",
+            children = listOf(
+                UiNode(className = "android.widget.TextView", text = "Entry code"),
+                UiNode(className = "android.widget.TextView", text = "#1234"),
+                UiNode(className = "android.widget.TextView", text = "Apt/Suite"),
+                UiNode(className = "android.widget.TextView", text = "704"),
+                UiNode(className = "android.widget.TextView", text = "Building Name"),
+                UiNode(className = "android.widget.TextView", text = buildingName),
+                // Over-match guard: an id-less free-text node that is NOT preceded by
+                // the label must survive untouched.
+                UiNode(className = "android.widget.TextView", text = "Leave it at the door"),
+            ),
+        ).restoreParents()
+
+        val masked = serialize(rule.redact.apply(addressBlock("Maple Court Apartments ")))
+
+        assertFalse("building name must not persist", masked.contains("Maple Court Apartments"))
+        assertTrue(
+            "the label is app chrome and stays raw",
+            masked.contains("Building Name"),
+        )
+        assertTrue(
+            "the building-name value masks to the hash family [redacted:<4hex>]",
+            Regex("""\[redacted:[0-9a-f]{4}]""").containsMatchIn(masked),
+        )
+        assertTrue(
+            "over-match guard: an unlabeled sibling stays raw",
+            masked.contains("Leave it at the door"),
+        )
+
+        // Distinctness (#623): two different complexes must not collide on one mask.
+        // Isolated label/value pair so the only masked node in the tree IS the value.
+        fun hexOf(name: String): String {
+            val pair = UiNode(
+                className = "android.view.View",
+                children = listOf(
+                    UiNode(className = "android.widget.TextView", text = "Building Name"),
+                    UiNode(className = "android.widget.TextView", text = name),
+                ),
+            ).restoreParents()
+            val value = rule.redact.apply(pair).children[1].text!!
+            return Regex("""^\[redacted:([0-9a-f]{4})]$""").find(value)?.groupValues?.get(1)
+                ?: error("Building Name value was not masked; got '$value'")
+        }
+        assertFalse(
+            "different building names must redact to different suffixes",
+            hexOf("Maple Court Apartments") == hexOf("Cedar Ridge Villas"),
+        )
+    }
+
     @Test
     fun `every For-family redact masks the fused customer header, keeps the For marker (#809)`() {
         // #809: the four pickup "For <customer> • <store>" surfaces each ship a

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -201,11 +201,21 @@ class CaptureRedactionCorpusTest {
      * that capture is reproduced here — the label is app chrome, and every value below
      * is invented.
      *
-     * Teeth: deleting the rule's Building-Name redact entry turns this RED.
+     * Covers BOTH rules that render this workflow sheet: `dropoff_pre_arrival` (the
+     * fielded ground truth) and `dropoff_pre_arrival_completion`, which is the SAME
+     * sheet one CTA-state later and carries the same id-less label/value rows. No
+     * committed corpus fixture carries a `Building Name` row for either, so the shape
+     * is asserted directly rather than through a fixture; the completion rule's entry
+     * is shape-inherited from the pre-arrival capture.
+     *
+     * Teeth: deleting either rule's Building-Name redact entry turns this RED.
      */
     @Test
-    fun `dropoff_pre_arrival redact masks the Building Name value, keeps the label (#860)`() {
-        val rule = TestRulesetFactory.screenRuleset.ruleById("doordash.screen.dropoff_pre_arrival")!!
+    fun `dropoff workflow-sheet redacts mask the Building Name value, keep the label (#860)`() {
+        val ruleIds = listOf(
+            "doordash.screen.dropoff_pre_arrival",
+            "doordash.screen.dropoff_pre_arrival_completion",
+        )
 
         fun addressBlock(buildingName: String) = UiNode(
             className = "android.view.View",
@@ -222,40 +232,43 @@ class CaptureRedactionCorpusTest {
             ),
         ).restoreParents()
 
-        val masked = serialize(rule.redact.apply(addressBlock("Maple Court Apartments ")))
+        for (id in ruleIds) {
+            val rule = TestRulesetFactory.screenRuleset.ruleById(id)!!
+            val masked = serialize(rule.redact.apply(addressBlock("Maple Court Apartments ")))
 
-        assertFalse("building name must not persist", masked.contains("Maple Court Apartments"))
-        assertTrue(
-            "the label is app chrome and stays raw",
-            masked.contains("Building Name"),
-        )
-        assertTrue(
-            "the building-name value masks to the hash family [redacted:<4hex>]",
-            Regex("""\[redacted:[0-9a-f]{4}]""").containsMatchIn(masked),
-        )
-        assertTrue(
-            "over-match guard: an unlabeled sibling stays raw",
-            masked.contains("Leave it at the door"),
-        )
+            assertFalse("$id: building name must not persist", masked.contains("Maple Court Apartments"))
+            assertTrue(
+                "$id: the label is app chrome and stays raw",
+                masked.contains("Building Name"),
+            )
+            assertTrue(
+                "$id: the building-name value masks to the hash family [redacted:<4hex>]",
+                Regex("""\[redacted:[0-9a-f]{4}]""").containsMatchIn(masked),
+            )
+            assertTrue(
+                "$id: over-match guard — an unlabeled sibling stays raw",
+                masked.contains("Leave it at the door"),
+            )
 
-        // Distinctness (#623): two different complexes must not collide on one mask.
-        // Isolated label/value pair so the only masked node in the tree IS the value.
-        fun hexOf(name: String): String {
-            val pair = UiNode(
-                className = "android.view.View",
-                children = listOf(
-                    UiNode(className = "android.widget.TextView", text = "Building Name"),
-                    UiNode(className = "android.widget.TextView", text = name),
-                ),
-            ).restoreParents()
-            val value = rule.redact.apply(pair).children[1].text!!
-            return Regex("""^\[redacted:([0-9a-f]{4})]$""").find(value)?.groupValues?.get(1)
-                ?: error("Building Name value was not masked; got '$value'")
+            // Distinctness (#623): two different complexes must not collide on one mask.
+            // Isolated label/value pair so the only masked node in the tree IS the value.
+            fun hexOf(name: String): String {
+                val pair = UiNode(
+                    className = "android.view.View",
+                    children = listOf(
+                        UiNode(className = "android.widget.TextView", text = "Building Name"),
+                        UiNode(className = "android.widget.TextView", text = name),
+                    ),
+                ).restoreParents()
+                val value = rule.redact.apply(pair).children[1].text!!
+                return Regex("""^\[redacted:([0-9a-f]{4})]$""").find(value)?.groupValues?.get(1)
+                    ?: error("$id: Building Name value was not masked; got '$value'")
+            }
+            assertFalse(
+                "$id: different building names must redact to different suffixes",
+                hexOf("Maple Court Apartments") == hexOf("Cedar Ridge Villas"),
+            )
         }
-        assertFalse(
-            "different building names must redact to different suffixes",
-            hexOf("Maple Court Apartments") == hexOf("Cedar Ridge Villas"),
-        )
     }
 
     @Test

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/PredicateCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/PredicateCompiler.kt
@@ -140,6 +140,20 @@ internal object PredicateCompiler {
                 ;{ node -> node.text?.let { str -> regex.containsMatchIn(str) } == true }
             }
 
+            // Matches a node whose IMMEDIATELY PRECEDING sibling's text equals
+            // the value, case-insensitive (#860). The label→value predicate: a
+            // Compose/RN address block renders `<label TextView><value TextView>`
+            // pairs with NO viewId on either node, so a value carrying free-form
+            // PII (an apartment-complex "Building Name") is unreachable by every
+            // other predicate — its own text has no stable shape, and its id is
+            // absent. Anchoring on the LABEL (app chrome, stable vocabulary) is
+            // the only tight way to name it; the label string stays rule DATA, so
+            // this predicate is platform-agnostic (principle 8).
+            "hasPrecedingSiblingText" -> {
+                val s = primOf(value, key).content
+                ;{ node -> precedingSibling(node)?.text?.equals(s, ignoreCase = true) == true }
+            }
+
             // Matches when *any* text node anywhere in this subtree (including
             // the node itself and any descendant's text or contentDescription)
             // equals the value, case-insensitive. Necessary for buttons whose
@@ -329,6 +343,25 @@ internal object PredicateCompiler {
             }
             else -> throw RuleCompileException("Unknown notification predicate key: '$key'")
         }
+    }
+
+    /**
+     * The sibling immediately BEFORE [node], resolved by REFERENTIAL identity
+     * (#860). Deliberately does NOT reuse `UiNode.sibling(-1)`: that helper
+     * resolves the node's index with `List.indexOf`, i.e. structural equality —
+     * so a structurally identical earlier sibling would silently resolve the
+     * WRONG index and the predicate would fail to match, UNDER-masking a PII
+     * node. A privacy control must not depend on structural uniqueness, so this
+     * walks the parent's children by identity. Returns null when the tree has no
+     * parent back-references wired (`restoreParents`, always called by
+     * `AccessibilityNodeMapper` and `UiNodeDto.toDomain`) or the node is first —
+     * fail-closed for recognition, and for redaction a null simply means "no
+     * match here", with the `CustomerTextMarkers` backstop still downstream.
+     */
+    private fun precedingSibling(node: UiNode): UiNode? {
+        val siblings = node.parent?.children ?: return null
+        val idx = siblings.indexOfFirst { it === node }
+        return if (idx > 0) siblings[idx - 1] else null
     }
 
     // -- #293 robustness helpers, predicate-scoped ------------------------------

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
@@ -221,6 +221,36 @@ class RuleCompilerTest {
     }
 
     @Test
+    fun `hasPrecedingSiblingText matches the value node of a label-value pair`() {
+        val pred = RuleCompiler.compileNodePred(json("hasPrecedingSiblingText" to "Building Name"))
+        val label = node(text = "Building Name")
+        val value = node(text = "Maple Court Apartments")
+        val other = node(text = "Leave it at the door")
+        val root = tree(node(text = "Apt/Suite"), node(text = "704"), label, value, other)
+        val kids = root.children
+
+        assertTrue("value node follows the label", pred(kids[3]))
+        assertFalse("the label itself never matches", pred(kids[2]))
+        assertFalse("an unrelated later sibling never matches", pred(kids[4]))
+        assertFalse("a node before the label never matches", pred(kids[1]))
+        // Case-insensitive on the label, like every other text predicate.
+        assertTrue(
+            pred(
+                tree(node(text = "BUILDING NAME"), node(text = "X")).children[1],
+            ),
+        )
+    }
+
+    @Test
+    fun `hasPrecedingSiblingText does not match the first child or a parentless node`() {
+        val pred = RuleCompiler.compileNodePred(json("hasPrecedingSiblingText" to "Building Name"))
+        // First child: no preceding sibling.
+        assertFalse(pred(tree(node(text = "Maple Court Apartments")).children[0]))
+        // Parentless (no restoreParents) — fail-closed, no crash.
+        assertFalse(pred(node(text = "Maple Court Apartments")))
+    }
+
+    @Test
     fun `hasClassNameEndsWith matches class suffix`() {
         val pred = RuleCompiler.compileNodePred(json("hasClassNameEndsWith" to "TextView"))
         assertTrue(pred(node(className = "android.widget.TextView")))

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
@@ -242,6 +242,26 @@ class RuleCompilerTest {
     }
 
     @Test
+    fun `hasPrecedingSiblingText resolves the sibling by reference, not structural equality`() {
+        // #860 teeth: UiNode.equals compares identity FIELDS, not object identity, so
+        // two equal-but-distinct siblings are `==`. A List.indexOf-based lookup would
+        // resolve BOTH to the first one's index — the node actually following the label
+        // would then read the wrong predecessor and silently fail to mask (an UNDER-mask
+        // on a privacy control). The compiler walks by reference (`it === node`) for
+        // exactly this shape; swapping it back to indexOf turns this test RED.
+        val pred = RuleCompiler.compileNodePred(json("hasPrecedingSiblingText" to "Building Name"))
+        val first = node(text = "Maple Court Apartments")
+        val second = node(text = "Maple Court Apartments")
+        assertTrue("precondition: the two nodes are structurally equal", first == second)
+        assertFalse("precondition: but distinct instances", first === second)
+
+        val kids = tree(first, node(text = "Building Name"), second).children
+
+        assertTrue("the node that actually follows the label matches", pred(kids[2]))
+        assertFalse("its structural twin, which does NOT follow the label, must not", pred(kids[0]))
+    }
+
+    @Test
     fun `hasPrecedingSiblingText does not match the first child or a parentless node`() {
         val pred = RuleCompiler.compileNodePred(json("hasPrecedingSiblingText" to "Building Name"))
         // First child: no preceding sibling.

--- a/docs/adr/ADR-0001-matcher-rule-format.md
+++ b/docs/adr/ADR-0001-matcher-rule-format.md
@@ -372,6 +372,7 @@ with `all`/`any`/`not` at the node level. Every predicate object carries exactly
 | `{ hasTextContaining: "s" }`             | `text` contains `s` (case-insensitive)                                   | `.contains("s", ignoreCase=true)`   |
 | `{ hasTextStartsWith: "s" }`             | `text` starts with `s` (case-insensitive)                                | `.startsWith("s", ignoreCase=true)` |
 | `{ hasTextMatchesRegex: "p" }`           | `text` matches regex pattern `p` (bounded — max 200 chars, #418)         | `Regex(p).containsMatchIn(text)`    |
+| `{ hasPrecedingSiblingText: "s" }`       | The node's IMMEDIATELY PRECEDING sibling's `text` equals `s` (case-insensitive) — the label→value predicate for id-less `<label><value>` pairs (#860); resolved by referential identity, so a structural twin can't shift the index | `node.parent.children[idx-1].text.equals(s, ignoreCase=true)` |
 | `{ hasAnyText: "s" }`                    | Some text anywhere in this subtree (node or any descendant's text/contentDescription) equals `s` (case-insensitive) — for buttons whose visible label lives in a nested child | `node.allText.any { it.equals(s, ignoreCase=true) }` |
 | `{ hasDesc: "s" }`                       | `contentDescription` equals `s` (case-insensitive)                       | `.equals("s", ignoreCase=true)`     |
 | `{ hasDescContaining: "s" }`             | `contentDescription` contains `s` (case-insensitive)                     | `.contains("s", ignoreCase=true)`   |

--- a/docs/rules.schema.json
+++ b/docs/rules.schema.json
@@ -1390,6 +1390,10 @@
           "properties": { "hasAnyText": { "type": "string", "description": "Some text anywhere in this subtree (this node or any descendant's text/contentDescription) equals this value, case-insensitive — for buttons whose visible label lives in a nested child node." } }
         },
         {
+          "required": ["hasPrecedingSiblingText"],
+          "properties": { "hasPrecedingSiblingText": { "type": "string", "description": "The IMMEDIATELY PRECEDING sibling's text equals this value, case-insensitive (#860). The label→value predicate for id-less `<label><value>` pairs (an address block's 'Building Name' row): anchors on the stable app-chrome LABEL to name a value node that has no id and no stable text shape. Requires parent back-references (always wired in production)." } }
+        },
+        {
           "required": ["hasTextCaseSensitive"],
           "properties": { "hasTextCaseSensitive": { "type": "string", "description": "Exact text match (case-sensitive)." } }
         },

--- a/matchers/rules/doordash/dropoff.json5
+++ b/matchers/rules/doordash/dropoff.json5
@@ -666,6 +666,12 @@
           ]
         },
         {
+          "comment": "#860: the address block's 'Building Name' VALUE — an apartment-complex or building label (free-form proper-noun text, sometimes a bare building number) is customer-locating PII, and it was the ONE labeled field in this block shipping raw: street/city/zip fall to the id-less numeric shapes below, 'Entry code'/'Apt/Suite' values to the `^#?\\s?\\d{1,4}[A-Za-z]?$` entry, the instruction body to the dasher_instruction_* ids — but a building name has no id, no digits, and no stable text shape, so nothing named it. Anchored on the LABEL sibling (app chrome, not customer data), which is the only tight handle; the label node itself is NOT redacted (a label is vocabulary, not PII). Hash-mask family (no plainMask): a building name is a large, unbounded space, so the <4hex> distinctness suffix is not brute-recoverable and it buys per-complex replay fidelity. No `normalize` — that canonicalizer is the customer-NAME key and would degrade an address-class token's mask distinctness.",
+          "find": {
+            "hasPrecedingSiblingText": "Building Name"
+          }
+        },
+        {
           "find": {
             "hasIdSuffix": "dasher_instruction_content_collapsed"
           }

--- a/matchers/rules/doordash/dropoff.json5
+++ b/matchers/rules/doordash/dropoff.json5
@@ -1024,6 +1024,12 @@
               }
             ]
           }
+        },
+        {
+          "comment": "#860: same address-block 'Building Name' VALUE as dropoff_pre_arrival — this rule renders the SAME workflow sheet one CTA-state later and carries the same id-less label/value rows, so it inherits the same gap: free-form proper-noun text the digit-shape entries above structurally cannot reach. Predicate and rationale identical to the pre-arrival entry (label-anchored, hash-mask, no plainMask/normalize). Inert when the row is absent — over-redaction is the only failure direction.",
+          "find": {
+            "hasPrecedingSiblingText": "Building Name"
+          }
         }
       ],
       "state": {


### PR DESCRIPTION
Closes #860.

## What changed

The recognized `doordash.screen.dropoff_pre_arrival` envelope already masked street, city/zip, `Entry code`, `Apt/Suite` and the instruction body — but shipped the address block's **`Building Name` VALUE raw**. An apartment-complex name is customer-locating PII, so a *recognized* capture was persisting it to disk (a #598 Pledge gap, not an UNKNOWN-frame residual).

**Why nothing caught it.** That row is an id-less `<label TextView><value TextView>` sibling pair inside a Compose/RN address block with no viewIds anywhere. Its siblings are masked *incidentally*: the `Entry code` / `Apt/Suite` values by the id-less `^#?\s?\d{1,4}[A-Za-z]?$` entry, street/zip by `^\d{1,5}\s+\S` / `\d{5}`, the instruction body by the `dasher_instruction_*` ids. A building name has **no id, no digits and no stable text shape**, so no predicate could name it — and `CustomerTextMarkers` has no marker prefix on this surface, so the rules-independent backstop is structurally blind to it too. It was the one labeled field in the block with no control at all.

**Three pieces:**

1. **New node predicate `hasPrecedingSiblingText`** (`PredicateCompiler`, + `docs/rules.schema.json`, + the ADR-0001 predicate table) — the label→value predicate. It anchors on the **LABEL** (app chrome, stable vocabulary) to name a value node nothing else can reach. Deliberately resolved by **referential identity**, not by reusing `UiNode.sibling(-1)`: that helper resolves the index with `List.indexOf` (structural equality), so a structurally identical earlier sibling would resolve the *wrong* index and the predicate would silently **under-mask** a PII node — unacceptable direction for a privacy control. Parentless / first-child both return "no match" (fail-closed, no crash).
2. **One redact entry** on `doordash.screen.dropoff_pre_arrival`: `{ find: { hasPrecedingSiblingText: "Building Name" } }`. Hash-mask family (no `plainMask`: a building name is a large, unbounded space, so the `<4hex>` distinctness suffix is not brute-recoverable and it buys per-complex replay fidelity; no `normalize`: that canonicalizer is the customer-NAME key and would degrade an address-class token's mask distinctness). The **label node itself is not redacted** — a label is vocabulary, not PII.
3. **Tests with teeth** (both mutation-verified — see below).

## Ground truth

Confirmed against three real 2026-07-23 device captures in the 07-25 pull (`dropoff_pre_arrival`, incl. `…__cb7c26.json`): a parent `android.view.View` with six id-less TextViews in `Entry code` / value / `Apt/Suite` / value / `Building Name` / value order. In those captures the first two values were already `[redacted:xxxx]` and the building name was verbatim — exactly the reported leak.

## Tests — red→green verified

- `CaptureRedactionCorpusTest.dropoff_pre_arrival redact masks the Building Name value, keeps the label (#860)` — runs the **production** compiled redact over a tree mirroring the captured node shape and asserts: the value does not persist; it masks to `[redacted:<4hex>]`; the `Building Name` label survives; an unlabeled id-less free-text sibling survives (over-match guard); two different complexes produce **different** suffixes (#623 distinctness).
- `RuleCompilerTest` (×2, `:core:pipeline`) — predicate semantics: matches the value node only, never the label, never an unrelated sibling, never a node *before* the label; case-insensitive on the label; first-child and parentless nodes fail closed.

**Mutation check (verified, not asserted):** deleting the new redact entry from `dropoff.json5` and re-running turns `CaptureRedactionCorpusTest` **RED** (`dropoff_pre_arrival redact masks the Building Name value… FAILED`); restoring it returns **GREEN**.

Suites run (`JAVA_HOME=java-25`): `:app:testDebugUnitTest --tests "*AllMatchersSuite*"` ✅ and `:core:pipeline:testDebugUnitTest` ✅ (both re-run with `--rerun` after a transient JVM `SIGSEGV` in a Gradle test worker — `klassVtable::adjust_method_entries`, an environment flake, crash log deleted, not committed).

`ParseOutputGoldenTest` is **unchanged, no regeneration** — redaction is envelope-only and this PR adds no corpus.

## Security / privacy posture (Pledge surface)

- **Now masked:** the dropoff address block's `Building Name` value, on the *recognized* screen path, at the capture edge before the envelope hits disk. Mask is the standard `[redacted:<4hex>]` (first 4 hex of `sha256` of the trimmed token), fail-closed to plain `[redacted]`.
- **Still kept raw (by design):** the `Building Name` **label** (app chrome), merchant/store names (driver-owned), and every non-adjacent node — the predicate is exact-label + immediate-adjacency, the tightest possible handle.
- **Trust boundary:** unchanged. The new predicate reads only the already-mapped, already-bounded `UiNode` tree; it introduces no regex, no new ingestion, no unbounded traversal (one parent-children scan), and no network. It is compile-checked by the existing single-key predicate contract, so a malformed/unknown-key rule still fails load.
- **Direction of failure:** under-mask is the only harmful direction, and the identity-resolved sibling lookup exists specifically to remove the one shape (a structural twin) that could cause it. A tree without parent back-references simply doesn't match, and the `CustomerTextMarkers` backstop remains downstream.
- **No raw tokens in the repo:** nothing from the device captures is reproduced anywhere in this diff. Every value in the tests is invented (`Maple Court Apartments`, `Cedar Ridge Villas`, `#1234`, `704`); the only real strings are the app's own labels (`Building Name`, `Entry code`, `Apt/Suite`, `Leave it at the door`), which are DoorDash chrome, not customer data. **Self-caught during authoring:** an earlier local commit briefly contained a captured building name inside a rule `comment` — the same PR #800 class this PR exists to prevent. It was amended away **before the PR was opened**; the branch's current history is clean (verified by grep over the full diff and commits). The pre-amend object survives as an unreachable object on the remote — acknowledged residual, no live ref points at it.

### Adversarial review

Fable adversarial review returned **APPROVE-WITH-FIXES**. All three findings applied on-branch in a follow-up commit:

- **F1 (MED — test teeth).** The referential-identity resolution in `precedingSibling` (the whole reason it avoids `UiNode.sibling(-1)`) was exercised by **no** test: every node in the trees was structurally distinct, so a refactor back to `indexOf` would have stayed green while silently reintroducing the under-mask. Added `RuleCompilerTest.hasPrecedingSiblingText resolves the sibling by reference, not structural equality` — two equal-but-distinct instances around the label, asserting the one that *actually* follows it matches and its twin does not. **Mutation-verified:** swapping `indexOfFirst { it === node }` → `indexOf(node)` turns exactly that test RED (`hasPrecedingSiblingText resolves the sibling by reference, not structural equality FAILED`); restored → green.
- **F2 (MED — live gap).** `doordash.screen.dropoff_pre_arrival_completion` renders the **same** workflow sheet one CTA-state later with the same id-less label/value rows and the same digit-shape redacts, but had no Building Name entry — the identical leak. Copied the entry there with a comment pointing at #860. **No committed corpus fixture carries a `Building Name` row for either rule**, so the corpus test is now parametrized over **both** rule ids and asserts the shape directly; the completion rule's entry is shape-inherited from the pre-arrival ground truth. Inert when the row is absent — over-redaction is the only failure direction.
- **F3 (LOW).** Removed the pre-amend/post-amend SHA pair from the privacy note above (the pre-amend object is still retrievable by full SHA via the API, and the body was handing out the pointer). Disclosure prose kept.

## Deviations from the plan

- **No new corpus fixture.** The plan allowed creating one from the `cb7c26` capture if no committed fixture carried a `Building Name`; none does. I declined for three reasons: (a) importing a 112 KB real frame is exactly the PR #800 sanitization hazard the plan warns about, for a row that adds **zero** recognition signal (nine `dropoff_pre_arrival` fixtures already cover this layout); (b) a new corpus file would force an `approved-parse-output.json` regeneration, which the plan explicitly said should not happen; (c) the redact predicate is per-node, so a faithfully reconstructed label/value pair exercises it identically — this is the same "inject a synthetic PII node onto the real shape" pattern the existing `#624` / `#809` cases in this very test class already use. The captured node shape is documented in the test KDoc so the fidelity claim is auditable.
- **The plan assumed the sibling fields had a mirrorable predicate shape.** They don't — `Entry code` and `Apt/Suite` are masked *incidentally* by digit-shape regexes, not by any label association. There was no existing mechanism to name a label-anchored value, which is why this PR adds one predicate rather than only a rule entry.
- ~~**Scope held** — `dropoff_pre_arrival_completion` left untouched per "one rule".~~ **Superseded by review finding F2:** the completion rule now carries the same redact entry (it was the identical live gap, not a hypothetical one).

### Design-goal review

- **P5 (SSOT).** One redact SSOT extended — the rule's own `redact` block — not a second masking path. The new predicate joins the single node-predicate vocabulary shared by `require`/`bind`/`redact`, so there is still exactly one predicate compiler. The one deliberate non-reuse (`UiNode.sibling(-1)`) is documented in code with its reason; it is a *stricter* resolution for a privacy control at a single call site, not a duplicated definition.
- **P6 (Security & privacy first).** The point of the PR: closes a raw-customer-PII-to-disk leak on a recognized surface, at the edge, fail-closed. Posture stated in full above.
- **P8 (Platform-agnostic core).** The predicate is **structural** — no platform literal, no package, no wire string, no `when` on `Platform`. The label `"Building Name"` lives in the DoorDash ruleset as **data**; any platform with a label/value block can use the same predicate. Adding it required zero `:core:state` edits.
- **P3 (Single responsibility).** ~33 lines in `PredicateCompiler` (one `when` arm + one private helper); no file grew meaningfully.
- **P4 (Kotlin/Android practices).** Matches the surrounding compiler style; case-insensitive comparison like every sibling text predicate; null-safe throughout.
- **P2 (MAD), P1 (UDF), P7 (logging), Reactive UI** — untouched by this diff (no UI, no reducer, no new log site).

## Field validation

Desk-only change; on-dash confirmation is: the next pull's `dropoff_pre_arrival` capture envelopes show the `Building Name` row as `Building Name` followed by `[redacted:<4hex>]` instead of the complex name. A checklist item for `docs/field-testing/README.md` is intentionally **not** added here — the coordinator batches those.
