### PR TITLE
fix(rules): #857 uber.screen.idle_map requires positive offline evidence

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/UberIdleMapOfflineEvidenceTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/UberIdleMapOfflineEvidenceTest.kt
@@ -1,0 +1,94 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.test.util.SnapshotSecurityScanner
+import cloud.trotter.dashbuddy.test.util.TestResourceLoader
+import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+/**
+ * Negative guard for `uber.screen.idle_map` (#857).
+ *
+ * The rule claims `modeHint: offline`, and a false offline claim is destructive: it arms
+ * the `SESSION_END` grace, and with the dasher multi-apping in the other platform no Uber
+ * frame arrives to contradict it, so the grace commits and a live dash is split into two
+ * `session_records` — permanently, since the read model is a faithful refold of the log.
+ * Measured over the 2026-07-25 pull: 20 of 27 Online→Offline edges fired on frames with no
+ * offline evidence, 6 of which destroyed a real session (7 real toggles → 13 sessions).
+ *
+ * The cause was a claim from ABSENCE: `home_screen_overlay_container` exists (present online
+ * AND offline) plus `notExists` of the online labels. Every fixture in
+ * `fixtures/uber_idle_map_partial/` is a real capture of a **partially rendered** Uber home
+ * that satisfied that shape vacuously — the status sheet not inflated, the label subtree
+ * missing, the label mid-refresh reading "Loading…", and (worst) a 115-node tree with zero
+ * text nodes at all. None of them is evidence of anything.
+ *
+ * The rule now requires POSITIVE offline evidence, so these must classify UNKNOWN — no
+ * observation reaches the state machine and the platform region keeps its last known mode
+ * until a settled frame or the (already recognized) `uber.click.go_offline` arrives. The
+ * corresponding positive half lives in the golden corpus: the two `snapshots/idle_map/
+ * *__uber__*` captures, guarded by [cloud.trotter.dashbuddy.core.pipeline.recognition.matchers.GoldenSnapshotRegressionTest].
+ */
+@RunWith(Parameterized::class)
+class UberIdleMapOfflineEvidenceTest(
+    private val filename: String,
+    private val node: UiNode,
+) {
+
+    companion object {
+        private const val FIXTURES = "fixtures/uber_idle_map_partial"
+
+        private val screenRuleset: Ruleset<UiNode> by lazy { TestRulesetFactory.screenRuleset }
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun data(): Collection<Array<Any>> {
+            val loaded = TestResourceLoader.loadSnapshots(FIXTURES)
+            assertTrue("fixtures/$FIXTURES must not be empty", loaded.isNotEmpty())
+            return loaded.map { (filename, node, _) -> arrayOf(filename, node) }
+        }
+
+        private fun hasContainer(node: UiNode): Boolean =
+            node.viewIdResourceName?.endsWith("home_screen_overlay_container", ignoreCase = true) == true ||
+                node.children.any(::hasContainer)
+    }
+
+    /**
+     * Pins that each fixture really is an instance of the bug's precondition — it carries the
+     * container the old rule anchored on. Without this the UNKNOWN assertion below could pass
+     * on any unrelated tree and the regression would be untested.
+     */
+    @Test
+    fun `fixture carries the home overlay container the absence-claim anchored on`() {
+        assertTrue(
+            "$filename no longer carries home_screen_overlay_container — it is not a #857 " +
+                "specimen any more; replace it with a real partial-render capture",
+            hasContainer(node),
+        )
+    }
+
+    @Test
+    fun `partially rendered uber home makes no offline claim`() {
+        val intent = screenRuleset.matchFirst(node)?.intent ?: "UNKNOWN"
+        assertEquals(
+            "$filename classified '$intent' — a partially rendered Uber home carries no offline " +
+                "evidence, so claiming one forges an Online→Offline edge (#857)",
+            "UNKNOWN",
+            intent,
+        )
+    }
+
+    /** These are chrome/map frames; they are committed corpus, so hold them to the same bar. */
+    @Test
+    fun `fixture carries no dasher-sensitive content`() {
+        assertFalse(
+            "$filename tripped the security scanner — redact or drop it",
+            SnapshotSecurityScanner.scan(node).isToxic,
+        )
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatchersSuite.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatchersSuite.kt
@@ -13,6 +13,7 @@ import cloud.trotter.dashbuddy.core.pipeline.rules.NotificationRulesetTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.ParseOutputGoldenTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.ScreenRulesetTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.TriageRulesTest
+import cloud.trotter.dashbuddy.core.pipeline.rules.UberIdleMapOfflineEvidenceTest
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
 
@@ -51,6 +52,9 @@ import org.junit.runners.Suite
  *   anchor across ALL platforms' generated assets is independently caught by the rules-INDEPENDENT
  *   [cloud.trotter.dashbuddy.core.pipeline.SensitiveTextMarkers] backstop (a documented,
  *   shrink-only ledger excuses pre-existing DoorDash debt out of D10's Uber scope).
+ * - [UberIdleMapOfflineEvidenceTest] — #857 negative guard: real partially-rendered Uber
+ *   home captures (`fixtures/uber_idle_map_partial/`) must classify UNKNOWN, so
+ *   `uber.screen.idle_map` can never claim `modeHint: offline` from absence again.
  * - [OfferPipelineTest] — Layer 2 (#105): a real `offer_popup/` snapshot through the SAME
  *   production ruleset, feeding the recognized `ParsedOffer` into `OfferEvaluator` and pinning the
  *   resulting `OfferEvaluation` — proves the recognition→parse→evaluate wiring, not just the
@@ -66,6 +70,7 @@ import org.junit.runners.Suite
     ClickRulesetTest::class,
     NotificationRulesetTest::class,
     TriageRulesTest::class,
+    UberIdleMapOfflineEvidenceTest::class,
     DefaultRulesIntegrationTest::class,
     NotificationClassifierTest::class,
     ClickClassifierTest::class,

--- a/app/src/test/resources/fixtures/uber_idle_map_partial/2026-07-23_19-35-44-857__uber__accessibility.window__idle_map__4571c6.json
+++ b/app/src/test/resources/fixtures/uber_idle_map_partial/2026-07-23_19-35-44-857__uber__accessibility.window__idle_map__4571c6.json
@@ -1,0 +1,2494 @@
+{
+    "captureId": "b761862c-95bc-4363-8f05-5bad11d1109f",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784853344836,
+    "platform": "uber",
+    "ruleId": "uber.screen.idle_map",
+    "classificationName": "idle_map",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/glide_screen_stack_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/glide_active_view_container",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 0
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/active_container",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/background_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/screen_stack_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/ub__top_banner_container",
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 0
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/bottom_sheet_container",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 2169,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant",
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2169,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_offline_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_overlay_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_background_view",
+                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 2169,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "Unable to go offline",
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_overlay_text",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 2169,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_online_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_padding_container",
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_chevron",
+                                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 53,
+                                                                                                                                                                                                    "top": 2231,
+                                                                                                                                                                                                    "right": 106,
+                                                                                                                                                                                                    "bottom": 2284
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 159,
+                                                                                                                                                                                                    "top": 2169,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2347
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "Recommended for you",
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_content_override",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 159,
+                                                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                            "bottom": 2347
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_content",
+                                                                                                                                                                                                        "class": "android.widget.RelativeLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 159,
+                                                                                                                                                                                                            "top": 2196,
+                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                            "bottom": 2320
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "text": "Loading…",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_label_leading",
+                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 159,
+                                                                                                                                                                                                                    "top": 2196,
+                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                    "bottom": 2267
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/key_info_container",
+                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 159,
+                                                                                                                                                                                                                    "top": 2267,
+                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                    "bottom": 2320
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2400,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2402,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 4486,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/home_screen_overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 0,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 0,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 0,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            },
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 353
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_left_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 36,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 143,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "desc": "Home",
+                                                                                                                                                                                "id": "com.ubercab.driver:id/profile_entry",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_icon",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_photo",
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/earnings_tracker_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 261,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 819,
+                                                                                                                                                                            "bottom": 353
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                    "bottom": 353
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__tracker_entry_content_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                            "bottom": 353
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                    "bottom": 353
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_entry_public_mode_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                            "bottom": 353
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__earnings_tracker_indicator_card",
+                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                                    "top": 149,
+                                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                                    "bottom": 229
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                        "text": "$0.00",
+                                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_counter_content_status",
+                                                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                            "left": 457,
+                                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                                            "right": 623,
+                                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 431,
+                                                                                                                                                                                                                    "top": 243,
+                                                                                                                                                                                                                    "right": 648,
+                                                                                                                                                                                                                    "bottom": 353
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__tracker_entry_public_label_container",
+                                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 449,
+                                                                                                                                                                                                                            "top": 261,
+                                                                                                                                                                                                                            "right": 630,
+                                                                                                                                                                                                                            "bottom": 335
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "text": "TODAY",
+                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__earnings_tracker_label_text",
+                                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 467,
+                                                                                                                                                                                                                                    "top": 270,
+                                                                                                                                                                                                                                    "right": 612,
+                                                                                                                                                                                                                                    "bottom": 326
+                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/my_hub_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 937,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "desc": "Search for places",
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/search_entry_button",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 937,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_center_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 540,
+                                                                                                                                                                            "top": 353,
+                                                                                                                                                                            "right": 540,
+                                                                                                                                                                            "bottom": 353
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_container",
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 136
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_view",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_control_top_right_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 1044,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 172
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_left_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2016,
+                                                                                                                                                                                    "right": 179,
+                                                                                                                                                                                    "bottom": 2355
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_safety_toolkit_container",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 18,
+                                                                                                                                                                                            "top": 2034,
+                                                                                                                                                                                            "right": 161,
+                                                                                                                                                                                            "bottom": 2177
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                    "top": 2052,
+                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                    "bottom": 2159
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__safety_toolkit_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                            "top": 2052,
+                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                            "bottom": 2159
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Safety Toolkit",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__safety_toolkit_button_container",
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                                    "top": 2052,
+                                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                                    "bottom": 2159
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__shield_animation_view",
+                                                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                                            "top": 2052,
+                                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                                            "bottom": 2159
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_container",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 901,
+                                                                                                                                                                                    "top": 1873,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2373
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                            "top": 1891,
+                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                            "bottom": 2195
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_ugc_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 1891,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 2034
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__ugc_map_button",
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 1891,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 2034
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Report a map issue",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__ugc_map_button_icon",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 1909,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 2016
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_earnings_trends_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 2034,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 2177
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 2034,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 2177
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Earnings Trends",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/map_control_earnings_trends",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 2052,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 2159
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_bottom_right_buttons",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 1062,
+                                                                                                                                                                                                    "top": 2177,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 2195
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_nav_button_layout",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 1062,
+                                                                                                                                                                                                            "top": 2177,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 2177
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 299,
+                                                                                                                                            "top": 3598,
+                                                                                                                                            "right": 709,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "La Siberia De Monterrey Mexican Bar And Grill",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 299,
+                                                                                                                                                    "top": 3598,
+                                                                                                                                                    "right": 709,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 614,
+                                                                                                                                            "top": 3429,
+                                                                                                                                            "right": 1024,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Capparelli's Italian Food & Pizza",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 614,
+                                                                                                                                                    "top": 3429,
+                                                                                                                                                    "right": 1024,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 215,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 268,
+                                                                                                                                            "bottom": -291
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 215,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 268,
+                                                                                                                                                    "bottom": -291
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 228,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 255,
+                                                                                                                                                            "bottom": -304
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 237,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 246,
+                                                                                                                                                    "bottom": -294
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1676,
+                                                                                                                                            "right": -945,
+                                                                                                                                            "bottom": 1729
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 1676,
+                                                                                                                                                    "right": -945,
+                                                                                                                                                    "bottom": 1729
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 1689,
+                                                                                                                                                            "right": -958,
+                                                                                                                                                            "bottom": 1716
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 1726,
+                                                                                                                                                    "right": -967,
+                                                                                                                                                    "bottom": 1726
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 8,
+                                                                                                                                            "top": 495,
+                                                                                                                                            "right": 61,
+                                                                                                                                            "bottom": 548
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 6,
+                                                                                                                                                    "top": 492,
+                                                                                                                                                    "right": 59,
+                                                                                                                                                    "bottom": 545
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 21,
+                                                                                                                                                            "top": 508,
+                                                                                                                                                            "right": 48,
+                                                                                                                                                            "bottom": 535
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 30,
+                                                                                                                                                    "top": 545,
+                                                                                                                                                    "right": 39,
+                                                                                                                                                    "bottom": 545
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 173,
+                                                                                                                                            "right": -992,
+                                                                                                                                            "bottom": 226
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 173,
+                                                                                                                                                    "right": -992,
+                                                                                                                                                    "bottom": 226
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 186,
+                                                                                                                                                            "right": -1005,
+                                                                                                                                                            "bottom": 213
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 223,
+                                                                                                                                                    "right": -1014,
+                                                                                                                                                    "bottom": 223
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1080,
+                                                                                                                                            "top": 2543,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1092,
+                                                                                                                                                    "top": 2569,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1105,
+                                                                                                                                                            "top": 2582,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1124,
+                                                                                                                                                    "top": 2642,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 873,
+                                                                                                                                            "top": 1629,
+                                                                                                                                            "right": 926,
+                                                                                                                                            "bottom": 1682
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 873,
+                                                                                                                                                    "top": 1629,
+                                                                                                                                                    "right": 926,
+                                                                                                                                                    "bottom": 1682
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 886,
+                                                                                                                                                            "top": 1642,
+                                                                                                                                                            "right": 913,
+                                                                                                                                                            "bottom": 1669
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 895,
+                                                                                                                                                    "top": 1679,
+                                                                                                                                                    "right": 904,
+                                                                                                                                                    "bottom": 1679
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1194,
+                                                                                                                                            "top": 1592,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1645
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1194,
+                                                                                                                                                    "top": 1592,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1645
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1207,
+                                                                                                                                                            "top": 1605,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 1632
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1216,
+                                                                                                                                                    "top": 1642,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1642
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1295,
+                                                                                                                                            "top": 1123,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1176
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1295,
+                                                                                                                                                    "top": 1123,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1176
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1308,
+                                                                                                                                                            "top": 1136,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 1163
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1317,
+                                                                                                                                                    "top": 1173,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1173
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 822,
+                                                                                                                                            "right": -1322,
+                                                                                                                                            "bottom": 875
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 812,
+                                                                                                                                                    "right": -1361,
+                                                                                                                                                    "bottom": 865
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 835,
+                                                                                                                                                            "right": -1335,
+                                                                                                                                                            "bottom": 862
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 872,
+                                                                                                                                                    "right": -1344,
+                                                                                                                                                    "bottom": 872
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 2535,
+                                                                                                                                            "right": -654,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 2585,
+                                                                                                                                                    "right": -676,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1094,
+                                                                                                                                            "top": 1048,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1101
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1098,
+                                                                                                                                                    "top": 1046,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1099
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1107,
+                                                                                                                                                            "top": 1061,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 1088
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1116,
+                                                                                                                                                    "top": 1098,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1098
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1119,
+                                                                                                                                            "top": 1650,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1703
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1122,
+                                                                                                                                                    "top": 1652,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1705
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1132,
+                                                                                                                                                            "top": 1663,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 1690
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1141,
+                                                                                                                                                    "top": 1700,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1700
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1103,
+                                                                                                                                            "top": 2315,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2368
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1103,
+                                                                                                                                                    "top": 2315,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2368
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1116,
+                                                                                                                                                            "top": 2328,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2355
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1125,
+                                                                                                                                                    "top": 2365,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2365
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 430,
+                                                                                                                                            "top": 2251,
+                                                                                                                                            "right": 483,
+                                                                                                                                            "bottom": 2304
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 430,
+                                                                                                                                                    "top": 2251,
+                                                                                                                                                    "right": 483,
+                                                                                                                                                    "bottom": 2304
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 442,
+                                                                                                                                                            "top": 2270,
+                                                                                                                                                            "right": 469,
+                                                                                                                                                            "bottom": 2297
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 451,
+                                                                                                                                                    "top": 2314,
+                                                                                                                                                    "right": 460,
+                                                                                                                                                    "bottom": 2314
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 343,
+                                                                                                                                            "top": 1629,
+                                                                                                                                            "right": 396,
+                                                                                                                                            "bottom": 1682
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 342,
+                                                                                                                                                    "top": 1631,
+                                                                                                                                                    "right": 395,
+                                                                                                                                                    "bottom": 1684
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 355,
+                                                                                                                                                            "top": 1644,
+                                                                                                                                                            "right": 382,
+                                                                                                                                                            "bottom": 1671
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 365,
+                                                                                                                                                    "top": 1679,
+                                                                                                                                                    "right": 374,
+                                                                                                                                                    "bottom": 1679
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 657,
+                                                                                                                                            "top": 1994,
+                                                                                                                                            "right": 710,
+                                                                                                                                            "bottom": 2047
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 658,
+                                                                                                                                                    "top": 1996,
+                                                                                                                                                    "right": 711,
+                                                                                                                                                    "bottom": 2049
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 671,
+                                                                                                                                                            "top": 2009,
+                                                                                                                                                            "right": 698,
+                                                                                                                                                            "bottom": 2036
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 680,
+                                                                                                                                                    "top": 2049,
+                                                                                                                                                    "right": 689,
+                                                                                                                                                    "bottom": 2049
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 413,
+                                                                                                                                            "top": 1590,
+                                                                                                                                            "right": 466,
+                                                                                                                                            "bottom": 1643
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 413,
+                                                                                                                                                    "top": 1591,
+                                                                                                                                                    "right": 466,
+                                                                                                                                                    "bottom": 1644
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 426,
+                                                                                                                                                            "top": 1604,
+                                                                                                                                                            "right": 453,
+                                                                                                                                                            "bottom": 1631
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 435,
+                                                                                                                                                    "top": 1642,
+                                                                                                                                                    "right": 444,
+                                                                                                                                                    "bottom": 1642
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 267,
+                                                                                                                                            "top": 447,
+                                                                                                                                            "right": 320,
+                                                                                                                                            "bottom": 500
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 267,
+                                                                                                                                                    "top": 446,
+                                                                                                                                                    "right": 320,
+                                                                                                                                                    "bottom": 499
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 280,
+                                                                                                                                                            "top": 460,
+                                                                                                                                                            "right": 307,
+                                                                                                                                                            "bottom": 487
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 289,
+                                                                                                                                                    "top": 497,
+                                                                                                                                                    "right": 298,
+                                                                                                                                                    "bottom": 497
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 973,
+                                                                                                                                            "top": 1727,
+                                                                                                                                            "right": 1026,
+                                                                                                                                            "bottom": 1780
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 973,
+                                                                                                                                                    "top": 1727,
+                                                                                                                                                    "right": 1026,
+                                                                                                                                                    "bottom": 1780
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 986,
+                                                                                                                                                            "top": 1740,
+                                                                                                                                                            "right": 1013,
+                                                                                                                                                            "bottom": 1767
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 995,
+                                                                                                                                                    "top": 1777,
+                                                                                                                                                    "right": 1004,
+                                                                                                                                                    "bottom": 1777
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 567,
+                                                                                                                                            "top": 250,
+                                                                                                                                            "right": 620,
+                                                                                                                                            "bottom": 303
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 567,
+                                                                                                                                                    "top": 250,
+                                                                                                                                                    "right": 620,
+                                                                                                                                                    "bottom": 303
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 580,
+                                                                                                                                                            "top": 262,
+                                                                                                                                                            "right": 607,
+                                                                                                                                                            "bottom": 289
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 589,
+                                                                                                                                                    "top": 300,
+                                                                                                                                                    "right": 598,
+                                                                                                                                                    "bottom": 300
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 240,
+                                                                                                                                            "top": 623,
+                                                                                                                                            "right": 293,
+                                                                                                                                            "bottom": 676
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 240,
+                                                                                                                                                    "top": 623,
+                                                                                                                                                    "right": 293,
+                                                                                                                                                    "bottom": 676
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 253,
+                                                                                                                                                            "top": 636,
+                                                                                                                                                            "right": 280,
+                                                                                                                                                            "bottom": 663
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 262,
+                                                                                                                                                    "top": 673,
+                                                                                                                                                    "right": 271,
+                                                                                                                                                    "bottom": 673
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 499,
+                                                                                                                                            "top": 1174,
+                                                                                                                                            "right": 552,
+                                                                                                                                            "bottom": 1227
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 499,
+                                                                                                                                                    "top": 1174,
+                                                                                                                                                    "right": 552,
+                                                                                                                                                    "bottom": 1227
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 512,
+                                                                                                                                                            "top": 1187,
+                                                                                                                                                            "right": 539,
+                                                                                                                                                            "bottom": 1214
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 521,
+                                                                                                                                                    "top": 1224,
+                                                                                                                                                    "right": 530,
+                                                                                                                                                    "bottom": 1224
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 339,
+                                                                                                                                            "top": 2411,
+                                                                                                                                            "right": 392,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 339,
+                                                                                                                                                    "top": 2411,
+                                                                                                                                                    "right": 392,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 352,
+                                                                                                                                                            "top": 2424,
+                                                                                                                                                            "right": 379,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 361,
+                                                                                                                                                    "top": 2461,
+                                                                                                                                                    "right": 370,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 68,
+                                                                                                                                            "top": 1565,
+                                                                                                                                            "right": 104,
+                                                                                                                                            "bottom": 1601
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 906,
+                                                                                                                                            "top": 980,
+                                                                                                                                            "right": 942,
+                                                                                                                                            "bottom": 1016
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 199,
+                                                                                                                                            "top": 2222,
+                                                                                                                                            "right": 235,
+                                                                                                                                            "bottom": 2258
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 713,
+                                                                                                                                            "top": 2008,
+                                                                                                                                            "right": 749,
+                                                                                                                                            "bottom": 2044
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1103,
+                                                                                                                                            "top": 2471,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 985,
+                                                                                                                                            "top": 1634,
+                                                                                                                                            "right": 1021,
+                                                                                                                                            "bottom": 1670
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 586,
+                                                                                                                                            "top": 990,
+                                                                                                                                            "right": 622,
+                                                                                                                                            "bottom": 1026
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/fixtures/uber_idle_map_partial/2026-07-24_19-33-56-577__uber__accessibility.window__idle_map__2c28dc.json
+++ b/app/src/test/resources/fixtures/uber_idle_map_partial/2026-07-24_19-33-56-577__uber__accessibility.window__idle_map__2c28dc.json
@@ -1,0 +1,1415 @@
+{
+    "captureId": "b57f7fe0-c408-4371-b677-bd9116af1871",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784939636565,
+    "platform": "uber",
+    "ruleId": "uber.screen.idle_map",
+    "classificationName": "idle_map",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/glide_screen_stack_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/glide_active_view_container",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 0
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/active_container",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/background_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/screen_stack_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/ub__top_banner_container",
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 0
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/home_screen_overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 0,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 0,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            },
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/bottom_sheet_container",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1154,
+                                                                                                                                            "top": 740,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 793
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1154,
+                                                                                                                                                    "top": 740,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 793
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1167,
+                                                                                                                                                            "top": 753,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 780
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1176,
+                                                                                                                                                    "top": 790,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 790
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 568,
+                                                                                                                                            "top": 866,
+                                                                                                                                            "right": 621,
+                                                                                                                                            "bottom": 919
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 568,
+                                                                                                                                                    "top": 866,
+                                                                                                                                                    "right": 621,
+                                                                                                                                                    "bottom": 919
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 581,
+                                                                                                                                                            "top": 879,
+                                                                                                                                                            "right": 608,
+                                                                                                                                                            "bottom": 906
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 590,
+                                                                                                                                                    "top": 916,
+                                                                                                                                                    "right": 599,
+                                                                                                                                                    "bottom": 916
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1096,
+                                                                                                                                            "top": 2458,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1096,
+                                                                                                                                                    "top": 2458,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1109,
+                                                                                                                                                            "top": 2471,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1118,
+                                                                                                                                                    "top": 2508,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 556,
+                                                                                                                                            "top": 257,
+                                                                                                                                            "right": 609,
+                                                                                                                                            "bottom": 310
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 556,
+                                                                                                                                                    "top": 257,
+                                                                                                                                                    "right": 609,
+                                                                                                                                                    "bottom": 310
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 569,
+                                                                                                                                                            "top": 270,
+                                                                                                                                                            "right": 596,
+                                                                                                                                                            "bottom": 297
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 578,
+                                                                                                                                                    "top": 307,
+                                                                                                                                                    "right": 587,
+                                                                                                                                                    "bottom": 307
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 265,
+                                                                                                                                            "top": 363,
+                                                                                                                                            "right": 318,
+                                                                                                                                            "bottom": 416
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 265,
+                                                                                                                                                    "top": 363,
+                                                                                                                                                    "right": 318,
+                                                                                                                                                    "bottom": 416
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 278,
+                                                                                                                                                            "top": 376,
+                                                                                                                                                            "right": 305,
+                                                                                                                                                            "bottom": 403
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 287,
+                                                                                                                                                    "top": 413,
+                                                                                                                                                    "right": 296,
+                                                                                                                                                    "bottom": 413
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 659,
+                                                                                                                                            "top": 1567,
+                                                                                                                                            "right": 712,
+                                                                                                                                            "bottom": 1620
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 659,
+                                                                                                                                                    "top": 1567,
+                                                                                                                                                    "right": 712,
+                                                                                                                                                    "bottom": 1620
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 672,
+                                                                                                                                                            "top": 1580,
+                                                                                                                                                            "right": 699,
+                                                                                                                                                            "bottom": 1607
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 681,
+                                                                                                                                                    "top": 1617,
+                                                                                                                                                    "right": 690,
+                                                                                                                                                    "bottom": 1617
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 900,
+                                                                                                                                            "top": 901,
+                                                                                                                                            "right": 953,
+                                                                                                                                            "bottom": 954
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 900,
+                                                                                                                                                    "top": 901,
+                                                                                                                                                    "right": 953,
+                                                                                                                                                    "bottom": 954
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 913,
+                                                                                                                                                            "top": 914,
+                                                                                                                                                            "right": 940,
+                                                                                                                                                            "bottom": 941
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 922,
+                                                                                                                                                    "top": 951,
+                                                                                                                                                    "right": 931,
+                                                                                                                                                    "bottom": 951
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 425,
+                                                                                                                                            "top": 2257,
+                                                                                                                                            "right": 478,
+                                                                                                                                            "bottom": 2310
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 425,
+                                                                                                                                                    "top": 2257,
+                                                                                                                                                    "right": 478,
+                                                                                                                                                    "bottom": 2310
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 438,
+                                                                                                                                                            "top": 2270,
+                                                                                                                                                            "right": 465,
+                                                                                                                                                            "bottom": 2297
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 447,
+                                                                                                                                                    "top": 2307,
+                                                                                                                                                    "right": 456,
+                                                                                                                                                    "bottom": 2307
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 138,
+                                                                                                                                            "top": 1416,
+                                                                                                                                            "right": 191,
+                                                                                                                                            "bottom": 1469
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 138,
+                                                                                                                                                    "top": 1416,
+                                                                                                                                                    "right": 191,
+                                                                                                                                                    "bottom": 1469
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 151,
+                                                                                                                                                            "top": 1429,
+                                                                                                                                                            "right": 178,
+                                                                                                                                                            "bottom": 1456
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 160,
+                                                                                                                                                    "top": 1466,
+                                                                                                                                                    "right": 169,
+                                                                                                                                                    "bottom": 1466
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 365,
+                                                                                                                                            "top": 1461,
+                                                                                                                                            "right": 418,
+                                                                                                                                            "bottom": 1514
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 365,
+                                                                                                                                                    "top": 1461,
+                                                                                                                                                    "right": 418,
+                                                                                                                                                    "bottom": 1514
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 378,
+                                                                                                                                                            "top": 1474,
+                                                                                                                                                            "right": 405,
+                                                                                                                                                            "bottom": 1501
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 387,
+                                                                                                                                                    "top": 1511,
+                                                                                                                                                    "right": 396,
+                                                                                                                                                    "bottom": 1511
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 711,
+                                                                                                                                            "top": 423,
+                                                                                                                                            "right": 764,
+                                                                                                                                            "bottom": 476
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 711,
+                                                                                                                                                    "top": 423,
+                                                                                                                                                    "right": 764,
+                                                                                                                                                    "bottom": 476
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 724,
+                                                                                                                                                            "top": 436,
+                                                                                                                                                            "right": 751,
+                                                                                                                                                            "bottom": 463
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 733,
+                                                                                                                                                    "top": 473,
+                                                                                                                                                    "right": 742,
+                                                                                                                                                    "bottom": 473
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 549,
+                                                                                                                                            "top": 1826,
+                                                                                                                                            "right": 602,
+                                                                                                                                            "bottom": 1879
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 549,
+                                                                                                                                                    "top": 1826,
+                                                                                                                                                    "right": 602,
+                                                                                                                                                    "bottom": 1879
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 562,
+                                                                                                                                                            "top": 1839,
+                                                                                                                                                            "right": 589,
+                                                                                                                                                            "bottom": 1866
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 571,
+                                                                                                                                                    "top": 1876,
+                                                                                                                                                    "right": 580,
+                                                                                                                                                    "bottom": 1876
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 529,
+                                                                                                                                            "top": 1063,
+                                                                                                                                            "right": 582,
+                                                                                                                                            "bottom": 1116
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 529,
+                                                                                                                                                    "top": 1063,
+                                                                                                                                                    "right": 582,
+                                                                                                                                                    "bottom": 1116
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 542,
+                                                                                                                                                            "top": 1076,
+                                                                                                                                                            "right": 569,
+                                                                                                                                                            "bottom": 1103
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 551,
+                                                                                                                                                    "top": 1113,
+                                                                                                                                                    "right": 560,
+                                                                                                                                                    "bottom": 1113
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 694,
+                                                                                                                                            "top": 1973,
+                                                                                                                                            "right": 747,
+                                                                                                                                            "bottom": 2026
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 694,
+                                                                                                                                                    "top": 1973,
+                                                                                                                                                    "right": 747,
+                                                                                                                                                    "bottom": 2026
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 707,
+                                                                                                                                                            "top": 1986,
+                                                                                                                                                            "right": 734,
+                                                                                                                                                            "bottom": 2013
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 716,
+                                                                                                                                                    "top": 2023,
+                                                                                                                                                    "right": 725,
+                                                                                                                                                    "bottom": 2023
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 344,
+                                                                                                                                            "top": 2328,
+                                                                                                                                            "right": 397,
+                                                                                                                                            "bottom": 2381
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 344,
+                                                                                                                                                    "top": 2328,
+                                                                                                                                                    "right": 397,
+                                                                                                                                                    "bottom": 2381
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 357,
+                                                                                                                                                            "top": 2341,
+                                                                                                                                                            "right": 384,
+                                                                                                                                                            "bottom": 2368
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 366,
+                                                                                                                                                    "top": 2378,
+                                                                                                                                                    "right": 375,
+                                                                                                                                                    "bottom": 2378
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 302,
+                                                                                                                                            "top": 1698,
+                                                                                                                                            "right": 355,
+                                                                                                                                            "bottom": 1751
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 302,
+                                                                                                                                                    "top": 1698,
+                                                                                                                                                    "right": 355,
+                                                                                                                                                    "bottom": 1751
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 315,
+                                                                                                                                                            "top": 1711,
+                                                                                                                                                            "right": 342,
+                                                                                                                                                            "bottom": 1738
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 324,
+                                                                                                                                                    "top": 1748,
+                                                                                                                                                    "right": 333,
+                                                                                                                                                    "bottom": 1748
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 742,
+                                                                                                                                            "right": -15,
+                                                                                                                                            "bottom": 795
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 742,
+                                                                                                                                                    "right": -15,
+                                                                                                                                                    "bottom": 795
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 755,
+                                                                                                                                                            "right": -28,
+                                                                                                                                                            "bottom": 782
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 792,
+                                                                                                                                                    "right": -37,
+                                                                                                                                                    "bottom": 792
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 52,
+                                                                                                                                            "top": 1003,
+                                                                                                                                            "right": 105,
+                                                                                                                                            "bottom": 1056
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 52,
+                                                                                                                                                    "top": 1003,
+                                                                                                                                                    "right": 105,
+                                                                                                                                                    "bottom": 1056
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 65,
+                                                                                                                                                            "top": 1016,
+                                                                                                                                                            "right": 92,
+                                                                                                                                                            "bottom": 1043
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 74,
+                                                                                                                                                    "top": 1053,
+                                                                                                                                                    "right": 83,
+                                                                                                                                                    "bottom": 1053
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 261,
+                                                                                                                                            "top": 1807,
+                                                                                                                                            "right": 297,
+                                                                                                                                            "bottom": 1843
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 856,
+                                                                                                                                            "top": 2120,
+                                                                                                                                            "right": 892,
+                                                                                                                                            "bottom": 2156
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 279,
+                                                                                                                                            "top": 1476,
+                                                                                                                                            "right": 315,
+                                                                                                                                            "bottom": 1512
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 420,
+                                                                                                                                            "top": 1537,
+                                                                                                                                            "right": 456,
+                                                                                                                                            "bottom": 1573
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/fixtures/uber_idle_map_partial/2026-07-24_19-35-56-545__uber__accessibility.window__idle_map__a4bfa3.json
+++ b/app/src/test/resources/fixtures/uber_idle_map_partial/2026-07-24_19-35-56-545__uber__accessibility.window__idle_map__a4bfa3.json
@@ -1,0 +1,1089 @@
+{
+    "captureId": "a3472c45-318b-4cbb-aab1-d0902e7c0eda",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784939756530,
+    "platform": "uber",
+    "ruleId": "uber.screen.idle_map",
+    "classificationName": "idle_map",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/glide_screen_stack_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/glide_active_view_container",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 0
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/active_container",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/background_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/screen_stack_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/ub__top_banner_container",
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 0
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/home_screen_overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 0,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 0,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 0,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            },
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_left_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 36,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 143,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "desc": "Home",
+                                                                                                                                                                                "id": "com.ubercab.driver:id/profile_entry",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_icon",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_photo",
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/earnings_tracker_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 261,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 819,
+                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__tracker_entry_content_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_entry_public_mode_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__earnings_tracker_indicator_card",
+                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                                    "top": 149,
+                                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                                    "bottom": 229
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                        "text": "$0.00",
+                                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_counter_content_status",
+                                                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                            "left": 457,
+                                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                                            "right": 623,
+                                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 522,
+                                                                                                                                                                                                                    "top": 243,
+                                                                                                                                                                                                                    "right": 558,
+                                                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/my_hub_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 937,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "desc": "Search for places",
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/search_entry_button",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 937,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_center_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 540,
+                                                                                                                                                                            "top": 279,
+                                                                                                                                                                            "right": 540,
+                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_container",
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 136
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_view",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_control_top_right_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 1044,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 172
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_left_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 1820,
+                                                                                                                                                                                    "right": 179,
+                                                                                                                                                                                    "bottom": 2355
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_safety_toolkit_container",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 18,
+                                                                                                                                                                                            "top": 1838,
+                                                                                                                                                                                            "right": 161,
+                                                                                                                                                                                            "bottom": 1981
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                    "top": 1856,
+                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                    "bottom": 1963
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__safety_toolkit_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                            "top": 1856,
+                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                            "bottom": 1963
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Safety Toolkit",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__safety_toolkit_button_container",
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                                    "top": 1856,
+                                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                                    "bottom": 1963
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__shield_animation_view",
+                                                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                                            "top": 1856,
+                                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                                            "bottom": 1963
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_container",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 901,
+                                                                                                                                                                                    "top": 1677,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2373
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                            "top": 1695,
+                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                            "bottom": 1999
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_ugc_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 1695,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 1838
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__ugc_map_button",
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 1695,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 1838
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Report a map issue",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__ugc_map_button_icon",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 1713,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 1820
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_earnings_trends_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 1838,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 1981
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 1838,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 1981
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Earnings Trends",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/map_control_earnings_trends",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 1856,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 1963
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_bottom_right_buttons",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 1062,
+                                                                                                                                                                                                    "top": 1981,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 1999
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_nav_button_layout",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 1062,
+                                                                                                                                                                                                            "top": 1981,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 1981
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/bottom_sheet_container",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 2026,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 2026,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant",
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2026,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2168
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_offline_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2026,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2168
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_overlay_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2026,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2168
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_background_view",
+                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 2026,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2168
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "Unable to go offline",
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_overlay_text",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 2026,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2168
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_online_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2026,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2168
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_padding_container",
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2026,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2168
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2168,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2170
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2170,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 4424,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/fixtures/uber_idle_map_partial/2026-07-24_19-37-07-910__uber__accessibility.window__idle_map__992e80.json
+++ b/app/src/test/resources/fixtures/uber_idle_map_partial/2026-07-24_19-37-07-910__uber__accessibility.window__idle_map__992e80.json
@@ -1,0 +1,2462 @@
+{
+    "captureId": "d93d04bc-a575-4f7b-8268-90352b7bd3df",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784939827875,
+    "platform": "uber",
+    "ruleId": "uber.screen.idle_map",
+    "classificationName": "idle_map",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/glide_screen_stack_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/glide_active_view_container",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 0
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/active_container",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/background_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/screen_stack_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/ub__top_banner_container",
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 0
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/home_screen_overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 0,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 0,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 0,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            },
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_left_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 36,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 143,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "desc": "Home",
+                                                                                                                                                                                "id": "com.ubercab.driver:id/profile_entry",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_icon",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_photo",
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/earnings_tracker_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 261,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 819,
+                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__tracker_entry_content_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_entry_public_mode_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__earnings_tracker_indicator_card",
+                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                                    "top": 149,
+                                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                                    "bottom": 229
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                        "text": "$0.00",
+                                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_counter_content_status",
+                                                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                            "left": 457,
+                                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                                            "right": 623,
+                                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 522,
+                                                                                                                                                                                                                    "top": 243,
+                                                                                                                                                                                                                    "right": 558,
+                                                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/my_hub_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 937,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "desc": "Search for places",
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/search_entry_button",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 937,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_center_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 540,
+                                                                                                                                                                            "top": 279,
+                                                                                                                                                                            "right": 540,
+                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_container",
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 136
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_view",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_control_top_right_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 1044,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 172
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_left_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 1820,
+                                                                                                                                                                                    "right": 179,
+                                                                                                                                                                                    "bottom": 2355
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_safety_toolkit_container",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 18,
+                                                                                                                                                                                            "top": 1838,
+                                                                                                                                                                                            "right": 161,
+                                                                                                                                                                                            "bottom": 1981
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                    "top": 1856,
+                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                    "bottom": 1963
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__safety_toolkit_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                            "top": 1856,
+                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                            "bottom": 1963
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Safety Toolkit",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__safety_toolkit_button_container",
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                                    "top": 1856,
+                                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                                    "bottom": 1963
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__shield_animation_view",
+                                                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                                            "top": 1856,
+                                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                                            "bottom": 1963
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_bottom_center_container",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 357,
+                                                                                                                                                                                    "top": 1856,
+                                                                                                                                                                                    "right": 723,
+                                                                                                                                                                                    "bottom": 2355
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 375,
+                                                                                                                                                                                            "top": 1874,
+                                                                                                                                                                                            "right": 705,
+                                                                                                                                                                                            "bottom": 1981
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "Trip Radar",
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__driver_job_offers_pill_title",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 411,
+                                                                                                                                                                                                    "top": 1900,
+                                                                                                                                                                                                    "right": 606,
+                                                                                                                                                                                                    "bottom": 1956
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__driver_job_offers_pill_badge",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 624,
+                                                                                                                                                                                                    "top": 1905,
+                                                                                                                                                                                                    "right": 669,
+                                                                                                                                                                                                    "bottom": 1950
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "2",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 628,
+                                                                                                                                                                                                            "top": 1909,
+                                                                                                                                                                                                            "right": 665,
+                                                                                                                                                                                                            "bottom": 1946
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_container",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 901,
+                                                                                                                                                                                    "top": 1534,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2373
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                            "top": 1552,
+                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                            "bottom": 1999
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_ugc_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 1552,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 1695
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__ugc_map_button",
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 1552,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 1695
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Report a map issue",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__ugc_map_button_icon",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 1570,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 1677
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_earnings_trends_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 1695,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 1838
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 1695,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 1838
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Earnings Trends",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/map_control_earnings_trends",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 1713,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 1820
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_bottom_right_buttons",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 1838,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 1999
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_nav_button_layout",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 1838,
+                                                                                                                                                                                                            "right": 919,
+                                                                                                                                                                                                            "bottom": 1838
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_bottom_right_center_me",
+                                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 937,
+                                                                                                                                                                                                            "top": 1856,
+                                                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                                                            "bottom": 1963
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/bottom_sheet_container",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 2026,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 2026,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant",
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2026,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2168
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_offline_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2026,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2168
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 579,
+                                                                                                                                            "top": 507,
+                                                                                                                                            "right": 989,
+                                                                                                                                            "bottom": 602
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Camila's Mexican Restaurant",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 579,
+                                                                                                                                                    "top": 507,
+                                                                                                                                                    "right": 989,
+                                                                                                                                                    "bottom": 602
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1143,
+                                                                                                                                            "top": 2467,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1143,
+                                                                                                                                                    "top": 2467,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1156,
+                                                                                                                                                            "top": 2480,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1165,
+                                                                                                                                                    "top": 2517,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 391,
+                                                                                                                                            "top": 2337,
+                                                                                                                                            "right": 444,
+                                                                                                                                            "bottom": 2390
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 391,
+                                                                                                                                                    "top": 2337,
+                                                                                                                                                    "right": 444,
+                                                                                                                                                    "bottom": 2390
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 404,
+                                                                                                                                                            "top": 2350,
+                                                                                                                                                            "right": 431,
+                                                                                                                                                            "bottom": 2377
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 413,
+                                                                                                                                                    "top": 2387,
+                                                                                                                                                    "right": 422,
+                                                                                                                                                    "bottom": 2387
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 751,
+                                                                                                                                            "right": 31,
+                                                                                                                                            "bottom": 804
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 751,
+                                                                                                                                                    "right": 31,
+                                                                                                                                                    "bottom": 804
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 764,
+                                                                                                                                                            "right": 18,
+                                                                                                                                                            "bottom": 791
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 801,
+                                                                                                                                                    "right": 9,
+                                                                                                                                                    "bottom": 801
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 184,
+                                                                                                                                            "top": 1425,
+                                                                                                                                            "right": 237,
+                                                                                                                                            "bottom": 1478
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 184,
+                                                                                                                                                    "top": 1425,
+                                                                                                                                                    "right": 237,
+                                                                                                                                                    "bottom": 1478
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 197,
+                                                                                                                                                            "top": 1438,
+                                                                                                                                                            "right": 224,
+                                                                                                                                                            "bottom": 1465
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 206,
+                                                                                                                                                    "top": 1475,
+                                                                                                                                                    "right": 215,
+                                                                                                                                                    "bottom": 1475
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 614,
+                                                                                                                                            "top": 875,
+                                                                                                                                            "right": 667,
+                                                                                                                                            "bottom": 928
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 614,
+                                                                                                                                                    "top": 875,
+                                                                                                                                                    "right": 667,
+                                                                                                                                                    "bottom": 928
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 627,
+                                                                                                                                                            "top": 888,
+                                                                                                                                                            "right": 654,
+                                                                                                                                                            "bottom": 915
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 636,
+                                                                                                                                                    "top": 925,
+                                                                                                                                                    "right": 645,
+                                                                                                                                                    "bottom": 925
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 98,
+                                                                                                                                            "top": 1012,
+                                                                                                                                            "right": 151,
+                                                                                                                                            "bottom": 1065
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 98,
+                                                                                                                                                    "top": 1012,
+                                                                                                                                                    "right": 151,
+                                                                                                                                                    "bottom": 1065
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 111,
+                                                                                                                                                            "top": 1025,
+                                                                                                                                                            "right": 138,
+                                                                                                                                                            "bottom": 1052
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 120,
+                                                                                                                                                    "top": 1062,
+                                                                                                                                                    "right": 129,
+                                                                                                                                                    "bottom": 1062
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 705,
+                                                                                                                                            "top": 1576,
+                                                                                                                                            "right": 758,
+                                                                                                                                            "bottom": 1629
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 705,
+                                                                                                                                                    "top": 1576,
+                                                                                                                                                    "right": 758,
+                                                                                                                                                    "bottom": 1629
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 718,
+                                                                                                                                                            "top": 1589,
+                                                                                                                                                            "right": 745,
+                                                                                                                                                            "bottom": 1616
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 727,
+                                                                                                                                                    "top": 1626,
+                                                                                                                                                    "right": 736,
+                                                                                                                                                    "bottom": 1626
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 348,
+                                                                                                                                            "top": 1707,
+                                                                                                                                            "right": 401,
+                                                                                                                                            "bottom": 1760
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 348,
+                                                                                                                                                    "top": 1707,
+                                                                                                                                                    "right": 401,
+                                                                                                                                                    "bottom": 1760
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 361,
+                                                                                                                                                            "top": 1720,
+                                                                                                                                                            "right": 388,
+                                                                                                                                                            "bottom": 1747
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 370,
+                                                                                                                                                    "top": 1757,
+                                                                                                                                                    "right": 379,
+                                                                                                                                                    "bottom": 1757
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 946,
+                                                                                                                                            "top": 910,
+                                                                                                                                            "right": 999,
+                                                                                                                                            "bottom": 963
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 946,
+                                                                                                                                                    "top": 910,
+                                                                                                                                                    "right": 999,
+                                                                                                                                                    "bottom": 963
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 959,
+                                                                                                                                                            "top": 923,
+                                                                                                                                                            "right": 986,
+                                                                                                                                                            "bottom": 950
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 968,
+                                                                                                                                                    "top": 960,
+                                                                                                                                                    "right": 977,
+                                                                                                                                                    "bottom": 960
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 412,
+                                                                                                                                            "top": 1470,
+                                                                                                                                            "right": 465,
+                                                                                                                                            "bottom": 1523
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 412,
+                                                                                                                                                    "top": 1470,
+                                                                                                                                                    "right": 465,
+                                                                                                                                                    "bottom": 1523
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 425,
+                                                                                                                                                            "top": 1483,
+                                                                                                                                                            "right": 452,
+                                                                                                                                                            "bottom": 1510
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 434,
+                                                                                                                                                    "top": 1520,
+                                                                                                                                                    "right": 443,
+                                                                                                                                                    "bottom": 1520
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 758,
+                                                                                                                                            "top": 432,
+                                                                                                                                            "right": 811,
+                                                                                                                                            "bottom": 485
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 758,
+                                                                                                                                                    "top": 432,
+                                                                                                                                                    "right": 811,
+                                                                                                                                                    "bottom": 485
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 771,
+                                                                                                                                                            "top": 445,
+                                                                                                                                                            "right": 798,
+                                                                                                                                                            "bottom": 472
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 780,
+                                                                                                                                                    "top": 482,
+                                                                                                                                                    "right": 789,
+                                                                                                                                                    "bottom": 482
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 603,
+                                                                                                                                            "top": 266,
+                                                                                                                                            "right": 656,
+                                                                                                                                            "bottom": 319
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 603,
+                                                                                                                                                    "top": 266,
+                                                                                                                                                    "right": 656,
+                                                                                                                                                    "bottom": 319
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 616,
+                                                                                                                                                            "top": 279,
+                                                                                                                                                            "right": 643,
+                                                                                                                                                            "bottom": 306
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 625,
+                                                                                                                                                    "top": 316,
+                                                                                                                                                    "right": 634,
+                                                                                                                                                    "bottom": 316
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 311,
+                                                                                                                                            "top": 372,
+                                                                                                                                            "right": 364,
+                                                                                                                                            "bottom": 425
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 311,
+                                                                                                                                                    "top": 372,
+                                                                                                                                                    "right": 364,
+                                                                                                                                                    "bottom": 425
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 324,
+                                                                                                                                                            "top": 385,
+                                                                                                                                                            "right": 351,
+                                                                                                                                                            "bottom": 412
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 333,
+                                                                                                                                                    "top": 422,
+                                                                                                                                                    "right": 342,
+                                                                                                                                                    "bottom": 422
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 596,
+                                                                                                                                            "top": 1835,
+                                                                                                                                            "right": 649,
+                                                                                                                                            "bottom": 1888
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 596,
+                                                                                                                                                    "top": 1835,
+                                                                                                                                                    "right": 649,
+                                                                                                                                                    "bottom": 1888
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 609,
+                                                                                                                                                            "top": 1848,
+                                                                                                                                                            "right": 636,
+                                                                                                                                                            "bottom": 1875
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 618,
+                                                                                                                                                    "top": 1885,
+                                                                                                                                                    "right": 627,
+                                                                                                                                                    "bottom": 1885
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 575,
+                                                                                                                                            "top": 1072,
+                                                                                                                                            "right": 628,
+                                                                                                                                            "bottom": 1125
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 575,
+                                                                                                                                                    "top": 1072,
+                                                                                                                                                    "right": 628,
+                                                                                                                                                    "bottom": 1125
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 588,
+                                                                                                                                                            "top": 1085,
+                                                                                                                                                            "right": 615,
+                                                                                                                                                            "bottom": 1112
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 597,
+                                                                                                                                                    "top": 1122,
+                                                                                                                                                    "right": 606,
+                                                                                                                                                    "bottom": 1122
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 740,
+                                                                                                                                            "top": 1982,
+                                                                                                                                            "right": 793,
+                                                                                                                                            "bottom": 2035
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 740,
+                                                                                                                                                    "top": 1982,
+                                                                                                                                                    "right": 793,
+                                                                                                                                                    "bottom": 2035
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 753,
+                                                                                                                                                            "top": 1995,
+                                                                                                                                                            "right": 780,
+                                                                                                                                                            "bottom": 2022
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 762,
+                                                                                                                                                    "top": 2032,
+                                                                                                                                                    "right": 771,
+                                                                                                                                                    "bottom": 2032
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 471,
+                                                                                                                                            "top": 2266,
+                                                                                                                                            "right": 524,
+                                                                                                                                            "bottom": 2319
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 471,
+                                                                                                                                                    "top": 2266,
+                                                                                                                                                    "right": 524,
+                                                                                                                                                    "bottom": 2319
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 484,
+                                                                                                                                                            "top": 2279,
+                                                                                                                                                            "right": 511,
+                                                                                                                                                            "bottom": 2306
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 493,
+                                                                                                                                                    "top": 2316,
+                                                                                                                                                    "right": 502,
+                                                                                                                                                    "bottom": 2316
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 446,
+                                                                                                                                            "top": 795,
+                                                                                                                                            "right": 835,
+                                                                                                                                            "bottom": 847
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "P. Terry’s Burger Stand",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 446,
+                                                                                                                                                    "top": 795,
+                                                                                                                                                    "right": 835,
+                                                                                                                                                    "bottom": 847
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 420,
+                                                                                                                                            "top": 1707,
+                                                                                                                                            "right": 806,
+                                                                                                                                            "bottom": 1759
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Saltgrass Steak House",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 420,
+                                                                                                                                                    "top": 1707,
+                                                                                                                                                    "right": 806,
+                                                                                                                                                    "bottom": 1759
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 32,
+                                                                                                                                            "top": 1345,
+                                                                                                                                            "right": 389,
+                                                                                                                                            "bottom": 1397
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Salata Salad Kitchen",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 32,
+                                                                                                                                                    "top": 1345,
+                                                                                                                                                    "right": 389,
+                                                                                                                                                    "bottom": 1397
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 612,
+                                                                                                                                            "top": 1902,
+                                                                                                                                            "right": 921,
+                                                                                                                                            "bottom": 1954
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Thai Chili Express",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 612,
+                                                                                                                                                    "top": 1902,
+                                                                                                                                                    "right": 921,
+                                                                                                                                                    "bottom": 1954
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 484,
+                                                                                                                                            "top": 1470,
+                                                                                                                                            "right": 786,
+                                                                                                                                            "bottom": 1522
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Teriyaki Madness",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 484,
+                                                                                                                                                    "top": 1470,
+                                                                                                                                                    "right": 786,
+                                                                                                                                                    "bottom": 1522
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 386,
+                                                                                                                                            "top": 1576,
+                                                                                                                                            "right": 685,
+                                                                                                                                            "bottom": 1628
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Delicious Garden",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 386,
+                                                                                                                                                    "top": 1576,
+                                                                                                                                                    "right": 685,
+                                                                                                                                                    "bottom": 1628
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 651,
+                                                                                                                                            "top": 910,
+                                                                                                                                            "right": 926,
+                                                                                                                                            "bottom": 962
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "46th St Pizzeria",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 651,
+                                                                                                                                                    "top": 910,
+                                                                                                                                                    "right": 926,
+                                                                                                                                                    "bottom": 962
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 170,
+                                                                                                                                            "top": 1012,
+                                                                                                                                            "right": 443,
+                                                                                                                                            "bottom": 1064
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Curry Boys BBQ",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 170,
+                                                                                                                                                    "top": 1012,
+                                                                                                                                                    "right": 443,
+                                                                                                                                                    "bottom": 1064
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 383,
+                                                                                                                                            "top": 372,
+                                                                                                                                            "right": 632,
+                                                                                                                                            "bottom": 424
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Sonic Drive-In",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 383,
+                                                                                                                                                    "top": 372,
+                                                                                                                                                    "right": 632,
+                                                                                                                                                    "bottom": 424
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 311,
+                                                                                                                                            "top": 1072,
+                                                                                                                                            "right": 555,
+                                                                                                                                            "bottom": 1124
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Little Caesars",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 311,
+                                                                                                                                                    "top": 1072,
+                                                                                                                                                    "right": 555,
+                                                                                                                                                    "bottom": 1124
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 50,
+                                                                                                                                            "top": 751,
+                                                                                                                                            "right": 285,
+                                                                                                                                            "bottom": 803
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Whataburger",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 50,
+                                                                                                                                                    "top": 751,
+                                                                                                                                                    "right": 285,
+                                                                                                                                                    "bottom": 803
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 463,
+                                                                                                                                            "top": 2337,
+                                                                                                                                            "right": 686,
+                                                                                                                                            "bottom": 2389
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "McDonald's®",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 463,
+                                                                                                                                                    "top": 2337,
+                                                                                                                                                    "right": 686,
+                                                                                                                                                    "bottom": 2389
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 514,
+                                                                                                                                            "top": 1755,
+                                                                                                                                            "right": 731,
+                                                                                                                                            "bottom": 1807
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Dairy Queen",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 514,
+                                                                                                                                                    "top": 1755,
+                                                                                                                                                    "right": 731,
+                                                                                                                                                    "bottom": 1807
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 544,
+                                                                                                                                            "top": 2266,
+                                                                                                                                            "right": 746,
+                                                                                                                                            "bottom": 2318
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Gogi Street",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 544,
+                                                                                                                                                    "top": 2266,
+                                                                                                                                                    "right": 746,
+                                                                                                                                                    "bottom": 2318
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 535,
+                                                                                                                                            "top": 186,
+                                                                                                                                            "right": 724,
+                                                                                                                                            "bottom": 238
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Walgreens",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 535,
+                                                                                                                                                    "top": 186,
+                                                                                                                                                    "right": 724,
+                                                                                                                                                    "bottom": 238
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1216,
+                                                                                                                                            "top": 2467,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "The Shack",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1216,
+                                                                                                                                                    "top": 2467,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 325,
+                                                                                                                                            "top": 1485,
+                                                                                                                                            "right": 361,
+                                                                                                                                            "bottom": 1521
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1535,
+                                                                                                                                            "right": -8,
+                                                                                                                                            "bottom": 1571
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 307,
+                                                                                                                                            "top": 1816,
+                                                                                                                                            "right": 343,
+                                                                                                                                            "bottom": 1852
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 198,
+                                                                                                                                            "top": 2154,
+                                                                                                                                            "right": 234,
+                                                                                                                                            "bottom": 2190
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 466,
+                                                                                                                                            "top": 1546,
+                                                                                                                                            "right": 502,
+                                                                                                                                            "bottom": 1582
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -2516,6 +2516,18 @@
             "zoneName": null
         }
     },
+    "idle_map/2026-07-23_20-27-05-326__uber__accessibility.window__idle_map__4918e3.json": {
+        "ruleId": "uber.screen.idle_map",
+        "intent": "idle_map",
+        "shape": null,
+        "fields": {}
+    },
+    "idle_map/2026-07-24_18-46-44-317__uber__accessibility.window__idle_map__a75080.json": {
+        "ruleId": "uber.screen.idle_map",
+        "intent": "idle_map",
+        "shape": null,
+        "fields": {}
+    },
     "idle_map/20260128_155954_491_MAIN_MAP_IDLE.json": {
         "ruleId": "doordash.screen.idle_map",
         "intent": "idle_map",

--- a/app/src/test/resources/snapshots/idle_map/2026-07-23_20-27-05-326__uber__accessibility.window__idle_map__4918e3.json
+++ b/app/src/test/resources/snapshots/idle_map/2026-07-23_20-27-05-326__uber__accessibility.window__idle_map__4918e3.json
@@ -1,0 +1,2360 @@
+{
+    "captureId": "fe9a9b47-0832-4e7c-a0b0-0afe2336f878",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784856425304,
+    "platform": "uber",
+    "ruleId": "uber.screen.idle_map",
+    "classificationName": "idle_map",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/glide_screen_stack_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/glide_active_view_container",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 0
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/active_container",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/background_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/screen_stack_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/ub__top_banner_container",
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 0
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/home_screen_overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 0,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 0,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 0,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 451,
+                                                                                                                                                                                                    "top": 2087,
+                                                                                                                                                                                                    "right": 629,
+                                                                                                                                                                                                    "bottom": 2265
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 451,
+                                                                                                                                                                                                            "top": 2087,
+                                                                                                                                                                                                            "right": 629,
+                                                                                                                                                                                                            "bottom": 2265
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "text": "GO",
+                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 497,
+                                                                                                                                                                                                                    "top": 2143,
+                                                                                                                                                                                                                    "right": 585,
+                                                                                                                                                                                                                    "bottom": 2210
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 479,
+                                                                                                                                                                                                            "top": 2115,
+                                                                                                                                                                                                            "right": 601,
+                                                                                                                                                                                                            "bottom": 2237
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            },
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_left_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 36,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 143,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "desc": "Home",
+                                                                                                                                                                                "id": "com.ubercab.driver:id/profile_entry",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_icon",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_photo",
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/earnings_tracker_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 261,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 819,
+                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__tracker_entry_content_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_entry_public_mode_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__earnings_tracker_indicator_card",
+                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                                    "top": 149,
+                                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                                    "bottom": 229
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                        "text": "$0.00",
+                                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_counter_content_status",
+                                                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                            "left": 457,
+                                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                                            "right": 623,
+                                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 522,
+                                                                                                                                                                                                                    "top": 243,
+                                                                                                                                                                                                                    "right": 558,
+                                                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/my_hub_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 937,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "desc": "Search for places",
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/search_entry_button",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 937,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_center_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 540,
+                                                                                                                                                                            "top": 279,
+                                                                                                                                                                            "right": 540,
+                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_container",
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 136
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_view",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_control_top_right_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 1044,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 172
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_left_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 1825,
+                                                                                                                                                                                    "right": 179,
+                                                                                                                                                                                    "bottom": 2355
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_safety_toolkit_container",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 18,
+                                                                                                                                                                                            "top": 1843,
+                                                                                                                                                                                            "right": 161,
+                                                                                                                                                                                            "bottom": 1986
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                    "top": 1861,
+                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                    "bottom": 1968
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__safety_toolkit_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                            "top": 1861,
+                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                            "bottom": 1968
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Safety Toolkit",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__safety_toolkit_button_container",
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                                    "top": 1861,
+                                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                                    "bottom": 1968
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__shield_animation_view",
+                                                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                                            "top": 1861,
+                                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                                            "bottom": 1968
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_container",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 901,
+                                                                                                                                                                                    "top": 1682,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2373
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                            "top": 1700,
+                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                            "bottom": 2004
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_ugc_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 1700,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 1843
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__ugc_map_button",
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 1700,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 1843
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Report a map issue",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__ugc_map_button_icon",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 1718,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 1825
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_earnings_trends_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 1843,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 1986
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 1843,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 1986
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Earnings Trends",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/map_control_earnings_trends",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 1861,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 1968
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_bottom_right_buttons",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 1062,
+                                                                                                                                                                                                    "top": 1986,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 2004
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_nav_button_layout",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 1062,
+                                                                                                                                                                                                            "top": 1986,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 1986
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/bottom_sheet_container",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 2169,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant",
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2169,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2328
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_offline_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2328
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_overlay_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2328
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_background_view",
+                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 2169,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2328
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "Unable to go offline",
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_overlay_text",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 2169,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2328
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_online_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2328
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_padding_container",
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2328
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_action_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 2185,
+                                                                                                                                                                                                    "right": 142,
+                                                                                                                                                                                                    "bottom": 2328
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                                            "top": 2185,
+                                                                                                                                                                                                            "right": 142,
+                                                                                                                                                                                                            "bottom": 2328
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Preferences",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/preferences_status_assistant_action_icon",
+                                                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 26,
+                                                                                                                                                                                                                    "top": 2212,
+                                                                                                                                                                                                                    "right": 115,
+                                                                                                                                                                                                                    "bottom": 2301
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 142,
+                                                                                                                                                                                                    "top": 2185,
+                                                                                                                                                                                                    "right": 938,
+                                                                                                                                                                                                    "bottom": 2328
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "Recommended for you",
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_content_override",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 142,
+                                                                                                                                                                                                            "top": 2185,
+                                                                                                                                                                                                            "right": 938,
+                                                                                                                                                                                                            "bottom": 2328
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_grabber_bar",
+                                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 469,
+                                                                                                                                                                                                            "top": 2203,
+                                                                                                                                                                                                            "right": 611,
+                                                                                                                                                                                                            "bottom": 2212
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_content",
+                                                                                                                                                                                                        "class": "android.widget.RelativeLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 146,
+                                                                                                                                                                                                            "top": 2221,
+                                                                                                                                                                                                            "right": 934,
+                                                                                                                                                                                                            "bottom": 2292
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "text": "You're offline",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_label_leading",
+                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 146,
+                                                                                                                                                                                                                    "top": 2221,
+                                                                                                                                                                                                                    "right": 934,
+                                                                                                                                                                                                                    "bottom": 2292
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_agenda_entry_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 938,
+                                                                                                                                                                                                    "top": 2230,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2283
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 938,
+                                                                                                                                                                                                            "top": 2230,
+                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                            "bottom": 2283
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Agenda",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_agenda_button",
+                                                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 938,
+                                                                                                                                                                                                                    "top": 2230,
+                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                    "bottom": 2283
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2328,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2330
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2330,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/agenda_feed_content_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2330,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 2330,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.GridView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                                            "top": 2330,
+                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                                    "top": 2330,
+                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                                                            "top": 2330,
+                                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/hard_blocker_rv",
+                                                                                                                                                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                                                    "top": 2330,
+                                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                                                                            "top": 2332,
+                                                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/alert_iv",
+                                                                                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                                                                    "top": 2385,
+                                                                                                                                                                                                                                                    "right": 107,
+                                                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                "text": "Required actions (1)",
+                                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/title_tv",
+                                                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                    "left": 142,
+                                                                                                                                                                                                                                                    "top": 2368,
+                                                                                                                                                                                                                                                    "right": 956,
+                                                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                "text": "Go online when resolved",
+                                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/subtitle_tv",
+                                                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                    "left": 142,
+                                                                                                                                                                                                                                                    "top": 2440,
+                                                                                                                                                                                                                                                    "right": 956,
+                                                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                    },
+                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                                                                            "top": 2533,
+                                                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                "text": "Turn on overlay permissions for Uber",
+                                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/title_tv",
+                                                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                    "left": 142,
+                                                                                                                                                                                                                                                    "top": 2577,
+                                                                                                                                                                                                                                                    "right": 836,
+                                                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/chevron_iv",
+                                                                                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                    "left": 992,
+                                                                                                                                                                                                                                                    "top": 2579,
+                                                                                                                                                                                                                                                    "right": 1045,
+                                                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                "text": "Go to device Settings",
+                                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/subtitle_tv",
+                                                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                                    "left": 142,
+                                                                                                                                                                                                                                                    "top": 2633,
+                                                                                                                                                                                                                                                    "right": 497,
+                                                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/hard_blocker_timeline_view",
+                                                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 69,
+                                                                                                                                                                                                                                    "top": 2450,
+                                                                                                                                                                                                                                    "right": 73,
+                                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/future_blocker_rv",
+                                                                                                                                                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                                                    "top": 2735,
+                                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/nudge_blocker_rv",
+                                                                                                                                                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                                                    "top": 2735,
+                                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                                    "top": 2737,
+                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                                                            "top": 2737,
+                                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                                    "top": 2739,
+                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                                                            "top": 2739,
+                                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/action_section_view_icon",
+                                                                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                                                    "top": 2775,
+                                                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "text": "See driving time",
+                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/action_section_view_cta",
+                                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 179,
+                                                                                                                                                                                                                                    "top": 2800,
+                                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                                    "top": 2920,
+                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "text": "Waybill",
+                                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                                                            "top": 2920,
+                                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 3838,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 314,
+                                                                                                                                            "top": 1042,
+                                                                                                                                            "right": 367,
+                                                                                                                                            "bottom": 1095
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 323,
+                                                                                                                                                    "top": 1007,
+                                                                                                                                                    "right": 376,
+                                                                                                                                                    "bottom": 1060
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 336,
+                                                                                                                                                            "top": 1020,
+                                                                                                                                                            "right": 363,
+                                                                                                                                                            "bottom": 1047
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 348,
+                                                                                                                                                    "top": 1045,
+                                                                                                                                                    "right": 357,
+                                                                                                                                                    "bottom": 1045
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 557,
+                                                                                                                                            "top": 1787,
+                                                                                                                                            "right": 610,
+                                                                                                                                            "bottom": 1840
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 557,
+                                                                                                                                                    "top": 1781,
+                                                                                                                                                    "right": 610,
+                                                                                                                                                    "bottom": 1834
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 570,
+                                                                                                                                                            "top": 1800,
+                                                                                                                                                            "right": 597,
+                                                                                                                                                            "bottom": 1827
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 579,
+                                                                                                                                                    "top": 1837,
+                                                                                                                                                    "right": 588,
+                                                                                                                                                    "bottom": 1837
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 374,
+                                                                                                                                            "top": 1366,
+                                                                                                                                            "right": 427,
+                                                                                                                                            "bottom": 1419
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 375,
+                                                                                                                                                    "top": 1361,
+                                                                                                                                                    "right": 428,
+                                                                                                                                                    "bottom": 1414
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 387,
+                                                                                                                                                            "top": 1379,
+                                                                                                                                                            "right": 414,
+                                                                                                                                                            "bottom": 1406
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 396,
+                                                                                                                                                    "top": 1416,
+                                                                                                                                                    "right": 405,
+                                                                                                                                                    "bottom": 1416
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 771,
+                                                                                                                                            "top": 881,
+                                                                                                                                            "right": 824,
+                                                                                                                                            "bottom": 934
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 771,
+                                                                                                                                                    "top": 881,
+                                                                                                                                                    "right": 824,
+                                                                                                                                                    "bottom": 934
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 784,
+                                                                                                                                                            "top": 894,
+                                                                                                                                                            "right": 811,
+                                                                                                                                                            "bottom": 921
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 793,
+                                                                                                                                                    "top": 931,
+                                                                                                                                                    "right": 802,
+                                                                                                                                                    "bottom": 931
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 255,
+                                                                                                                                            "top": 1128,
+                                                                                                                                            "right": 308,
+                                                                                                                                            "bottom": 1181
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 255,
+                                                                                                                                                    "top": 1128,
+                                                                                                                                                    "right": 308,
+                                                                                                                                                    "bottom": 1181
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 268,
+                                                                                                                                                            "top": 1141,
+                                                                                                                                                            "right": 295,
+                                                                                                                                                            "bottom": 1168
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 277,
+                                                                                                                                                    "top": 1178,
+                                                                                                                                                    "right": 286,
+                                                                                                                                                    "bottom": 1178
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 243,
+                                                                                                                                            "top": 1449,
+                                                                                                                                            "right": 296,
+                                                                                                                                            "bottom": 1502
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 247,
+                                                                                                                                                    "top": 1433,
+                                                                                                                                                    "right": 300,
+                                                                                                                                                    "bottom": 1486
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 260,
+                                                                                                                                                            "top": 1446,
+                                                                                                                                                            "right": 287,
+                                                                                                                                                            "bottom": 1473
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 274,
+                                                                                                                                                    "top": 1460,
+                                                                                                                                                    "right": 283,
+                                                                                                                                                    "bottom": 1460
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 239,
+                                                                                                                                            "top": 1231,
+                                                                                                                                            "right": 292,
+                                                                                                                                            "bottom": 1284
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 265,
+                                                                                                                                                    "top": 1141,
+                                                                                                                                                    "right": 318,
+                                                                                                                                                    "bottom": 1194
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 252,
+                                                                                                                                                            "top": 1244,
+                                                                                                                                                            "right": 279,
+                                                                                                                                                            "bottom": 1271
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 261,
+                                                                                                                                                    "top": 1281,
+                                                                                                                                                    "right": 270,
+                                                                                                                                                    "bottom": 1281
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 421,
+                                                                                                                                            "top": 1366,
+                                                                                                                                            "right": 469,
+                                                                                                                                            "bottom": 1414
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 623,
+                                                                                                                                                    "top": 1333,
+                                                                                                                                                    "right": 672,
+                                                                                                                                                    "bottom": 1381
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 635,
+                                                                                                                                                            "top": 1344,
+                                                                                                                                                            "right": 660,
+                                                                                                                                                            "bottom": 1369
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 644,
+                                                                                                                                                    "top": 1378,
+                                                                                                                                                    "right": 652,
+                                                                                                                                                    "bottom": 1378
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 744,
+                                                                                                                                            "top": 1364,
+                                                                                                                                            "right": 792,
+                                                                                                                                            "bottom": 1412
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 764,
+                                                                                                                                                    "top": 1410,
+                                                                                                                                                    "right": 772,
+                                                                                                                                                    "bottom": 1410
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 546,
+                                                                                                                                            "top": 796,
+                                                                                                                                            "right": 595,
+                                                                                                                                            "bottom": 845
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 546,
+                                                                                                                                                    "top": 796,
+                                                                                                                                                    "right": 595,
+                                                                                                                                                    "bottom": 845
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 558,
+                                                                                                                                                            "top": 808,
+                                                                                                                                                            "right": 583,
+                                                                                                                                                            "bottom": 833
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 570,
+                                                                                                                                                    "top": 834,
+                                                                                                                                                    "right": 579,
+                                                                                                                                                    "bottom": 834
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 792,
+                                                                                                                                            "top": 1287,
+                                                                                                                                            "right": 841,
+                                                                                                                                            "bottom": 1335
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 792,
+                                                                                                                                                    "top": 1287,
+                                                                                                                                                    "right": 841,
+                                                                                                                                                    "bottom": 1335
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 804,
+                                                                                                                                                            "top": 1299,
+                                                                                                                                                            "right": 829,
+                                                                                                                                                            "bottom": 1323
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 812,
+                                                                                                                                                    "top": 1317,
+                                                                                                                                                    "right": 820,
+                                                                                                                                                    "bottom": 1317
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 927,
+                                                                                                                                            "top": 1171,
+                                                                                                                                            "right": 976,
+                                                                                                                                            "bottom": 1220
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 925,
+                                                                                                                                                    "top": 1161,
+                                                                                                                                                    "right": 974,
+                                                                                                                                                    "bottom": 1210
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 939,
+                                                                                                                                                            "top": 1183,
+                                                                                                                                                            "right": 964,
+                                                                                                                                                            "bottom": 1208
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 947,
+                                                                                                                                                    "top": 1217,
+                                                                                                                                                    "right": 956,
+                                                                                                                                                    "bottom": 1217
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 420,
+                                                                                                                                            "top": 1848,
+                                                                                                                                            "right": 468,
+                                                                                                                                            "bottom": 1897
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 420,
+                                                                                                                                                    "top": 1848,
+                                                                                                                                                    "right": 468,
+                                                                                                                                                    "bottom": 1897
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 432,
+                                                                                                                                                            "top": 1860,
+                                                                                                                                                            "right": 457,
+                                                                                                                                                            "bottom": 1885
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 440,
+                                                                                                                                                    "top": 1894,
+                                                                                                                                                    "right": 448,
+                                                                                                                                                    "bottom": 1894
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 730,
+                                                                                                                                            "top": 1105,
+                                                                                                                                            "right": 779,
+                                                                                                                                            "bottom": 1154
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 730,
+                                                                                                                                                    "top": 1105,
+                                                                                                                                                    "right": 779,
+                                                                                                                                                    "bottom": 1154
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 742,
+                                                                                                                                                            "top": 1117,
+                                                                                                                                                            "right": 767,
+                                                                                                                                                            "bottom": 1142
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 750,
+                                                                                                                                                    "top": 1151,
+                                                                                                                                                    "right": 758,
+                                                                                                                                                    "bottom": 1151
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 961,
+                                                                                                                                            "top": 1268,
+                                                                                                                                            "right": 1010,
+                                                                                                                                            "bottom": 1317
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 961,
+                                                                                                                                                    "top": 1268,
+                                                                                                                                                    "right": 1010,
+                                                                                                                                                    "bottom": 1317
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 973,
+                                                                                                                                                            "top": 1280,
+                                                                                                                                                            "right": 998,
+                                                                                                                                                            "bottom": 1305
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 981,
+                                                                                                                                                    "top": 1314,
+                                                                                                                                                    "right": 989,
+                                                                                                                                                    "bottom": 1314
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 625,
+                                                                                                                                            "top": 1649,
+                                                                                                                                            "right": 674,
+                                                                                                                                            "bottom": 1698
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/idle_map/2026-07-24_18-46-44-317__uber__accessibility.window__idle_map__a75080.json
+++ b/app/src/test/resources/snapshots/idle_map/2026-07-24_18-46-44-317__uber__accessibility.window__idle_map__a75080.json
@@ -1,0 +1,3552 @@
+{
+    "captureId": "8bc84349-3df4-4272-a377-6d790c470519",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784936804287,
+    "platform": "uber",
+    "ruleId": "uber.screen.idle_map",
+    "classificationName": "idle_map",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 177,
+            "top": 198,
+            "right": 1037,
+            "bottom": 2108
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 177,
+                    "top": 198,
+                    "right": 1037,
+                    "bottom": 2108
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 177,
+                            "top": 198,
+                            "right": 1037,
+                            "bottom": 2108
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 177,
+                                    "top": 198,
+                                    "right": 1037,
+                                    "bottom": 2108
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 177,
+                                            "top": 198,
+                                            "right": 1037,
+                                            "bottom": 2108
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 177,
+                                                    "top": 198,
+                                                    "right": 1037,
+                                                    "bottom": 2108
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 177,
+                                                            "top": 198,
+                                                            "right": 1037,
+                                                            "bottom": 2108
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 177,
+                                                                    "top": 198,
+                                                                    "right": 1037,
+                                                                    "bottom": 2108
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 177,
+                                                                            "top": 198,
+                                                                            "right": 1037,
+                                                                            "bottom": 2108
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 177,
+                                                                                    "top": 198,
+                                                                                    "right": 1037,
+                                                                                    "bottom": 2108
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 177,
+                                                                                    "top": 198,
+                                                                                    "right": 1037,
+                                                                                    "bottom": 2108
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 177,
+                                                                                            "top": 198,
+                                                                                            "right": 1037,
+                                                                                            "bottom": 198
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 177,
+                                                                                            "top": 198,
+                                                                                            "right": 1037,
+                                                                                            "bottom": 2108
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 177,
+                                                                                                    "top": 198,
+                                                                                                    "right": 1037,
+                                                                                                    "bottom": 2108
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/glide_screen_stack_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 177,
+                                                                                                            "top": 198,
+                                                                                                            "right": 1037,
+                                                                                                            "bottom": 2108
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/glide_active_view_container",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 177,
+                                                                                                                    "top": 198,
+                                                                                                                    "right": 1037,
+                                                                                                                    "bottom": 2108
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 177,
+                                                                                                                            "top": 198,
+                                                                                                                            "right": 1037,
+                                                                                                                            "bottom": 2108
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 177,
+                                                                                                                                    "top": 198,
+                                                                                                                                    "right": 1037,
+                                                                                                                                    "bottom": 2108
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 177,
+                                                                                                                                            "top": 198,
+                                                                                                                                            "right": 1037,
+                                                                                                                                            "bottom": 198
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/active_container",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 177,
+                                                                                                                                            "top": 198,
+                                                                                                                                            "right": 1037,
+                                                                                                                                            "bottom": 2108
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/background_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 177,
+                                                                                                                                                    "top": 198,
+                                                                                                                                                    "right": 1037,
+                                                                                                                                                    "bottom": 2108
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/screen_stack_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 177,
+                                                                                                                                                    "top": 198,
+                                                                                                                                                    "right": 1037,
+                                                                                                                                                    "bottom": 2108
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/ub__top_banner_container",
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 177,
+                                                                                                                                                            "top": 198,
+                                                                                                                                                            "right": 1037,
+                                                                                                                                                            "bottom": 198
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 177,
+                                                                                                                                                            "top": 198,
+                                                                                                                                                            "right": 1037,
+                                                                                                                                                            "bottom": 2108
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/home_screen_overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 177,
+                                                                                                                                                            "top": 198,
+                                                                                                                                                            "right": 1037,
+                                                                                                                                                            "bottom": 2108
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 177,
+                                                                                                                                                                    "top": 198,
+                                                                                                                                                                    "right": 1037,
+                                                                                                                                                                    "bottom": 2108
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 177,
+                                                                                                                                                                            "top": 198,
+                                                                                                                                                                            "right": 1037,
+                                                                                                                                                                            "bottom": 2108
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 177,
+                                                                                                                                                                                    "top": 198,
+                                                                                                                                                                                    "right": 1037,
+                                                                                                                                                                                    "bottom": 2108
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 177,
+                                                                                                                                                                                            "top": 198,
+                                                                                                                                                                                            "right": 1037,
+                                                                                                                                                                                            "bottom": 2108
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 536,
+                                                                                                                                                                                                    "top": 1174,
+                                                                                                                                                                                                    "right": 678,
+                                                                                                                                                                                                    "bottom": 1315
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 536,
+                                                                                                                                                                                                            "top": 1174,
+                                                                                                                                                                                                            "right": 678,
+                                                                                                                                                                                                            "bottom": 1315
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "text": "GO",
+                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 573,
+                                                                                                                                                                                                                    "top": 1218,
+                                                                                                                                                                                                                    "right": 643,
+                                                                                                                                                                                                                    "bottom": 1272
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 551,
+                                                                                                                                                                                                            "top": 1189,
+                                                                                                                                                                                                            "right": 663,
+                                                                                                                                                                                                            "bottom": 1300
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            },
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 177,
+                                                                                                                                                                    "top": 198,
+                                                                                                                                                                    "right": 1037,
+                                                                                                                                                                    "bottom": 420
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_left_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 206,
+                                                                                                                                                                            "top": 307,
+                                                                                                                                                                            "right": 291,
+                                                                                                                                                                            "bottom": 392
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "desc": "Home",
+                                                                                                                                                                                "id": "com.ubercab.driver:id/profile_entry",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 206,
+                                                                                                                                                                                    "top": 307,
+                                                                                                                                                                                    "right": 291,
+                                                                                                                                                                                    "bottom": 392
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_icon",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 206,
+                                                                                                                                                                                            "top": 307,
+                                                                                                                                                                                            "right": 291,
+                                                                                                                                                                                            "bottom": 392
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_photo",
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 206,
+                                                                                                                                                                                            "top": 307,
+                                                                                                                                                                                            "right": 291,
+                                                                                                                                                                                            "bottom": 392
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/earnings_tracker_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 385,
+                                                                                                                                                                            "top": 307,
+                                                                                                                                                                            "right": 829,
+                                                                                                                                                                            "bottom": 420
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__tracker_entry_content_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 512,
+                                                                                                                                                                                            "top": 307,
+                                                                                                                                                                                            "right": 702,
+                                                                                                                                                                                            "bottom": 420
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 512,
+                                                                                                                                                                                                    "top": 307,
+                                                                                                                                                                                                    "right": 702,
+                                                                                                                                                                                                    "bottom": 420
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_entry_public_mode_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 512,
+                                                                                                                                                                                                            "top": 307,
+                                                                                                                                                                                                            "right": 702,
+                                                                                                                                                                                                            "bottom": 420
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__earnings_tracker_indicator_card",
+                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 512,
+                                                                                                                                                                                                                    "top": 307,
+                                                                                                                                                                                                                    "right": 702,
+                                                                                                                                                                                                                    "bottom": 392
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 512,
+                                                                                                                                                                                                                            "top": 317,
+                                                                                                                                                                                                                            "right": 702,
+                                                                                                                                                                                                                            "bottom": 381
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 512,
+                                                                                                                                                                                                                                    "top": 317,
+                                                                                                                                                                                                                                    "right": 702,
+                                                                                                                                                                                                                                    "bottom": 381
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                        "text": "$0.00",
+                                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_counter_content_status",
+                                                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                            "left": 541,
+                                                                                                                                                                                                                                            "top": 317,
+                                                                                                                                                                                                                                            "right": 673,
+                                                                                                                                                                                                                                            "bottom": 381
+                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 593,
+                                                                                                                                                                                                                    "top": 392,
+                                                                                                                                                                                                                    "right": 621,
+                                                                                                                                                                                                                    "bottom": 420
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/my_hub_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 937,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 923,
+                                                                                                                                                                                    "top": 307,
+                                                                                                                                                                                    "right": 1008,
+                                                                                                                                                                                    "bottom": 392
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "desc": "Search for places",
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/search_entry_button",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 923,
+                                                                                                                                                                                            "top": 307,
+                                                                                                                                                                                            "right": 1008,
+                                                                                                                                                                                            "bottom": 392
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_center_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 540,
+                                                                                                                                                                            "top": 279,
+                                                                                                                                                                            "right": 540,
+                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 177,
+                                                                                                                                                            "top": 198,
+                                                                                                                                                            "right": 1037,
+                                                                                                                                                            "bottom": 2108
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_container",
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 177,
+                                                                                                                                                                            "top": 307,
+                                                                                                                                                                            "right": 1037,
+                                                                                                                                                                            "bottom": 307
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 177,
+                                                                                                                                                                            "top": 307,
+                                                                                                                                                                            "right": 1037,
+                                                                                                                                                                            "bottom": 2108
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 177,
+                                                                                                                                                                            "top": 307,
+                                                                                                                                                                            "right": 1037,
+                                                                                                                                                                            "bottom": 2108
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 177,
+                                                                                                                                                                                    "top": 307,
+                                                                                                                                                                                    "right": 1037,
+                                                                                                                                                                                    "bottom": 2108
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 177,
+                                                                                                                                                                                            "top": 307,
+                                                                                                                                                                                            "right": 1037,
+                                                                                                                                                                                            "bottom": 2108
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_view",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 177,
+                                                                                                                                                                            "top": 307,
+                                                                                                                                                                            "right": 1037,
+                                                                                                                                                                            "bottom": 2108
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_control_top_right_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 1008,
+                                                                                                                                                                                    "top": 307,
+                                                                                                                                                                                    "right": 1037,
+                                                                                                                                                                                    "bottom": 335
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_left_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 177,
+                                                                                                                                                                                    "top": 1180,
+                                                                                                                                                                                    "right": 320,
+                                                                                                                                                                                    "bottom": 2072
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_safety_toolkit_container",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 18,
+                                                                                                                                                                                            "top": 1252,
+                                                                                                                                                                                            "right": 161,
+                                                                                                                                                                                            "bottom": 1395
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 206,
+                                                                                                                                                                                                    "top": 1209,
+                                                                                                                                                                                                    "right": 291,
+                                                                                                                                                                                                    "bottom": 1294
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__safety_toolkit_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 206,
+                                                                                                                                                                                                            "top": 1209,
+                                                                                                                                                                                                            "right": 291,
+                                                                                                                                                                                                            "bottom": 1294
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Safety Toolkit",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__safety_toolkit_button_container",
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 206,
+                                                                                                                                                                                                                    "top": 1209,
+                                                                                                                                                                                                                    "right": 291,
+                                                                                                                                                                                                                    "bottom": 1294
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__shield_animation_view",
+                                                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 206,
+                                                                                                                                                                                                                            "top": 1209,
+                                                                                                                                                                                                                            "right": 291,
+                                                                                                                                                                                                                            "bottom": 1294
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_container",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 901,
+                                                                                                                                                                                    "top": 1091,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2373
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 909,
+                                                                                                                                                                                            "top": 1081,
+                                                                                                                                                                                            "right": 1022,
+                                                                                                                                                                                            "bottom": 1323
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_ugc_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 909,
+                                                                                                                                                                                                    "top": 1081,
+                                                                                                                                                                                                    "right": 1022,
+                                                                                                                                                                                                    "bottom": 1194
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__ugc_map_button",
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 909,
+                                                                                                                                                                                                            "top": 1081,
+                                                                                                                                                                                                            "right": 1022,
+                                                                                                                                                                                                            "bottom": 1194
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Report a map issue",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__ugc_map_button_icon",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 923,
+                                                                                                                                                                                                                    "top": 1095,
+                                                                                                                                                                                                                    "right": 1008,
+                                                                                                                                                                                                                    "bottom": 1180
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_earnings_trends_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 909,
+                                                                                                                                                                                                    "top": 1194,
+                                                                                                                                                                                                    "right": 1022,
+                                                                                                                                                                                                    "bottom": 1308
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 909,
+                                                                                                                                                                                                            "top": 1194,
+                                                                                                                                                                                                            "right": 1022,
+                                                                                                                                                                                                            "bottom": 1308
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Earnings Trends",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/map_control_earnings_trends",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 923,
+                                                                                                                                                                                                                    "top": 1209,
+                                                                                                                                                                                                                    "right": 1008,
+                                                                                                                                                                                                                    "bottom": 1294
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_bottom_right_buttons",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 1022,
+                                                                                                                                                                                                    "top": 1308,
+                                                                                                                                                                                                    "right": 1022,
+                                                                                                                                                                                                    "bottom": 1323
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_nav_button_layout",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 1022,
+                                                                                                                                                                                                            "top": 1308,
+                                                                                                                                                                                                            "right": 1022,
+                                                                                                                                                                                                            "bottom": 1308
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/bottom_sheet_container",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 177,
+                                                                                                                                                            "top": 198,
+                                                                                                                                                            "right": 1037,
+                                                                                                                                                            "bottom": 2108
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 177,
+                                                                                                                                                                    "top": 1344,
+                                                                                                                                                                    "right": 1037,
+                                                                                                                                                                    "bottom": 2108
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 1440,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant",
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 1440,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 1582
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_offline_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 1440,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 1582
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_overlay_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 177,
+                                                                                                                                                                                            "top": 1344,
+                                                                                                                                                                                            "right": 1037,
+                                                                                                                                                                                            "bottom": 1457
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_background_view",
+                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 177,
+                                                                                                                                                                                                    "top": 1344,
+                                                                                                                                                                                                    "right": 1037,
+                                                                                                                                                                                                    "bottom": 1457
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "You're ready to go online",
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_overlay_text",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 177,
+                                                                                                                                                                                                    "top": 1344,
+                                                                                                                                                                                                    "right": 1037,
+                                                                                                                                                                                                    "bottom": 1457
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_online_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 177,
+                                                                                                                                                                                            "top": 1344,
+                                                                                                                                                                                            "right": 1037,
+                                                                                                                                                                                            "bottom": 1457
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_padding_container",
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 177,
+                                                                                                                                                                                            "top": 1344,
+                                                                                                                                                                                            "right": 1037,
+                                                                                                                                                                                            "bottom": 1457
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_action_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 177,
+                                                                                                                                                                                                    "top": 1344,
+                                                                                                                                                                                                    "right": 290,
+                                                                                                                                                                                                    "bottom": 1457
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 177,
+                                                                                                                                                                                                            "top": 1344,
+                                                                                                                                                                                                            "right": 290,
+                                                                                                                                                                                                            "bottom": 1457
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Preferences",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/preferences_status_assistant_action_icon",
+                                                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 198,
+                                                                                                                                                                                                                    "top": 1365,
+                                                                                                                                                                                                                    "right": 269,
+                                                                                                                                                                                                                    "bottom": 1436
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 290,
+                                                                                                                                                                                                    "top": 1344,
+                                                                                                                                                                                                    "right": 924,
+                                                                                                                                                                                                    "bottom": 1457
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "Trip Planner",
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_content_override",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 290,
+                                                                                                                                                                                                            "top": 1344,
+                                                                                                                                                                                                            "right": 924,
+                                                                                                                                                                                                            "bottom": 1457
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_grabber_bar",
+                                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 551,
+                                                                                                                                                                                                            "top": 1358,
+                                                                                                                                                                                                            "right": 663,
+                                                                                                                                                                                                            "bottom": 1366
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_content",
+                                                                                                                                                                                                        "class": "android.widget.RelativeLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 290,
+                                                                                                                                                                                                            "top": 1372,
+                                                                                                                                                                                                            "right": 924,
+                                                                                                                                                                                                            "bottom": 1428
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "text": "You're offline",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_label_leading",
+                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 290,
+                                                                                                                                                                                                                    "top": 1372,
+                                                                                                                                                                                                                    "right": 924,
+                                                                                                                                                                                                                    "bottom": 1428
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_agenda_entry_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 924,
+                                                                                                                                                                                                    "top": 1379,
+                                                                                                                                                                                                    "right": 1037,
+                                                                                                                                                                                                    "bottom": 1421
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 924,
+                                                                                                                                                                                                            "top": 1379,
+                                                                                                                                                                                                            "right": 1037,
+                                                                                                                                                                                                            "bottom": 1421
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Agenda",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_agenda_button",
+                                                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 924,
+                                                                                                                                                                                                                    "top": 1379,
+                                                                                                                                                                                                                    "right": 1037,
+                                                                                                                                                                                                                    "bottom": 1421
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 1582,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 1584
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 177,
+                                                                                                                                                                                    "top": 1459,
+                                                                                                                                                                                    "right": 1037,
+                                                                                                                                                                                    "bottom": 2108
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/agenda_feed_content_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 1584,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 177,
+                                                                                                                                                                                                    "top": 1459,
+                                                                                                                                                                                                    "right": 1037,
+                                                                                                                                                                                                    "bottom": 2108
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.GridView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                                            "top": 1584,
+                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                                    "top": 1584,
+                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                    "bottom": 1584
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                                                            "top": 1584,
+                                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                                            "bottom": 1584
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                                    "top": 1586,
+                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                    "bottom": 1765
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                                                            "top": 1586,
+                                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                                            "bottom": 1765
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/action_section_view_icon",
+                                                                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                                                    "top": 1622,
+                                                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                                                    "bottom": 1729
+                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "text": "See driving time",
+                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/action_section_view_cta",
+                                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 179,
+                                                                                                                                                                                                                                    "top": 1647,
+                                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                                    "bottom": 1703
+                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                                    "top": 1767,
+                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                    "bottom": 1891
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "text": "Waybill",
+                                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                                                            "top": 1767,
+                                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                                            "bottom": 1891
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 3838,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1156,
+                                                                                                                                            "top": 2087,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2140
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1156,
+                                                                                                                                                    "top": 2087,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2140
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1169,
+                                                                                                                                                            "top": 2100,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2127
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1178,
+                                                                                                                                                    "top": 2137,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2137
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 954,
+                                                                                                                                            "right": -55,
+                                                                                                                                            "bottom": 1007
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 954,
+                                                                                                                                                    "right": -55,
+                                                                                                                                                    "bottom": 1007
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 967,
+                                                                                                                                                            "right": -68,
+                                                                                                                                                            "bottom": 994
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 1004,
+                                                                                                                                                    "right": -77,
+                                                                                                                                                    "bottom": 1004
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 582,
+                                                                                                                                            "top": 2360,
+                                                                                                                                            "right": 635,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 582,
+                                                                                                                                                    "top": 2360,
+                                                                                                                                                    "right": 635,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 595,
+                                                                                                                                                            "top": 2373,
+                                                                                                                                                            "right": 622,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 604,
+                                                                                                                                                    "top": 2410,
+                                                                                                                                                    "right": 613,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1133,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": -21
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1133,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": -21
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1146,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": -34
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1155,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": -24
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1119,
+                                                                                                                                            "top": 2237,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2290
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1119,
+                                                                                                                                                    "top": 2237,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2290
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1132,
+                                                                                                                                                            "top": 2250,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2277
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1141,
+                                                                                                                                                    "top": 2287,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2287
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 783,
+                                                                                                                                            "top": 1345,
+                                                                                                                                            "right": 836,
+                                                                                                                                            "bottom": 1398
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 783,
+                                                                                                                                                    "top": 1345,
+                                                                                                                                                    "right": 836,
+                                                                                                                                                    "bottom": 1398
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 796,
+                                                                                                                                                            "top": 1358,
+                                                                                                                                                            "right": 823,
+                                                                                                                                                            "bottom": 1385
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 805,
+                                                                                                                                                    "top": 1395,
+                                                                                                                                                    "right": 814,
+                                                                                                                                                    "bottom": 1395
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 691,
+                                                                                                                                            "top": 1773,
+                                                                                                                                            "right": 744,
+                                                                                                                                            "bottom": 1826
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 691,
+                                                                                                                                                    "top": 1773,
+                                                                                                                                                    "right": 744,
+                                                                                                                                                    "bottom": 1826
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 704,
+                                                                                                                                                            "top": 1786,
+                                                                                                                                                            "right": 731,
+                                                                                                                                                            "bottom": 1813
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 713,
+                                                                                                                                                    "top": 1823,
+                                                                                                                                                    "right": 722,
+                                                                                                                                                    "bottom": 1823
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 597,
+                                                                                                                                            "top": 2168,
+                                                                                                                                            "right": 650,
+                                                                                                                                            "bottom": 2221
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 597,
+                                                                                                                                                    "top": 2168,
+                                                                                                                                                    "right": 650,
+                                                                                                                                                    "bottom": 2221
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 610,
+                                                                                                                                                            "top": 2181,
+                                                                                                                                                            "right": 637,
+                                                                                                                                                            "bottom": 2208
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 619,
+                                                                                                                                                    "top": 2218,
+                                                                                                                                                    "right": 628,
+                                                                                                                                                    "bottom": 2218
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 848,
+                                                                                                                                            "top": 1047,
+                                                                                                                                            "right": 901,
+                                                                                                                                            "bottom": 1100
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 848,
+                                                                                                                                                    "top": 1047,
+                                                                                                                                                    "right": 901,
+                                                                                                                                                    "bottom": 1100
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 861,
+                                                                                                                                                            "top": 1060,
+                                                                                                                                                            "right": 888,
+                                                                                                                                                            "bottom": 1087
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 870,
+                                                                                                                                                    "top": 1097,
+                                                                                                                                                    "right": 879,
+                                                                                                                                                    "bottom": 1097
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1119,
+                                                                                                                                            "top": 510,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 563
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1119,
+                                                                                                                                                    "top": 510,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 563
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1132,
+                                                                                                                                                            "top": 523,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 550
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1141,
+                                                                                                                                                    "top": 560,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 560
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 2052,
+                                                                                                                                            "right": -10,
+                                                                                                                                            "bottom": 2105
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 2052,
+                                                                                                                                                    "right": -10,
+                                                                                                                                                    "bottom": 2105
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 2065,
+                                                                                                                                                            "right": -23,
+                                                                                                                                                            "bottom": 2092
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 2102,
+                                                                                                                                                    "right": -32,
+                                                                                                                                                    "bottom": 2102
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1084,
+                                                                                                                                            "top": 1595,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1648
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1084,
+                                                                                                                                                    "top": 1595,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1648
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1097,
+                                                                                                                                                            "top": 1608,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 1635
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1106,
+                                                                                                                                                    "top": 1645,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1645
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1089,
+                                                                                                                                            "top": 1607,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1660
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1089,
+                                                                                                                                                    "top": 1607,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1660
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1102,
+                                                                                                                                                            "top": 1620,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 1647
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1111,
+                                                                                                                                                    "top": 1657,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1657
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 127,
+                                                                                                                                            "top": 1032,
+                                                                                                                                            "right": 180,
+                                                                                                                                            "bottom": 1085
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 127,
+                                                                                                                                                    "top": 1032,
+                                                                                                                                                    "right": 180,
+                                                                                                                                                    "bottom": 1085
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 140,
+                                                                                                                                                            "top": 1045,
+                                                                                                                                                            "right": 167,
+                                                                                                                                                            "bottom": 1072
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 149,
+                                                                                                                                                    "top": 1082,
+                                                                                                                                                    "right": 158,
+                                                                                                                                                    "bottom": 1082
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 831,
+                                                                                                                                            "top": 274,
+                                                                                                                                            "right": 884,
+                                                                                                                                            "bottom": 327
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 831,
+                                                                                                                                                    "top": 274,
+                                                                                                                                                    "right": 884,
+                                                                                                                                                    "bottom": 327
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 844,
+                                                                                                                                                            "top": 287,
+                                                                                                                                                            "right": 871,
+                                                                                                                                                            "bottom": 314
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 853,
+                                                                                                                                                    "top": 324,
+                                                                                                                                                    "right": 862,
+                                                                                                                                                    "bottom": 324
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1095,
+                                                                                                                                            "top": 1072,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1125
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1095,
+                                                                                                                                                    "top": 1072,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1125
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1108,
+                                                                                                                                                            "top": 1085,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 1112
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1117,
+                                                                                                                                                    "top": 1122,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1122
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 834,
+                                                                                                                                            "top": 1420,
+                                                                                                                                            "right": 887,
+                                                                                                                                            "bottom": 1473
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 834,
+                                                                                                                                                    "top": 1420,
+                                                                                                                                                    "right": 887,
+                                                                                                                                                    "bottom": 1473
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 847,
+                                                                                                                                                            "top": 1433,
+                                                                                                                                                            "right": 874,
+                                                                                                                                                            "bottom": 1460
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 856,
+                                                                                                                                                    "top": 1470,
+                                                                                                                                                    "right": 865,
+                                                                                                                                                    "bottom": 1470
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 246,
+                                                                                                                                            "top": 1548,
+                                                                                                                                            "right": 299,
+                                                                                                                                            "bottom": 1601
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 246,
+                                                                                                                                                    "top": 1548,
+                                                                                                                                                    "right": 299,
+                                                                                                                                                    "bottom": 1601
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 259,
+                                                                                                                                                            "top": 1561,
+                                                                                                                                                            "right": 286,
+                                                                                                                                                            "bottom": 1588
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 268,
+                                                                                                                                                    "top": 1598,
+                                                                                                                                                    "right": 277,
+                                                                                                                                                    "bottom": 1598
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 953,
+                                                                                                                                            "top": 723,
+                                                                                                                                            "right": 1006,
+                                                                                                                                            "bottom": 776
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 953,
+                                                                                                                                                    "top": 723,
+                                                                                                                                                    "right": 1006,
+                                                                                                                                                    "bottom": 776
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 966,
+                                                                                                                                                            "top": 736,
+                                                                                                                                                            "right": 993,
+                                                                                                                                                            "bottom": 763
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 975,
+                                                                                                                                                    "top": 773,
+                                                                                                                                                    "right": 984,
+                                                                                                                                                    "bottom": 773
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 784,
+                                                                                                                                            "top": 882,
+                                                                                                                                            "right": 837,
+                                                                                                                                            "bottom": 935
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 784,
+                                                                                                                                                    "top": 882,
+                                                                                                                                                    "right": 837,
+                                                                                                                                                    "bottom": 935
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 797,
+                                                                                                                                                            "top": 895,
+                                                                                                                                                            "right": 824,
+                                                                                                                                                            "bottom": 922
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 806,
+                                                                                                                                                    "top": 932,
+                                                                                                                                                    "right": 815,
+                                                                                                                                                    "bottom": 932
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 108,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 161,
+                                                                                                                                            "bottom": 48
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 108,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 161,
+                                                                                                                                                    "bottom": 48
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 121,
+                                                                                                                                                            "top": 8,
+                                                                                                                                                            "right": 148,
+                                                                                                                                                            "bottom": 35
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 130,
+                                                                                                                                                    "top": 45,
+                                                                                                                                                    "right": 139,
+                                                                                                                                                    "bottom": 45
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 284,
+                                                                                                                                            "top": 1349,
+                                                                                                                                            "right": 337,
+                                                                                                                                            "bottom": 1402
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 284,
+                                                                                                                                                    "top": 1349,
+                                                                                                                                                    "right": 337,
+                                                                                                                                                    "bottom": 1402
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 297,
+                                                                                                                                                            "top": 1362,
+                                                                                                                                                            "right": 324,
+                                                                                                                                                            "bottom": 1389
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 306,
+                                                                                                                                                    "top": 1399,
+                                                                                                                                                    "right": 315,
+                                                                                                                                                    "bottom": 1399
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 780,
+                                                                                                                                            "top": 1576,
+                                                                                                                                            "right": 833,
+                                                                                                                                            "bottom": 1629
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 780,
+                                                                                                                                                    "top": 1576,
+                                                                                                                                                    "right": 833,
+                                                                                                                                                    "bottom": 1629
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 793,
+                                                                                                                                                            "top": 1589,
+                                                                                                                                                            "right": 820,
+                                                                                                                                                            "bottom": 1616
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 802,
+                                                                                                                                                    "top": 1626,
+                                                                                                                                                    "right": 811,
+                                                                                                                                                    "bottom": 1626
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 365,
+                                                                                                                                            "top": 265,
+                                                                                                                                            "right": 418,
+                                                                                                                                            "bottom": 318
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 365,
+                                                                                                                                                    "top": 265,
+                                                                                                                                                    "right": 418,
+                                                                                                                                                    "bottom": 318
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 378,
+                                                                                                                                                            "top": 278,
+                                                                                                                                                            "right": 405,
+                                                                                                                                                            "bottom": 305
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 387,
+                                                                                                                                                    "top": 315,
+                                                                                                                                                    "right": 396,
+                                                                                                                                                    "bottom": 315
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 940,
+                                                                                                                                            "top": 802,
+                                                                                                                                            "right": 993,
+                                                                                                                                            "bottom": 855
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 940,
+                                                                                                                                                    "top": 802,
+                                                                                                                                                    "right": 993,
+                                                                                                                                                    "bottom": 855
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 953,
+                                                                                                                                                            "top": 815,
+                                                                                                                                                            "right": 980,
+                                                                                                                                                            "bottom": 842
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 962,
+                                                                                                                                                    "top": 852,
+                                                                                                                                                    "right": 971,
+                                                                                                                                                    "bottom": 852
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 329,
+                                                                                                                                            "top": 1872,
+                                                                                                                                            "right": 382,
+                                                                                                                                            "bottom": 1925
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 329,
+                                                                                                                                                    "top": 1872,
+                                                                                                                                                    "right": 382,
+                                                                                                                                                    "bottom": 1925
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 342,
+                                                                                                                                                            "top": 1885,
+                                                                                                                                                            "right": 369,
+                                                                                                                                                            "bottom": 1912
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 351,
+                                                                                                                                                    "top": 1922,
+                                                                                                                                                    "right": 360,
+                                                                                                                                                    "bottom": 1922
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1025,
+                                                                                                                                            "top": 325,
+                                                                                                                                            "right": 1078,
+                                                                                                                                            "bottom": 378
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1025,
+                                                                                                                                                    "top": 325,
+                                                                                                                                                    "right": 1078,
+                                                                                                                                                    "bottom": 378
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1038,
+                                                                                                                                                            "top": 338,
+                                                                                                                                                            "right": 1065,
+                                                                                                                                                            "bottom": 365
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1047,
+                                                                                                                                                    "top": 375,
+                                                                                                                                                    "right": 1056,
+                                                                                                                                                    "bottom": 375
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 409,
+                                                                                                                                            "top": 1183,
+                                                                                                                                            "right": 462,
+                                                                                                                                            "bottom": 1236
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 409,
+                                                                                                                                                    "top": 1183,
+                                                                                                                                                    "right": 462,
+                                                                                                                                                    "bottom": 1236
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 422,
+                                                                                                                                                            "top": 1196,
+                                                                                                                                                            "right": 449,
+                                                                                                                                                            "bottom": 1223
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 431,
+                                                                                                                                                    "top": 1233,
+                                                                                                                                                    "right": 440,
+                                                                                                                                                    "bottom": 1233
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 342,
+                                                                                                                                            "top": 841,
+                                                                                                                                            "right": 395,
+                                                                                                                                            "bottom": 894
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 342,
+                                                                                                                                                    "top": 841,
+                                                                                                                                                    "right": 395,
+                                                                                                                                                    "bottom": 894
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 355,
+                                                                                                                                                            "top": 854,
+                                                                                                                                                            "right": 382,
+                                                                                                                                                            "bottom": 881
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 364,
+                                                                                                                                                    "top": 891,
+                                                                                                                                                    "right": 373,
+                                                                                                                                                    "bottom": 891
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 593,
+                                                                                                                                            "top": 806,
+                                                                                                                                            "right": 646,
+                                                                                                                                            "bottom": 859
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 593,
+                                                                                                                                                    "top": 806,
+                                                                                                                                                    "right": 646,
+                                                                                                                                                    "bottom": 859
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 606,
+                                                                                                                                                            "top": 819,
+                                                                                                                                                            "right": 633,
+                                                                                                                                                            "bottom": 846
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 615,
+                                                                                                                                                    "top": 856,
+                                                                                                                                                    "right": 624,
+                                                                                                                                                    "bottom": 856
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 417,
+                                                                                                                                            "top": 2061,
+                                                                                                                                            "right": 470,
+                                                                                                                                            "bottom": 2114
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 417,
+                                                                                                                                                    "top": 2061,
+                                                                                                                                                    "right": 470,
+                                                                                                                                                    "bottom": 2114
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 430,
+                                                                                                                                                            "top": 2074,
+                                                                                                                                                            "right": 457,
+                                                                                                                                                            "bottom": 2101
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 439,
+                                                                                                                                                    "top": 2111,
+                                                                                                                                                    "right": 448,
+                                                                                                                                                    "bottom": 2111
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 478,
+                                                                                                                                            "top": 1641,
+                                                                                                                                            "right": 531,
+                                                                                                                                            "bottom": 1694
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 478,
+                                                                                                                                                    "top": 1641,
+                                                                                                                                                    "right": 531,
+                                                                                                                                                    "bottom": 1694
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 491,
+                                                                                                                                                            "top": 1654,
+                                                                                                                                                            "right": 518,
+                                                                                                                                                            "bottom": 1681
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 500,
+                                                                                                                                                    "top": 1691,
+                                                                                                                                                    "right": 509,
+                                                                                                                                                    "bottom": 1691
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 905,
+                                                                                                                                            "top": 515,
+                                                                                                                                            "right": 958,
+                                                                                                                                            "bottom": 568
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 905,
+                                                                                                                                                    "top": 515,
+                                                                                                                                                    "right": 958,
+                                                                                                                                                    "bottom": 568
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 918,
+                                                                                                                                                            "top": 528,
+                                                                                                                                                            "right": 945,
+                                                                                                                                                            "bottom": 555
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 927,
+                                                                                                                                                    "top": 565,
+                                                                                                                                                    "right": 936,
+                                                                                                                                                    "bottom": 565
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 553,
+                                                                                                                                            "top": 1085,
+                                                                                                                                            "right": 606,
+                                                                                                                                            "bottom": 1138
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 553,
+                                                                                                                                                    "top": 1085,
+                                                                                                                                                    "right": 606,
+                                                                                                                                                    "bottom": 1138
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 566,
+                                                                                                                                                            "top": 1098,
+                                                                                                                                                            "right": 593,
+                                                                                                                                                            "bottom": 1125
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 575,
+                                                                                                                                                    "top": 1135,
+                                                                                                                                                    "right": 584,
+                                                                                                                                                    "bottom": 1135
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 351,
+                                                                                                                                            "top": 1039,
+                                                                                                                                            "right": 404,
+                                                                                                                                            "bottom": 1092
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 351,
+                                                                                                                                                    "top": 1039,
+                                                                                                                                                    "right": 404,
+                                                                                                                                                    "bottom": 1092
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 364,
+                                                                                                                                                            "top": 1052,
+                                                                                                                                                            "right": 391,
+                                                                                                                                                            "bottom": 1079
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 373,
+                                                                                                                                                    "top": 1089,
+                                                                                                                                                    "right": 382,
+                                                                                                                                                    "bottom": 1089
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 285,
+                                                                                                                                            "top": 167,
+                                                                                                                                            "right": 338,
+                                                                                                                                            "bottom": 220
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 285,
+                                                                                                                                                    "top": 167,
+                                                                                                                                                    "right": 338,
+                                                                                                                                                    "bottom": 220
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 298,
+                                                                                                                                                            "top": 180,
+                                                                                                                                                            "right": 325,
+                                                                                                                                                            "bottom": 207
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 307,
+                                                                                                                                                    "top": 217,
+                                                                                                                                                    "right": 316,
+                                                                                                                                                    "bottom": 217
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 333,
+                                                                                                                                            "top": 1103,
+                                                                                                                                            "right": 386,
+                                                                                                                                            "bottom": 1156
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 333,
+                                                                                                                                                    "top": 1103,
+                                                                                                                                                    "right": 386,
+                                                                                                                                                    "bottom": 1156
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 346,
+                                                                                                                                                            "top": 1116,
+                                                                                                                                                            "right": 373,
+                                                                                                                                                            "bottom": 1143
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 355,
+                                                                                                                                                    "top": 1153,
+                                                                                                                                                    "right": 364,
+                                                                                                                                                    "bottom": 1153
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 804,
+                                                                                                                                            "top": 394,
+                                                                                                                                            "right": 857,
+                                                                                                                                            "bottom": 447
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 804,
+                                                                                                                                                    "top": 394,
+                                                                                                                                                    "right": 857,
+                                                                                                                                                    "bottom": 447
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 817,
+                                                                                                                                                            "top": 407,
+                                                                                                                                                            "right": 844,
+                                                                                                                                                            "bottom": 434
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 826,
+                                                                                                                                                    "top": 444,
+                                                                                                                                                    "right": 835,
+                                                                                                                                                    "bottom": 444
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 638,
+                                                                                                                                            "top": 967,
+                                                                                                                                            "right": 691,
+                                                                                                                                            "bottom": 1020
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 638,
+                                                                                                                                                    "top": 967,
+                                                                                                                                                    "right": 691,
+                                                                                                                                                    "bottom": 1020
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 651,
+                                                                                                                                                            "top": 980,
+                                                                                                                                                            "right": 678,
+                                                                                                                                                            "bottom": 1007
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 660,
+                                                                                                                                                    "top": 1017,
+                                                                                                                                                    "right": 669,
+                                                                                                                                                    "bottom": 1017
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 412,
+                                                                                                                                            "top": 424,
+                                                                                                                                            "right": 465,
+                                                                                                                                            "bottom": 477
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 412,
+                                                                                                                                                    "top": 424,
+                                                                                                                                                    "right": 465,
+                                                                                                                                                    "bottom": 477
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 425,
+                                                                                                                                                            "top": 437,
+                                                                                                                                                            "right": 452,
+                                                                                                                                                            "bottom": 464
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 434,
+                                                                                                                                                    "top": 474,
+                                                                                                                                                    "right": 443,
+                                                                                                                                                    "bottom": 474
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 296,
+                                                                                                                                            "top": 1408,
+                                                                                                                                            "right": 332,
+                                                                                                                                            "bottom": 1444
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 676,
+                                                                                                                                            "top": 686,
+                                                                                                                                            "right": 712,
+                                                                                                                                            "bottom": 722
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 292,
+                                                                                                                                            "top": 929,
+                                                                                                                                            "right": 328,
+                                                                                                                                            "bottom": 965
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 576,
+                                                                                                                                            "top": 994,
+                                                                                                                                            "right": 612,
+                                                                                                                                            "bottom": 1030
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 832,
+                                                                                                                                            "top": 778,
+                                                                                                                                            "right": 868,
+                                                                                                                                            "bottom": 814
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 370,
+                                                                                                                                            "top": 2072,
+                                                                                                                                            "right": 406,
+                                                                                                                                            "bottom": 2108
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 692,
+                                                                                                                                            "top": 952,
+                                                                                                                                            "right": 728,
+                                                                                                                                            "bottom": 988
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 703,
+                                                                                                                                            "top": 1540,
+                                                                                                                                            "right": 739,
+                                                                                                                                            "bottom": 1576
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1149,
+                                                                                                                                            "top": 1814,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1850
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 570,
+                                                                                                                                            "top": 655,
+                                                                                                                                            "right": 606,
+                                                                                                                                            "bottom": 691
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 732,
+                                                                                                                                            "top": 783,
+                                                                                                                                            "right": 768,
+                                                                                                                                            "bottom": 819
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/matchers/rules/uber.json5
+++ b/matchers/rules/uber.json5
@@ -1068,10 +1068,63 @@
     {
       "id": "uber.screen.idle_map",
       "priority": 130,
+      // #857 — this rule claims `modeHint: offline`, so it must never fire on ABSENCE.
+      // The pre-#857 shape was "the home overlay container exists AND no online text is
+      // present", but that container is present online AND offline, so ANY partially
+      // rendered tree (status sheet not inflated, label subtree missing, label mid-refresh
+      // reading "Loading…", or the 115-node zero-text worst case) satisfied it vacuously
+      // and forged an Online→Offline edge. Field measurement over the 2026-07-25 pull:
+      // 20 of 27 Online→Offline edges fired on frames carrying no offline evidence at all;
+      // 6 of them destroyed a real session (7 real toggles recorded as 13 sessions).
+      //
+      // So POSITIVE evidence is required, mirroring `doordash.screen.idle_map`: the
+      // fielded offline-home labels (`status_label_leading` = "You're offline", the
+      // `status_assistant_overlay_text` = "You're ready to go online" variant, or the big
+      // "GO" button) — all three co-occur with a genuinely offline home in the corpus, and
+      // none appears on any online (awaiting_offer / offer / active_trip) frame.
+      //
+      // Bias is deliberately "believe still online": a partial genuinely-offline frame now
+      // classifies UNKNOWN, makes no mode claim, and the platform region keeps its last
+      // mode until a settled frame or the (already recognized) `uber.click.go_offline`
+      // arrives. A false offline destroys a session record permanently; a delayed offline
+      // costs seconds.
       "state": {
         "flow": "idle",
         "modeHint": "offline"
       },
+      "reject": [
+        // Online-implying text — previously the `notExists` arms of `require`, moved here
+        // to match the DoorDash rule's shape. Behaviourally identical, read as guards.
+        {
+          "exists": {
+            "hasText": "You're online"
+          }
+        },
+        {
+          "exists": {
+            "hasTextContaining": "Finding trips"
+          }
+        },
+        // Status label mid-refresh: the sheet is inflated but its text has not settled, so
+        // whatever the label says next is unknown. Defense-in-depth — the positive arms
+        // below already fail such a frame; this makes the intent explicit and keeps the
+        // rule safe if a future positive marker is added that can co-render with a
+        // still-loading label. (NOTE: "Unable to go offline" is deliberately NOT rejected —
+        // it is Uber's overlay-permission warning and co-occurs with 7 of the 9 genuinely
+        // offline corpus frames.)
+        {
+          "exists": {
+            "all": [
+              {
+                "hasIdSuffix": "status_label_leading"
+              },
+              {
+                "hasTextContaining": "Loading"
+              }
+            ]
+          }
+        }
+      ],
       "require": {
         "all": [
           {
@@ -1080,13 +1133,35 @@
             }
           },
           {
-            "notExists": {
-              "hasText": "You're online"
-            }
-          },
-          {
-            "notExists": {
-              "hasTextContaining": "Finding trips"
+            "exists": {
+              "any": [
+                {
+                  "all": [
+                    {
+                      "hasIdSuffix": "status_label_leading"
+                    },
+                    {
+                      "hasText": "You're offline"
+                    }
+                  ]
+                },
+                {
+                  "all": [
+                    {
+                      "hasIdSuffix": "status_assistant_overlay_text"
+                    },
+                    {
+                      "hasText": "You're ready to go online"
+                    }
+                  ]
+                },
+                {
+                  // The big GO button. It carries no view id, so the anchor is the exact
+                  // (case-sensitive) label — tight enough that map chrome, whose text nodes
+                  // are merchant names, cannot collide.
+                  "hasTextCaseSensitive": "GO"
+                }
+              ]
             }
           }
         ]


### PR DESCRIPTION
Fixes #857.

`uber.screen.idle_map` claims `modeHint: offline`, and it claimed it from **absence**: `home_screen_overlay_container` exists (present online AND offline) + `notExists` of the two online labels. Any partially rendered tree satisfied that vacuously and forged an Online→Offline edge. Measured over the 2026-07-25 pull: **20 of 27** Online→Offline edges fired on frames carrying no offline evidence at all; 6 of them destroyed a real session (7 real toggles recorded as 13 `session_records`, permanently — the read model is a faithful refold of the log).

Rewritten to require **positive** offline evidence, mirroring `doordash.screen.idle_map`'s shape.

## The new blocks

```json5
"reject": [
  { "exists": { "hasText": "You're online" } },
  { "exists": { "hasTextContaining": "Finding trips" } },
  { "exists": { "all": [
      { "hasIdSuffix": "status_label_leading" },
      { "hasTextContaining": "Loading" }
  ] } }
],
"require": {
  "all": [
    { "exists": { "hasIdSuffix": "home_screen_overlay_container" } },
    { "exists": { "any": [
        { "all": [
            { "hasIdSuffix": "status_label_leading" },
            { "hasText": "You're offline" }
        ] },
        { "all": [
            { "hasIdSuffix": "status_assistant_overlay_text" },
            { "hasText": "You're ready to go online" }
        ] },
        { "hasTextCaseSensitive": "GO" }
    ] } }
  ]
}
```

The two `notExists` arms moved out of `require` into `reject` (behaviourally identical, reads as guards — the DoorDash shape). The `Loading…` arm is new defense-in-depth: the positive arms already fail such a frame, but it makes the mid-refresh case explicit.

**One deviation from the plan, evidence-driven: `"Unable to go offline"` is deliberately NOT rejected.** It is Uber's overlay-permission warning, not an online signal, and it co-occurs with **7 of the 9** genuinely-offline frames in the pull (every frame that also renders `status_label_leading = "You're offline"` and the GO button). Rejecting it would have thrown away most of the true positives.

The `GO` anchor is `hasTextCaseSensitive` (the plain `hasText` predicate is case-insensitive) because the GO button carries no view id — the exact-case label is tight enough that map chrome, whose text nodes are merchant names, cannot collide. In the pull, `"GO"` appears in **zero** of the 163 `awaiting_offer`, 102 `offer`, 19 `home_dashboard` or 114 `UNKNOWN` captures — it is offline-exclusive on the fielded surface.

## Classification census (2026-07-25 pull, production ruleset)

| Capture folder | n | before | after |
|---|---|---|---|
| `uber/…/idle_map` | 31 | `idle_map` 31 | **`idle_map` 9, `UNKNOWN` 22** |
| `uber/…/awaiting_offer` | 163 | `awaiting_offer` 163 | `awaiting_offer` 163 |
| `uber/…/offer` | 102 | `offer` 102 | `offer` 102 |
| `uber/…/home_dashboard` | 19 | `home_dashboard` 14, `notifications_view` 5 | unchanged |
| `uber/…/UNKNOWN` | 114 | `UNKNOWN` 112, `notifications_view` 2 | unchanged |

The 9 survivors are exactly the 9 evidence-bearing frames (`"You're offline"` and the GO button co-occur perfectly across the pull; `"You're ready to go online"` appears on one of them). The 22 that fall to UNKNOWN are the evidence-free partials — including all four named specimens: `2c28dc` (115 nodes, zero text), `a4bfa3` / `992e80` (status label subtree missing), `4571c6` (label mid-refresh reading `Loading…`). **No other Uber rule picks any of them up** — verified by running the full production screen ruleset over every capture in the pull, not just `idle_map`.

The two `home_dashboard` → `notifications_view` and `UNKNOWN` → `notifications_view` reclassifications are pre-existing drift between the device build and current `master`, unchanged by this diff.

## Bias rationale

A false offline destroys a session record permanently, while a delayed offline costs seconds and the already-recognized `uber.click.go_offline` click rule covers every deliberate toggle — so a genuinely-offline partial frame now classifying UNKNOWN (no mode claim; the region keeps its last mode until a settled frame arrives) is the cheaper error.

## Tests

- New `UberIdleMapOfflineEvidenceTest` (added to `AllMatchersSuite`) over `fixtures/uber_idle_map_partial/` — the four real partial-render specimens. Three assertions each: the fixture still carries `home_screen_overlay_container` (so the negative can't pass on an unrelated tree — it pins that each fixture really is an instance of the bug's precondition), it classifies `UNKNOWN`, and it trips no `SnapshotSecurityScanner` finding.
- Positive half: two true-offline captures committed to `snapshots/idle_map/`, guarded by the existing `GoldenSnapshotRegressionTest` — `a75080` (the `"You're ready to go online"` overlay variant) and `4918e3` (the `"Unable to go offline"` co-occurrence proof, i.e. the specimen that justifies the omitted reject arm).
- `ParseOutputGoldenTest`: with the rule change alone (before adding corpus) the golden was **unchanged** — `uber.screen.idle_map` has no `parse` block and no other rule's output moved. Regenerating after adding the two corpus files produced **exactly two NEW keys, zero CHANGED, zero GONE**.
- `./gradlew testDebugUnitTest :domain:test` — green. `./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` — green (774 tests).

PII sweep on all six committed captures: chrome + merchant map-marker names only (`GO`, `TODAY`, `$0.00`, `Waybill`, `Trip Radar`, `Required actions (1)`, restaurant names). No customer names, addresses, PINs, gate codes, or dasher banking content; the manual marker grep (`Deliver to `/`Pickup for `/`For Firstname I.`/`Customer Notes`/`pin \d{3,}`/`Message from `) returns nothing.

### Design-goal review

- **8 — platform-agnostic core.** Entirely data-side. The diff touches one rule in `matchers/rules/uber.json5` plus corpus and tests; no `:core:pipeline` / `:core:state` / `:domain` source changes, no new platform literal in logic, no new rule vocabulary (every predicate used — `hasIdSuffix`, `hasText`, `hasTextCaseSensitive`, `hasTextContaining`, node-level `all`/`any`, rule-level `reject` — already exists in the compiler and the schema). The bias this encodes is expressed as *ruleset data for one platform*, exactly where a per-platform difference belongs; DoorDash's own `idle_map` is untouched and already had this shape.
- **6 — security & privacy first.** The fail direction moves the safe way: the rule now *withholds* a claim on ambiguous input instead of asserting one, so the untrusted partially-rendered tree can no longer drive a destructive state edge. The 22 newly-UNKNOWN frames route to the UNKNOWN capture path, which is debug-only (`NoOpCaptureBus` in release) and passes the `SensitiveTextMarkers` + `CustomerTextMarkers` backstops; they carry no customer surface. Six real captures enter the repo — each hand-swept for PII (above) and, for the four fixtures, pinned non-toxic by an assertion in the new test. No change to the sensitive-block side: `uber.screen.sensitive.known` (priority 0, `overrideable: false`) is evaluated in the non-overrideable partition ahead of this rule and is untouched.
- **5 — SSOT.** No second copy of the offline vocabulary: the three labels live only in this rule, and the negative fixtures assert *behaviour* (classifies UNKNOWN) rather than re-encoding the marker strings.
- **3 — single responsibility / testing.** The negative corpus lives outside `snapshots/` (in `fixtures/uber_idle_map_partial/`) precisely so it does not interact with the intent-folder machinery — the golden guard, the parse golden, and the coverage ratchet all key off `snapshots/<intent>/`, and a "must stay UNKNOWN" fixture has no intent folder to belong to. `snapshots/UNKNOWN/` was rejected as the home because its resident tool (`UnknownScreenAnalysisTest`) *mutates* — it graduates a newly-recognized file out of the folder — which is triage, not a regression pin.
- **1 (UDF) / 2 (MAD) / 7 (logging) / Reactive UI** — untouched: no reducer, no effect, no log site, no composable in the diff.

### Field validation

Watch on the next Uber dash:
- No spurious "Started/Done Ubering!" churn while multi-apping — the bubble should announce a mode change only when you actually pressed GO or the offline toggle.
- Session count at the end of the dash equals the number of real toggles you made.
- Desk check on the next pull: Online→Offline edges should be 1:1 with `uber.click.go_offline` observations or with settled offline frames carrying one of the three labels; the previously-fatal pattern (an offline edge with zero Uber frames inside the following 10 s grace) should be gone.
