### PR TITLE
fix(bubble): #867 thread the originating session through UpdateBubble → chat save (write-side)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -210,7 +210,8 @@ class SideEffectEngine @Inject constructor(
             }
 
             is AppEffect.UpdateBubble -> {
-                bubbleManager.postMessage(effect.text, effect.persona, effect.expand)
+                // #867: the effect's OWN originating session, not the active-at-save-time one.
+                bubbleManager.postMessage(effect.text, effect.persona, effect.expand, effect.sessionId)
             }
 
             is AppEffect.CaptureScreenshot -> captureEvidence(effect)
@@ -414,7 +415,9 @@ class SideEffectEngine @Inject constructor(
                 pendingOfferNotifications[hashKey]?.cancel()
                 val job = engineScope.launch(start = CoroutineStart.LAZY) {
                     delay(OFFER_NOTIFICATION_DELAY_MS)
-                    bubbleManager.postOfferNotification(effect.offer, effect.evaluation, effect.platform)
+                    bubbleManager.postOfferNotification(
+                        effect.offer, effect.evaluation, effect.platform, effect.sessionId,
+                    )
                 }
                 job.invokeOnCompletion { pendingOfferNotifications.remove(hashKey, job) }
                 pendingOfferNotifications[hashKey] = job
@@ -567,6 +570,8 @@ class SideEffectEngine @Inject constructor(
         // Persona parsing is the SSOT ChatPersona.fromWire (#audit-2); the bubble
         // verb's schema can't carry a Merchant/Customer name, so none is supplied.
         val persona = ChatPersona.fromWire(args["persona"])
+        // #867: no explicit session — a rule-declared bubble's args carry no session provenance
+        // (RequestEffect is rule data, not a region diff), so it falls back to the active session.
         bubbleManager.postMessage(text, persona)
     }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -316,7 +316,7 @@ class SideEffectEngine @Inject constructor(
                 // the crash, so recovery reconciliation re-establishes tracking without re-anchoring.
                 odometerEffectHandler.onSessionStarted(effect.sessionId)
             }
-            is AppEffect.EndSession -> bubbleManager.endSession(effect.platformName)
+            is AppEffect.EndSession -> bubbleManager.endSession(effect.platformName, effect.sessionId)
             is AppEffect.StartOdometer -> odometerEffectHandler.startUp()
             is AppEffect.StopOdometer -> odometerEffectHandler.shutDown()
             is AppEffect.PauseOdometer -> odometerEffectHandler.pause()

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TipEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TipEffectHandler.kt
@@ -29,6 +29,9 @@ class TipEffectHandler @Inject constructor(
                 Timber.tag("Effects").d(
                     "Tip received: %s from %s", Formats.money(effect.amount), effect.storeName,
                 )
+                // #867: no explicit session — ProcessTipNotification comes from a push that carries
+                // no session provenance (a tip can even land after the dash ended), so the chat
+                // line falls back to the active session.
                 bubbleManager.postMessage(
                     text = context.getString(
                         R.string.tip_effect_chat_message,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -169,13 +169,19 @@ class BubbleManager @Inject constructor(
     }
 
     /**
-     * Session chat copy only — the dash id derives from state (#437). #867: no explicit session —
-     * [cloud.trotter.dashbuddy.core.state.AppEffect.EndSession] carries only the platform name, and
-     * the ending session is still the active one at this instant, so the fallback is correct here.
+     * Session chat copy only — the dash id derives from state (#437). #867: [sessionId] is the
+     * session that just ENDED, carried by the effect. The active session is NOT a safe stand-in
+     * here: a grace-lapsed end commits on a `GRACE_COMMIT` timer or a foreign platform's frame (so
+     * `activeSessionId` is the OTHER dash), and the ending region's own session is already null by
+     * execute time even single-app (so the line would file session-less).
      */
-    fun endSession(platformName: String? = null) {
+    fun endSession(platformName: String? = null, sessionId: String? = null) {
         val verb = sessionVerb(platformName)
-        postMessage(context.getString(R.string.bubble_chat_session_done, verb), ChatPersona.Dispatcher)
+        postMessage(
+            context.getString(R.string.bubble_chat_session_done, verb),
+            ChatPersona.Dispatcher,
+            sessionId = sessionId,
+        )
     }
 
     /**

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -154,13 +154,25 @@ class BubbleManager @Inject constructor(
         pushDynamicShortcut()
     }
 
-    /** Session chat copy only — the dash id derives from state (#437). */
+    /**
+     * Session chat copy only — the dash id derives from state (#437). #867: the STARTING session
+     * is known here, so the line is filed to it explicitly (the derived `activeSessionId` may not
+     * have caught up to — or may belong to — another platform's dash).
+     */
     fun startSession(sessionId: String, platformName: String) {
         val verb = sessionVerb(platformName)
-        postMessage(context.getString(R.string.bubble_chat_session_started, verb), ChatPersona.Dispatcher)
+        postMessage(
+            context.getString(R.string.bubble_chat_session_started, verb),
+            ChatPersona.Dispatcher,
+            sessionId = sessionId,
+        )
     }
 
-    /** Session chat copy only — the dash id derives from state (#437). */
+    /**
+     * Session chat copy only — the dash id derives from state (#437). #867: no explicit session —
+     * [cloud.trotter.dashbuddy.core.state.AppEffect.EndSession] carries only the platform name, and
+     * the ending session is still the active one at this instant, so the fallback is correct here.
+     */
     fun endSession(platformName: String? = null) {
         val verb = sessionVerb(platformName)
         postMessage(context.getString(R.string.bubble_chat_session_done, verb), ChatPersona.Dispatcher)
@@ -197,10 +209,22 @@ class BubbleManager @Inject constructor(
         }
     }
 
+    /**
+     * Post a chat line: save it to the dash's history + show the chathead notification.
+     *
+     * [sessionId] is the message's OWN originating session (#867). Null falls back to
+     * [activeSessionId] — the session of whichever platform produced the last recognized frame —
+     * which is correct only for a genuinely session-less message (a welcome line, a rule-declared
+     * bubble, a tip push). While multi-apping the active session flips on every app switch, so any
+     * caller that knows the originating session MUST pass it: without it an Uber offer's outcome
+     * line could be filed into the DoorDash session's chat, durably corrupting the per-session
+     * history (not just the live view).
+     */
     fun postMessage(
         text: CharSequence,
         persona: ChatPersona = ChatPersona.Dispatcher,
-        expand: Boolean = false
+        expand: Boolean = false,
+        sessionId: String? = null,
     ) {
         // #551 P7: chat text can carry raw merchant/store text ("Pickup: <store>"), so the
         // shareable INFO stream logs a counts-only milestone; the raw body stays on DEBUG.
@@ -210,7 +234,7 @@ class BubbleManager @Inject constructor(
 
         // 2. UPDATED: Launched in a coroutine because the Repository is pure suspend now!
         scope.launch {
-            chatRepository.saveMessage(activeSessionId.value, text.toString(), persona)
+            chatRepository.saveMessage(sessionId ?: activeSessionId.value, text.toString(), persona)
         }
 
         // Post Notification
@@ -337,14 +361,20 @@ class BubbleManager @Inject constructor(
      * DoorDash from the accessibility live-window set and fails the verified click (#457).
      * Formatting happens HERE at the UI edge (#436) — the engine hands over the domain evaluation.
      */
-    fun postOfferNotification(offer: FlowCardSnapshot.Offer, evaluation: OfferEvaluation, platform: Platform) {
+    fun postOfferNotification(
+        offer: FlowCardSnapshot.Offer,
+        evaluation: OfferEvaluation,
+        platform: Platform,
+        /** The offer's own originating session (#867); null falls back to [activeSessionId]. */
+        sessionId: String? = null,
+    ) {
         val summary = evaluation.toNotificationSummary()
         val persona = evaluation.notificationPersona()
         // #551 P7: the offer summary ends with the merchant name (raw third-party UI text), so
         // INFO carries a PII-safe milestone and the raw summary stays on the DEBUG firehose.
         Timber.tag("Chat").i("offer posted [%s] (%d chars)", persona.logLabel, summary.length)
         Timber.tag("Chat").d("[%s]: %s", persona.displayName, summary)
-        scope.launch { chatRepository.saveMessage(activeSessionId.value, summary.toString(), persona) }
+        scope.launch { chatRepository.saveMessage(sessionId ?: activeSessionId.value, summary.toString(), persona) }
         showOfferHeadsUp(offer, summary, persona, platform)
     }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -456,7 +456,7 @@ class SideEffectEngineTest {
         advanceTimeBy(SideEffectEngine.OFFER_NOTIFICATION_DELAY_MS + 100)
         runCurrent()
 
-        verify(bubbleManager, never()).postOfferNotification(any(), any(), any())
+        verify(bubbleManager, never()).postOfferNotification(any(), any(), any(), anyOrNull())
     }
 
     @Test
@@ -468,7 +468,7 @@ class SideEffectEngineTest {
         advanceTimeBy(SideEffectEngine.OFFER_NOTIFICATION_DELAY_MS + 100)
         runCurrent()
 
-        verify(bubbleManager, times(1)).postOfferNotification(any(), any(), any())
+        verify(bubbleManager, times(1)).postOfferNotification(any(), any(), any(), anyOrNull())
     }
 
     @Test
@@ -480,7 +480,7 @@ class SideEffectEngineTest {
         runCurrent()
         advanceTimeBy(SideEffectEngine.OFFER_NOTIFICATION_DELAY_MS + 100)
         runCurrent()
-        verify(bubbleManager, times(1)).postOfferNotification(any(), any(), any())
+        verify(bubbleManager, times(1)).postOfferNotification(any(), any(), any(), anyOrNull())
 
         engine.process(AppEffect.CancelOfferNotification(offerHash = "hash-9"))
         runCurrent()
@@ -543,7 +543,7 @@ class SideEffectEngineTest {
         engine.process(bubble, recovering = false)
         runCurrent()
 
-        verify(bubbleManager, times(1)).postMessage(eq("Pickup: Petsmart"), any(), any())
+        verify(bubbleManager, times(1)).postMessage(eq("Pickup: Petsmart"), any(), any(), anyOrNull())
         verifyBlocking(effectsFiredDao, times(1)) { markFired(any()) }
     }
 
@@ -559,7 +559,23 @@ class SideEffectEngineTest {
         engine.process(bubble, recovering = false)
         runCurrent()
 
-        verify(bubbleManager, times(2)).postMessage(eq("Offer Accepted"), any(), any())
+        verify(bubbleManager, times(2)).postMessage(eq("Offer Accepted"), any(), any(), anyOrNull())
+    }
+
+    @Test
+    fun `the bubble effect's originating session reaches BubbleManager (#867)`() = runTest {
+        // #867: the chat save used to read the ACTIVE session at save time, so a multi-app frame
+        // flip could file one platform's message into the other's chat. The engine is a pass-through
+        // for the provenance the effect carries — nothing here may re-derive it.
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+
+        engine.process(AppEffect.UpdateBubble("Offer Declined", sessionId = "uber-sess"), recovering = false)
+        engine.process(AppEffect.UpdateBubble("Welcome"), recovering = false)
+        runCurrent()
+
+        verify(bubbleManager).postMessage(eq("Offer Declined"), any(), any(), eq("uber-sess"))
+        // A genuinely session-less effect still hands null down (BubbleManager falls back).
+        verify(bubbleManager).postMessage(eq("Welcome"), any(), any(), eq(null))
     }
 
     @Test
@@ -605,9 +621,9 @@ class SideEffectEngineTest {
         runCurrent()
 
         inOrder(bubbleManager) {
-            verify(bubbleManager).postMessage(eq("first"), any(), any())
-            verify(bubbleManager).postMessage(eq("second"), any(), any())
-            verify(bubbleManager).postMessage(eq("third"), any(), any())
+            verify(bubbleManager).postMessage(eq("first"), any(), any(), anyOrNull())
+            verify(bubbleManager).postMessage(eq("second"), any(), any(), anyOrNull())
+            verify(bubbleManager).postMessage(eq("third"), any(), any(), anyOrNull())
         }
     }
 
@@ -653,7 +669,7 @@ class SideEffectEngineTest {
         engine.process(AppEffect.UpdateBubble("after-timer"))
         runCurrent() // no time advanced — the timer is still pending
 
-        verify(bubbleManager).postMessage(eq("after-timer"), any(), any())
+        verify(bubbleManager).postMessage(eq("after-timer"), any(), any(), anyOrNull())
     }
 
     // =========================================================================

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -579,6 +579,20 @@ class SideEffectEngineTest {
     }
 
     @Test
+    fun `the session lifecycle effects hand their own session to BubbleManager (#867)`() = runTest {
+        // Start/end chat copy is filed to the session the EFFECT names. The end is the load-bearing
+        // one: a grace-lapsed end executes when the active session is another platform's (or none).
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+
+        engine.process(AppEffect.StartSession("uber-sess", "Uber"), recovering = false)
+        engine.process(AppEffect.EndSession("Uber", sessionId = "uber-sess"), recovering = false)
+        runCurrent()
+
+        verify(bubbleManager).startSession(eq("uber-sess"), eq("Uber"))
+        verify(bubbleManager).endSession(eq("Uber"), eq("uber-sess"))
+    }
+
+    @Test
     fun `a gate-denied rule effect is not marked fired`() = runTest {
         val engine = buildEngine(StandardTestDispatcher(testScheduler))
         // Distinct dedupeKeys: a denied fire still consumes the wall-clock

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManagerSessionAttributionTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManagerSessionAttributionTest.kt
@@ -126,4 +126,17 @@ class BubbleManagerSessionAttributionTest {
             saveMessage(eq(uberSession), any(), any())
         }
     }
+
+    @Test
+    fun `endSession files its chat copy to the ENDED session`() {
+        val (manager, chatRepository) = buildFixture().let { it.manager to it.chatRepository }
+
+        // The grace-lapsed shape: the Uber dash's end commits while DoorDash owns the screen, and
+        // the Uber region's own session is already gone — only the effect knows which dash ended.
+        manager.endSession(Platform.Uber.name, sessionId = uberSession)
+
+        verifyBlocking(chatRepository, timeout(5_000)) {
+            saveMessage(eq(uberSession), any(), any())
+        }
+    }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManagerSessionAttributionTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManagerSessionAttributionTest.kt
@@ -1,0 +1,129 @@
+package cloud.trotter.dashbuddy.ui.bubble
+
+import android.app.NotificationManager
+import cloud.trotter.dashbuddy.core.data.chat.ChatRepository
+import cloud.trotter.dashbuddy.core.state.StateManagerV2
+import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Regions
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.activeSessionId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.timeout
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * #867 (write-side): a chat line must be filed to the session it CAME FROM, not to whichever
+ * platform happened to produce the last recognized frame.
+ *
+ * [BubbleManager.postMessage]/[BubbleManager.postOfferNotification] used to save every message to
+ * `activeSessionId.value` **at save time**. `AppState.activeSessionId()` is the session of
+ * `regions.flow.activePlatform`, which flips on every app switch while multi-apping — so an Uber
+ * offer's outcome line could be written into the DoorDash session's chat history (durable
+ * corruption of the per-session drill-down, not just the live view). Both now take an explicit
+ * originating session, falling back to the active one only when the caller genuinely has none.
+ *
+ * Drives the REAL [BubbleManager] with mocked collaborators, the [BubbleManagerChatLogTest]
+ * precedent (a `@HiltViewModel`-free Robolectric seam; the effect-side threading is asserted in
+ * `:core:state`'s `EffectMapTest`).
+ */
+@RunWith(RobolectricTestRunner::class)
+class BubbleManagerSessionAttributionTest {
+
+    private val doorDashSession = "dd-session-1"
+    private val uberSession = "uber-session-2"
+
+    /** Active platform = DoorDash, so `activeSessionId()` resolves to the DoorDash session. */
+    private fun stateWithDoorDashActive() = AppState(
+        regions = Regions(
+            flow = FlowRegion(activePlatform = Platform.DoorDash),
+            platforms = mapOf(
+                Platform.DoorDash to PlatformRegion(
+                    platform = Platform.DoorDash,
+                    session = Session(sessionId = doorDashSession, startedAt = 1_000L),
+                ),
+                Platform.Uber to PlatformRegion(
+                    platform = Platform.Uber,
+                    session = Session(sessionId = uberSession, startedAt = 2_000L),
+                ),
+            ),
+        ),
+    )
+
+    private class Fixture(val manager: BubbleManager, val chatRepository: ChatRepository)
+
+    private fun buildFixture(): Fixture {
+        val context = org.robolectric.RuntimeEnvironment.getApplication()
+        val notificationManager: NotificationManager = mock()
+        val chatRepository: ChatRepository = mock()
+        val stateManager: StateManagerV2 = mock()
+        val state = MutableStateFlow(stateWithDoorDashActive())
+        whenever(stateManager.state).thenReturn(state)
+        val lazyStateManager = dagger.Lazy<StateManagerV2> { stateManager }
+        val manager = BubbleManager(context, notificationManager, chatRepository, lazyStateManager)
+        // The derived flow is Eagerly-started on an IO scope; await it so the fallback assertions
+        // race nothing (an un-emitted flow would read null, not the DoorDash session).
+        runBlocking { withTimeout(5_000) { manager.activeSessionId.first { it != null } } }
+        return Fixture(manager, chatRepository)
+    }
+
+    @Test
+    fun `the fixture's active session is the DoorDash one — the mis-filing target`() {
+        assertEquals(doorDashSession, stateWithDoorDashActive().activeSessionId())
+    }
+
+    @Test
+    fun `a message with an explicit session saves to THAT session, not the active one`() {
+        val (manager, chatRepository) = buildFixture().let { it.manager to it.chatRepository }
+
+        manager.postMessage(
+            text = "Offer Declined",
+            persona = ChatPersona.Dispatcher,
+            sessionId = uberSession,
+        )
+
+        // The Uber offer's outcome lands in the UBER dash's chat even though DoorDash owns the
+        // screen (and therefore `activeSessionId`) at save time.
+        verifyBlocking(chatRepository, timeout(5_000)) {
+            saveMessage(uberSession, "Offer Declined", ChatPersona.Dispatcher)
+        }
+    }
+
+    @Test
+    fun `a session-less message still falls back to the active session`() {
+        val (manager, chatRepository) = buildFixture().let { it.manager to it.chatRepository }
+
+        // A genuinely session-less caller (rule-declared bubble, tip push, welcome line).
+        manager.postMessage(text = "Welcome", persona = ChatPersona.Dispatcher)
+
+        verifyBlocking(chatRepository, timeout(5_000)) {
+            saveMessage(doorDashSession, "Welcome", ChatPersona.Dispatcher)
+        }
+    }
+
+    @Test
+    fun `startSession files its chat copy to the STARTING session`() {
+        val (manager, chatRepository) = buildFixture().let { it.manager to it.chatRepository }
+
+        // The Uber dash just started while DoorDash still owns the screen.
+        manager.startSession(uberSession, Platform.Uber.name)
+
+        verifyBlocking(chatRepository, timeout(5_000)) {
+            saveMessage(eq(uberSession), any(), any())
+        }
+    }
+}

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -267,5 +267,16 @@ sealed class AppEffect {
     data class StartSession(val sessionId: String, val platformName: String) : AppEffect() {
         override val effectKey: String get() = "start_session:$sessionId"
     }
-    data class EndSession(val platformName: String? = null) : AppEffect()
+    data class EndSession(
+        val platformName: String? = null,
+        /**
+         * The session that just ENDED (#867) — the chat copy this effect posts belongs to it, not
+         * to whatever session is active when the effect executes. Load-bearing on a grace-lapsed
+         * end: the commit can ride a `GRACE_COMMIT` timer or a FOREIGN platform's frame, by which
+         * point `BubbleManager.activeSessionId` is the other platform's dash (the #867 class); and
+         * even single-app the ending region's session is already null at execute time, which would
+         * file the line session-less. Null only for a caller with no session in scope.
+         */
+        val sessionId: String? = null,
+    ) : AppEffect()
 }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -65,6 +65,19 @@ sealed class AppEffect {
         val persona: ChatPersona = ChatPersona.Dispatcher,
         val expand: Boolean = false,
         val dedupeScope: String? = null,
+        /**
+         * The originating session — the dash this chat line belongs to; null = genuinely
+         * session-less, falls back to the active session at save time.
+         *
+         * #867: the chat save used to read `BubbleManager.activeSessionId` **at save time**, which
+         * is the session of whichever platform produced the LAST recognized frame. While
+         * multi-apping that flips constantly, so an Uber offer's outcome message could be filed
+         * into the DoorDash session's chat — durable corruption of the per-session history, not
+         * just the live view. Every emitter that has a session in scope stamps it here (the same
+         * per-platform `sessionId` its sibling `logEffect(sessionId, …)` uses), so provenance
+         * travels WITH the effect instead of being re-derived at the edge.
+         */
+        val sessionId: String? = null,
     ) : AppEffect() {
         override val effectKey: String? get() =
             dedupeScope?.let { "bubble:$it:${persona.id}:${text.hashCode()}" }
@@ -192,6 +205,13 @@ sealed class AppEffect {
          * carries a real target platform instead of deriving [Platform.Unknown].
          */
         val platform: Platform,
+        /**
+         * The originating session; null = genuinely session-less, falls back to the active
+         * session at save time. Same #867 contract as [UpdateBubble.sessionId] — this effect's
+         * handler ALSO writes a chat message (the offer summary line), so it carries the same
+         * provenance rather than re-deriving it from the last-recognized-frame active session.
+         */
+        val sessionId: String? = null,
     ) : AppEffect()
 
     /**

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/ModeEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/ModeEffects.kt
@@ -97,7 +97,13 @@ internal fun EffectMap.diffMode(
                     // activeSessionCount 1→0 crossing (this session end is that crossing when
                     // it's the last live session), so one platform ending can't kill GPS under
                     // another still-live dash.
-                    add(AppEffect.UpdateBubble("Session Ended. Total: $earnings", ChatPersona.Dispatcher))
+                    add(
+                        AppEffect.UpdateBubble(
+                            "Session Ended. Total: $earnings",
+                            ChatPersona.Dispatcher,
+                            sessionId = sessionId,
+                        )
+                    )
                     // #606: no CaptureScreenshot here — the dash_summary
                     // rule effect (doordash.json) already owns the
                     // DashSummary screenshot (deduped + throttled, fires
@@ -154,7 +160,7 @@ internal fun EffectMap.diffMode(
                 } else if (nextSession != null && prevSession?.sessionId == nextSession.sessionId) {
                     // Grace resume — same session, no start effects needed
                     Timber.d("Session grace resume: ${nextSession.sessionId}")
-                    add(AppEffect.UpdateBubble("Session resumed (grace)"))
+                    add(AppEffect.UpdateBubble("Session resumed (grace)", sessionId = nextSession.sessionId))
                 }
 
                 // Cancel pause safety timer if resuming from paused
@@ -212,7 +218,7 @@ internal fun EffectMap.diffMode(
                             platform = next.platform,
                         )
                     )
-                    add(AppEffect.UpdateBubble("Dash Paused!"))
+                    add(AppEffect.UpdateBubble("Dash Paused!", sessionId = sessionId))
                 }
             }
         }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/ModeEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/ModeEffects.kt
@@ -128,7 +128,9 @@ internal fun EffectMap.diffMode(
                     )
                     // #438 B5: StopOdometer arbitrated at the cross-platform tier (see above).
                 }
-                add(AppEffect.EndSession(prev.platform.name))
+                // #867: the ENDED session (prevSession), not the diff-wide `sessionId` — on a
+                // dash-replaced-by-a-fresh-dash edge that local resolves to the NEW session.
+                add(AppEffect.EndSession(prev.platform.name, sessionId = prevSession.sessionId))
             }
         }
 

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/OfferEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/OfferEffects.kt
@@ -86,7 +86,13 @@ internal fun EffectMap.diffOfferLifecycle(
             val outcome = resolveOfferOutcome(obs, prevOffer)
             add(logEffect(sessionId, outcome, obs.timestamp, offerPayload(prevOffer, outcome, obs.timestamp, "Replaced by new offer")))
             // #601: surface the replaced offer's disposition, suffixed so it reads as the OLD offer's.
-            add(AppEffect.UpdateBubble("${outcomeCardText(outcome)} (offer replaced)", persona = ChatPersona.Dispatcher))
+            add(
+                AppEffect.UpdateBubble(
+                    "${outcomeCardText(outcome)} (offer replaced)",
+                    persona = ChatPersona.Dispatcher,
+                    sessionId = sessionId,
+                )
+            )
         }
         // #457/#830: dismiss the OLD hash's heads-up (dead offer on replace, stale-hash banner on a
         // churn) so a tap can't resolve against a hash that is no longer presented.
@@ -119,7 +125,11 @@ internal fun EffectMap.diffOfferLifecycle(
         // fresh numbers — a feature). The spoken read fires ONCE per physical presentation (#830):
         // only when the PREVIOUS state had no eval-landed marker, so a churning offer that
         // re-evaluates on each variant is read aloud exactly once, not on every re-quote.
-        add(AppEffect.PostOfferNotification(landedEval, offerCard, nextOffer.offerHash, nextOffer.platform))
+        add(
+            AppEffect.PostOfferNotification(
+                landedEval, offerCard, nextOffer.offerHash, nextOffer.platform, sessionId = sessionId,
+            )
+        )
         if (prevOffer.firstEvalLandedAt == null) add(AppEffect.SpeakOffer(landedEval))
     }
 
@@ -143,7 +153,7 @@ internal fun EffectMap.diffOfferLifecycle(
         add(AppEffect.CancelOfferNotification(prevOffer.offerHash))
         add(logEffect(sessionId, outcome, obs.timestamp, offerPayload(prevOffer, outcome, obs.timestamp, raceDescription)))
         // #601: the single place the chat states what actually happened, off the SAME logged outcome.
-        add(AppEffect.UpdateBubble(outcomeCardText(outcome), persona = ChatPersona.Dispatcher))
+        add(AppEffect.UpdateBubble(outcomeCardText(outcome), persona = ChatPersona.Dispatcher, sessionId = sessionId))
         addAll(cancelOfferExpiry(platform))
     }
 
@@ -164,13 +174,14 @@ internal fun EffectMap.diffOfferLifecycle(
                         AppEffect.UpdateBubble(
                             "Decline already submitted — Accept won't take",
                             persona = ChatPersona.Dispatcher,
+                            sessionId = sessionId,
                         )
                     )
                 } else {
-                    add(AppEffect.UpdateBubble("Accepting…", persona = ChatPersona.Dispatcher))
+                    add(AppEffect.UpdateBubble("Accepting…", persona = ChatPersona.Dispatcher, sessionId = sessionId))
                 }
             OfferIntent.DECLINE -> add(
-                AppEffect.UpdateBubble("Declining…", persona = ChatPersona.Dispatcher)
+                AppEffect.UpdateBubble("Declining…", persona = ChatPersona.Dispatcher, sessionId = sessionId)
             )
         }
     }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TaskEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TaskEffects.kt
@@ -84,6 +84,7 @@ internal fun EffectMap.diffTask(
                     "Unassigned: ${abandonedTask.storeName ?: UNKNOWN_STORE}",
                     ChatPersona.Navigator,
                     dedupeScope = abandonedTask.taskId,
+                    sessionId = sessionId,
                 ),
             )
         }
@@ -121,7 +122,12 @@ internal fun EffectMap.diffTask(
                     nextTask.arrivedAt != null,
                     storeName,
                 )
-                add(AppEffect.UpdateBubble("Pickup: $storeName", persona, dedupeScope = nextTask.taskId))
+                add(
+                    AppEffect.UpdateBubble(
+                        "Pickup: $storeName", persona,
+                        dedupeScope = nextTask.taskId, sessionId = sessionId,
+                    )
+                )
             }
         }
 
@@ -244,7 +250,12 @@ internal fun EffectMap.diffTask(
                     nextTask.arrivedAt != null,
                     storeName,
                 )
-                add(AppEffect.UpdateBubble("Pickup: $storeName", persona, dedupeScope = nextTask.taskId))
+                add(
+                    AppEffect.UpdateBubble(
+                        "Pickup: $storeName", persona,
+                        dedupeScope = nextTask.taskId, sessionId = sessionId,
+                    )
+                )
             }
 
             // Store name resolution — re-emit the pickup payload with the
@@ -301,7 +312,12 @@ private fun EffectMap.deliveryNavStartedEffects(
     // #568: store-flavored label ("Heading to H-E-B's customer") — friendlier
     // than the raw 6-char hash, and it disambiguates a multi-store stack's drops.
     val customer = customerLabel(task.storeName)
-    add(AppEffect.UpdateBubble("Heading to $customer", ChatPersona.Customer(customer), dedupeScope = task.taskId))
+    add(
+        AppEffect.UpdateBubble(
+            "Heading to $customer", ChatPersona.Customer(customer),
+            dedupeScope = task.taskId, sessionId = sessionId,
+        )
+    )
 }
 
 /**
@@ -496,7 +512,10 @@ internal fun EffectMap.diffPostTask(
     } else {
         "Saved: ${Formats.money(parsed.totalPay)}"
     }
-    return listOf(AppEffect.UpdateBubble(text, ChatPersona.Earnings))
+    // #867: same per-platform session resolution [diffTask] uses — the receipt belongs to THIS
+    // region's dash, not to whichever platform produced the last recognized frame.
+    val sessionId = next.session?.sessionId ?: prev.session?.sessionId
+    return listOf(AppEffect.UpdateBubble(text, ChatPersona.Earnings, sessionId = sessionId))
 }
 
 private fun EffectMap.determinePickupPersona(

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -447,6 +447,47 @@ class EffectMapTest {
     }
 
     @Test
+    fun `an ending session's chat copy carries the ENDED session, even on a foreign frame (#867)`() {
+        // The grace-lapsed shape: the Uber dash's end commits on a GRACE_COMMIT timer or a
+        // DoorDash frame, so `activeSessionId` is the DoorDash dash by execute time — and the Uber
+        // region's own session is already null. Nothing at the edge can recover the ended session;
+        // the effect has to carry it.
+        val ddRegion = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("dd-sess", startedAt = 100L),
+        )
+        fun state(uberSession: Session?, uberMode: Mode) = AppState(
+            regions = Regions(
+                flow = FlowRegion(flow = Flow.Idle, activePlatform = Platform.DoorDash),
+                platforms = mapOf(
+                    Platform.Uber to PlatformRegion(
+                        platform = Platform.Uber,
+                        mode = uberMode,
+                        session = uberSession,
+                    ),
+                    Platform.DoorDash to ddRegion,
+                ),
+            ),
+        )
+        val prev = state(Session("uber-sess", startedAt = 100L), Mode.Online)
+        val next = state(null, Mode.Offline)
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.Idle))
+
+        assertEquals("dd-sess", next.activeSessionId()) // the wrong dash the edge would pick
+        val end = effects.effectsOfType<AppEffect.EndSession>().single()
+        assertEquals(
+            "the 'done dashing' chat copy must be filed to the ENDED Uber dash",
+            "uber-sess",
+            end.sessionId,
+        )
+        // The "Session Ended"/DASH_STOP siblings agree — one provenance for the whole edge.
+        val stop = effects.logEvents().first { it.event.type == AppEventType.DASH_STOP }
+        assertEquals("uber-sess", stop.event.sessionId)
+    }
+
+    @Test
     fun `the offer heads-up notification carries the resolving platform's session too (#867)`() {
         // The eval-land step ALSO writes a chat line (the offer summary) via BubbleManager, so
         // PostOfferNotification carries the same provenance.

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -18,6 +18,7 @@ import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.pipeline.TransitionTrigger
 import cloud.trotter.dashbuddy.domain.state.AcceptedOfferEconomics
 import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.activeSessionId
 import cloud.trotter.dashbuddy.domain.state.CrossPlatformRegion
 import cloud.trotter.dashbuddy.domain.state.DestructiveKind
 import cloud.trotter.dashbuddy.domain.state.Flow
@@ -389,6 +390,73 @@ class EffectMapTest {
         assertTrue("Should show timeout bubble", effects.any {
             it is AppEffect.UpdateBubble && it.text.contains("Timed Out")
         })
+    }
+
+    // =========================================================================
+    // #867 — a chat bubble carries the session it came FROM
+    // =========================================================================
+
+    /**
+     * A multi-app state: an Uber offer is live on the Uber region (session `uber-sess`) while
+     * DoorDash is the flow's active platform (session `dd-sess`). `AppState.activeSessionId()` —
+     * what `BubbleManager` used to file every chat line under — reads `dd-sess` here, so a bubble
+     * that does NOT carry its own session is mis-attributed to the DoorDash dash.
+     */
+    private fun multiAppOfferState(uberOffer: PendingOffer?): AppState = AppState(
+        regions = Regions(
+            flow = FlowRegion(flow = Flow.Idle, activePlatform = Platform.DoorDash),
+            platforms = mapOf(
+                Platform.Uber to PlatformRegion(
+                    platform = Platform.Uber,
+                    mode = Mode.Online,
+                    session = Session("uber-sess", startedAt = 100L),
+                    pendingOffers = listOfNotNull(uberOffer),
+                ),
+                Platform.DoorDash to PlatformRegion(
+                    platform = Platform.DoorDash,
+                    mode = Mode.Online,
+                    session = Session("dd-sess", startedAt = 100L),
+                ),
+            ),
+        ),
+    )
+
+    @Test
+    fun `an offer outcome bubble carries the RESOLVING platform's session, not the active one (#867)`() {
+        val uberOffer = testPendingOffer.copy(
+            sourceRuleId = "uber.screen.offer",
+            lastClickIntent = "decline_offer",
+        )
+        val prev = multiAppOfferState(uberOffer)
+        val next = multiAppOfferState(null)
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.Idle))
+
+        // Guard the fixture: the "active" session really is the OTHER platform's.
+        assertEquals("dd-sess", prev.activeSessionId())
+        val outcome = effects.effectsOfType<AppEffect.UpdateBubble>()
+            .first { it.text == expectedOutcomeCard(AppEventType.OFFER_DECLINED) }
+        assertEquals(
+            "the Uber offer's outcome card must be filed to the UBER dash, not the active DoorDash one",
+            "uber-sess",
+            outcome.sessionId,
+        )
+        // ...and it matches the session its own ledger event was logged under (one provenance).
+        val declined = effects.logEvents().first { it.event.type == AppEventType.OFFER_DECLINED }
+        assertEquals(declined.event.sessionId, outcome.sessionId)
+    }
+
+    @Test
+    fun `the offer heads-up notification carries the resolving platform's session too (#867)`() {
+        // The eval-land step ALSO writes a chat line (the offer summary) via BubbleManager, so
+        // PostOfferNotification carries the same provenance.
+        val uberOffer = testPendingOffer.copy(sourceRuleId = "uber.screen.offer")
+        val prev = multiAppOfferState(uberOffer)
+        val next = multiAppOfferState(uberOffer.copy(evaluation = testEvaluation))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.Idle))
+        val post = effects.effectsOfType<AppEffect.PostOfferNotification>().single()
+        assertEquals("uber-sess", post.sessionId)
     }
 
     @Test


### PR DESCRIPTION
Write-side half of #867. The display-side redesign (what the bubble should show when two sessions are live) is dev-gated and **untouched** — no `BubbleViewModel` / card-stack / chat-header changes here.

## The defect

`AppEffect.UpdateBubble` carried no originating session. `SideEffectEngine` forwarded `(text, persona, expand)` to `BubbleManager.postMessage`, which saved to `activeSessionId.value` **at save time** — `AppState.activeSessionId()` is the session of `regions.flow.activePlatform`, i.e. whichever platform produced the LAST recognized frame. While multi-apping that flips on every app switch, so an Uber offer's outcome message could be filed into the DoorDash session's chat. That corrupts the per-session chat history durably (drill-down + `messages` replay), not just the live glance.

## The fix

Effects carry their own provenance; the edge no longer re-derives it.

- `AppEffect.UpdateBubble.sessionId: String? = null` (`:core:state`) — *"the originating session; null = genuinely session-less, falls back to the active session at save time."*
- Same field on `AppEffect.PostOfferNotification` — its handler ALSO writes a chat line (the offer summary at `BubbleManager.kt:377`), the identical defect class, and its emitter has the same `sessionId` in scope.
- `SideEffectEngine` passes both straight through (no re-derivation).
- `BubbleManager.postMessage(…, sessionId: String? = null)` / `postOfferNotification(…, sessionId: String? = null)` save to `sessionId ?: activeSessionId.value`.
- `effectKey` is **unchanged** — `sessionId` does not participate, so the #566 per-task bubble dedup behaves byte-identically.

### Emitter census — 14 sites, 14 threaded, 0 legitimately null

Every `UpdateBubble(` construction site in `:core:state`. Each was already sitting next to a `logEffect(sessionId, …)` (or in a function whose `sessionId` param feeds one), so all 14 got the SAME per-platform session — the offer/mode/task diffs all run per `PlatformRegion`, and `EffectMap.diffPlatformRegion` resolves `next.session?.sessionId ?: prev.session?.sessionId` for that region.

| File | Site | Session source |
|---|---|---|
| `OfferEffects.kt:90` | `"… (offer replaced)"` | `diffOfferLifecycle(sessionId)` |
| `OfferEffects.kt:156` | outcome card (Accepted/Declined/Timed Out) | ″ |
| `OfferEffects.kt:174` | `"Decline already submitted…"` (#594) | ″ |
| `OfferEffects.kt:181` | `"Accepting…"` ack | ″ |
| `OfferEffects.kt:184` | `"Declining…"` ack | ″ |
| `OfferEffects.kt:129` | `PostOfferNotification` (chat-writing twin) | ″ |
| `ModeEffects.kt:101` | `"Session Ended. Total: $X"` | `diffMode`'s `nextSession ?: prevSession` |
| `ModeEffects.kt:163` | `"Session resumed (grace)"` | `nextSession.sessionId` (in-branch, non-null) |
| `ModeEffects.kt:221` | `"Dash Paused!"` | `diffMode` sessionId |
| `TaskEffects.kt:83` | `"Unassigned: <store>"` | `diffTask` sessionId |
| `TaskEffects.kt:126` | `"Pickup: <store>"` (nav start) | ″ |
| `TaskEffects.kt:254` | `"Pickup: <store>"` (store/activity update) | ″ |
| `TaskEffects.kt:316` | `"Heading to <customer>"` | `deliveryNavStartedEffects(sessionId)` |
| `TaskEffects.kt:518` | `"Saved: $X"` post-task receipt | **new** local `next.session ?: prev.session` — the only site that had no session in scope; resolved with the identical per-region expression `diffTask` uses |

**Scoping note (reviewer Finding 2, pre-existing convention, left as-is):** the `"Session Ended. Total: $X"` bubble + its `DASH_STOP` sibling both ride `diffMode`'s `nextSession ?: prevSession`, so on the *replaced-session* edge (a fresh dash starting in the same step) they attribute to the NEW session, matching the ledger's existing `logEffect(sessionId, DASH_STOP, …)` attribution. The bubble deliberately mirrors its own log event rather than diverging. Only `EndSession` (the "Done dashing!" chat copy) is pinned to `prevSession.sessionId` — it has no ledger twin to stay consistent with, and it is the one that executes late.

### The OTHER `BubbleManager` chat-save call sites (asked for explicitly)

`saveMessage` has exactly two call sites (`:237` `postMessage`, `:377` `postOfferNotification`); everything else funnels through `postMessage`. Findings:

- **`postOfferNotification` (`:377`)** — same defect, **fixed** (see above).
- **`startSession(sessionId, platformName)`** — the caller literally holds the starting session (`AppEffect.StartSession.sessionId`). **Threaded**: the "started dashing" line is filed to the starting dash, not to whatever `activeSessionId` had caught up to.
- **`endSession(platformName, sessionId)`** — **threaded** (adversarial-review MED-1; the original "the ending session is still the active one" justification was wrong). `prevSession.sessionId` — the ENDED session — is in scope at the `ModeEffects.kt:131` emitter, so `AppEffect.EndSession` now carries it. The active session is not a safe stand-in on two shapes: a grace-lapsed end commits on a `GRACE_COMMIT` timer or a FOREIGN platform's frame (→ `activeSessionId` is the other dash, the exact #867 class), and even single-app the ending region's session is already null at execute time (→ the line files session-less). Deliberately **not** `diffMode`'s `sessionId` local, which resolves to the NEW session on a dash-replaced edge.
- **`postWelcomeMessage()`** — first-run copy, no dash exists. **Null by nature.**
- **`SideEffectEngine.bubbleFromArgs`** (rule-declared `bubble` verb via `RequestEffect`) — rule data carries no session provenance. **Left null**, commented.
- **`TipEffectHandler`** (`ProcessTipNotification`) — a tip push carries no session and can land after the dash ended. **Left null**, commented.

### Fallback semantics

`sessionId ?: activeSessionId.value`. A non-null value is authoritative and wins outright; null means *"this message genuinely has no originating dash"* and keeps the pre-#867 behaviour (attribute to the active session, which is right for a welcome/rule/tip line). Nothing is dropped, no message becomes session-less that wasn't already, and no historical rows are touched — this is write-path only, going forward.

## Tests

- **`EffectMapTest` (`:core:state`, new)** — a genuine multi-app state (Uber offer live on the Uber region `uber-sess`, DoorDash the flow's active platform `dd-sess`, so `activeSessionId()` = `dd-sess`): the resolved offer's outcome bubble carries `uber-sess`, and it equals the sessionId of its own `OFFER_DECLINED` ledger event (one provenance, two sinks). A second test pins `PostOfferNotification.sessionId`. **Mutation-verified**: dropping the threading on `OfferEffects.kt:156` turns it red.
- **`SideEffectEngineTest` (new)** — the engine is a pass-through: an effect carrying `uber-sess` reaches `postMessage` with `uber-sess`; a session-less one hands down `null`. Existing bubble/offer-notification verifications updated for the new arity (`anyOrNull()` — arity only, no assertion weakened).
- **MED-1 coverage (new)** — `EffectMapTest` pins the grace-lapsed foreign-frame shape (the Uber dash ends while DoorDash is the active platform → `EndSession.sessionId == "uber-sess"`, agreeing with its `DASH_STOP` sibling); `SideEffectEngineTest` pins the start/end pass-through; `BubbleManagerSessionAttributionTest` pins the sink. Both the emitter and sink assertions **mutation-verified** red on revert.
- **`BubbleManagerSessionAttributionTest` (`:app`, new)** — the seam itself, driving the REAL `BubbleManager` with mocked collaborators (the `BubbleManagerChatLogTest` Robolectric precedent — `BubbleManager` was already unit-tested there, so this is the cheapest honest home for it). Explicit session wins over a differing `activeSessionId`; a session-less message still falls back; `startSession` files to the starting session. **Mutation-verified**: restoring `saveMessage(activeSessionId.value, …)` turns two of them red.

Run: `export JAVA_HOME=/usr/lib/jvm/java-25 && ./gradlew testDebugUnitTest :domain:test` — **green** (the `:app` suite is 975 tests; `:core:state`, `:domain` and every other module included).

### Design-goal review

- **1 (UDF).** Strengthened: effects now carry their own provenance out of the pure diff, and the edge (`SideEffectEngine` → `BubbleManager`) merely forwards it instead of re-deriving state at execution time. Steppers/reducers untouched; no new wall-clock or Android dependency anywhere in `:core:state`.
- **3 (single responsibility).** No file grew a responsibility; the one new local (`diffPostTask`'s session resolution) mirrors the expression its sibling `diffTask` already uses.
- **4 (Kotlin/Android).** Nullable-with-default parameter, appended so every existing positional construction still compiles; immutable data classes throughout.
- **5 (SSOT).** The point of the change: session provenance now flows from the ONE place that knows it (the per-platform region diff, the same value `logEffect(sessionId, …)` stamps on the ledger event) instead of being independently re-derived at save time from a *different* anchor (`flow.activePlatform`) that can disagree. The `EffectMapTest` assertion `declined.event.sessionId == outcome.sessionId` pins the two sinks to one source.
- **6 (security/privacy).** No new data at rest: `sessionId` is an app-minted id already stored on every `app_events` row and on `chat_messages.dashId`. No PII, no new capture/network/effect surface, no gate touched. The `PostOfferNotification` addition changes no actuation path (`platform`/`offerHash` identity untouched, #438 B4 intact).
- **7 (logging).** No log sites added or moved; the existing PII-safe `Chat` INFO milestones are unchanged (the new field is never logged).
- **Census total.** 14 `UpdateBubble` sites + `PostOfferNotification` + `StartSession` + `EndSession` = every chat-writing effect now carries its own session; the three remaining null callers (rule-declared bubble, tip push, welcome line) are session-less by construction and documented at the call site.
- **8 (platform-agnostic core).** Clean — zero platform literals added. `sessionId` is an opaque String threaded from `PlatformRegion.session`, which is keyed by `Platform`; the fix is *itself* a multi-platform-correctness fix (the defect only manifests with ≥2 live regions, exactly the class #438/#585 patrol). The new tests use `Platform.Uber` + `Platform.DoorDash` as data to prove the value is READ from the region rather than hardcoded (the #588 test convention).
- **Reactive UI.** Not touched — no composable, no display scoping, no ticker. The display-side half stays dev-gated.

### Field note

Desk-side check on the next multi-app pull: in `dashbuddy-v2.db`, every `chat_messages.dashId` should match the platform of the offer/task the message describes — e.g. an "Offer Declined"/"Offer Timed Out!" line for an Uber offer joins to the Uber `session_records` row, never the DoorDash one that owned the screen at that instant. Pre-fix rows will still show the mis-attribution (write-path fix, no backfill), so compare by timestamp against the install date.

Closes the buildable half of #867 (the design-gated display half stays open).
