### PR TITLE
fix(rules): #858 uber offer rule rejects the expiry overlay ('This request is no longer available')

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/UberOfferExpiryOverlayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/UberOfferExpiryOverlayTest.kt
@@ -1,0 +1,141 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.test.util.SnapshotSecurityScanner
+import cloud.trotter.dashbuddy.test.util.TestResourceLoader
+import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.experimental.runners.Enclosed
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+/**
+ * Guards for the Uber offer-expiry overlay (#858).
+ *
+ * When a request dies, Uber renders `message_content_overlay` / `image_message_text`
+ * ("This request is no longer available") **over the still-present, dimmed card** —
+ * inside `primary_touch_area`, so every arm of `uber.screen.offer`'s presence-only
+ * `require` still held and the rule kept matching a dead offer. The message TextView
+ * then won the `storeName` read (it is the first card TextView that is not a
+ * price/badge/duration/dropoff line), which on 2026-07-23 shipped
+ * `offer_records.merchantName = "This request is no longer available"` (seq 735),
+ * spoke it over TTS, named an evidence screenshot with it, and — since
+ * `presentationKey = sha256(storeNames|orders.size|orderTypes)` is built from
+ * `orders[].storeName` — poisoned the #830 offer identity into a spurious REPLACE,
+ * an `OFFER_TIMEOUT("Replaced by new offer")` on the live offer, and a phantom row.
+ *
+ * The fix is two layers of rule data, both in `matchers/rules/uber.json5`:
+ *  1. **primary** — a `notExists` of `image_message_text` in the offer rule's
+ *     `require`, so an overlay-bearing frame matches NO rule and falls UNKNOWN;
+ *  2. **defense in depth** — the overlay's id *and* text added to both `storeName`
+ *     negation lists (top-level and `orders[]`), so a future overlay variant that
+ *     slips past layer 1 still cannot win the store read.
+ *
+ * These fixtures are the negative half. UNKNOWN is the *correct* fail-direction: the
+ * frame is dropped before the state machine, the pending offer stays live until the
+ * next real frame or its own `OFFER_EXPIRY` timer resolves it. Recognizing the
+ * overlay as its own flow — the platform's explicit "this was not a decline" witness
+ * — is #251's H3a and is deliberately deferred to the Trip Radar board design.
+ *
+ * The positive half lives in [CleanOfferStillRecognized] below (and, corpus-wide, in
+ * [cloud.trotter.dashbuddy.core.pipeline.recognition.matchers.GoldenSnapshotRegressionTest]).
+ */
+@RunWith(Enclosed::class)
+class UberOfferExpiryOverlayTest {
+
+    /** Every overlay-bearing capture must classify UNKNOWN. */
+    @RunWith(Parameterized::class)
+    class OverlayFramesStayUnknown(
+        private val filename: String,
+        private val node: UiNode,
+    ) {
+
+        companion object {
+            private const val FIXTURES = "fixtures/uber_offer_expiry_overlay"
+
+            @JvmStatic
+            @Parameterized.Parameters(name = "{0}")
+            fun data(): Collection<Array<Any>> {
+                val loaded = TestResourceLoader.loadSnapshots(FIXTURES)
+                assertTrue("fixtures/$FIXTURES must not be empty", loaded.isNotEmpty())
+                return loaded.map { (filename, node, _) -> arrayOf(filename, node) }
+            }
+
+            private fun hasOverlay(node: UiNode): Boolean =
+                node.viewIdResourceName?.endsWith("image_message_text", ignoreCase = true) == true ||
+                    node.children.any(::hasOverlay)
+        }
+
+        /**
+         * Pins that each fixture really is a #858 specimen — it carries the expiry
+         * overlay node. Without this the UNKNOWN assertion below could pass on any
+         * unrelated tree and the regression would be untested.
+         */
+        @Test
+        fun `fixture carries the expiry overlay node`() {
+            assertTrue(
+                "$filename no longer carries image_message_text — it is not a #858 specimen " +
+                    "any more; replace it with a real expiring-card capture",
+                hasOverlay(node),
+            )
+        }
+
+        @Test
+        fun `an expiring card is not a live offer`() {
+            val intent = TestRulesetFactory.screenRuleset.matchFirst(node)?.intent ?: "UNKNOWN"
+            assertEquals(
+                "$filename classified '$intent' — the platform is saying this request is GONE, " +
+                    "so nothing on this frame may mint OFFER_RECEIVED, name a screenshot, or " +
+                    "re-identify the presentation (#858)",
+                "UNKNOWN",
+                intent,
+            )
+        }
+
+        /** These are committed captures; hold them to the same bar as the corpus. */
+        @Test
+        fun `fixture carries no dasher-sensitive content`() {
+            assertFalse(
+                "$filename tripped the security scanner — redact or drop it",
+                SnapshotSecurityScanner.scan(node).isToxic,
+            )
+        }
+    }
+
+    /**
+     * The positive counterweight: layer 1 is a `notExists`, and a `notExists` that is
+     * too broad silently deletes recognition. A clean (non-expiring) Uber offer must
+     * still classify `offer` AND still parse a real store name — the field the
+     * overlay used to steal.
+     */
+    class CleanOfferStillRecognized {
+
+        @Test
+        fun `a clean uber offer still classifies offer and parses its store`() {
+            val clean = TestResourceLoader.loadSnapshots("snapshots/offer")
+                .filter { (name, _, _) -> name.contains("__uber__") }
+            assertTrue(
+                "no committed uber offer snapshots found — the over-rejection guard is vacuous",
+                clean.isNotEmpty(),
+            )
+            clean.forEach { (filename, node, _) ->
+                val match = TestRulesetFactory.screenRuleset.matchFirst(node)
+                assertEquals(
+                    "$filename no longer classifies 'offer' — the #858 notExists over-rejects",
+                    "offer",
+                    match?.intent,
+                )
+                val store = match?.fields?.get("storeName") as? String
+                assertNotNull("$filename parsed no storeName", store)
+                assertTrue(
+                    "$filename parsed the expiry overlay as its store",
+                    store!!.isNotBlank() && !store.contains("no longer available", ignoreCase = true),
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatchersSuite.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatchersSuite.kt
@@ -14,6 +14,7 @@ import cloud.trotter.dashbuddy.core.pipeline.rules.ParseOutputGoldenTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.ScreenRulesetTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.TriageRulesTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.UberIdleMapOfflineEvidenceTest
+import cloud.trotter.dashbuddy.core.pipeline.rules.UberOfferExpiryOverlayTest
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
 
@@ -55,6 +56,11 @@ import org.junit.runners.Suite
  * - [UberIdleMapOfflineEvidenceTest] — #857 negative guard: real partially-rendered Uber
  *   home captures (`fixtures/uber_idle_map_partial/`) must classify UNKNOWN, so
  *   `uber.screen.idle_map` can never claim `modeHint: offline` from absence again.
+ * - [UberOfferExpiryOverlayTest] — #858: real captures of Uber's expiry overlay
+ *   ("This request is no longer available", rendered OVER the dimmed card inside
+ *   `primary_touch_area`) must classify UNKNOWN, so a dead request can never mint an
+ *   offer or poison `storeName`/`presentationKey`; plus the paired over-rejection
+ *   guard that a clean uber offer still classifies `offer` with a real store.
  * - [OfferPipelineTest] — Layer 2 (#105): a real `offer_popup/` snapshot through the SAME
  *   production ruleset, feeding the recognized `ParsedOffer` into `OfferEvaluator` and pinning the
  *   resulting `OfferEvaluation` — proves the recognition→parse→evaluate wiring, not just the
@@ -71,6 +77,7 @@ import org.junit.runners.Suite
     NotificationRulesetTest::class,
     TriageRulesTest::class,
     UberIdleMapOfflineEvidenceTest::class,
+    UberOfferExpiryOverlayTest::class,
     DefaultRulesIntegrationTest::class,
     NotificationClassifierTest::class,
     ClickClassifierTest::class,

--- a/app/src/test/resources/fixtures/uber_offer_expiry_overlay/2026-07-23_18-48-34-589__uber__accessibility.window__offer__5a0d26.json
+++ b/app/src/test/resources/fixtures/uber_offer_expiry_overlay/2026-07-23_18-48-34-589__uber__accessibility.window__offer__5a0d26.json
@@ -1,0 +1,1020 @@
+{
+    "captureId": "ff72e437-76fc-4671-855e-5722eb3bebf3",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784850514579,
+    "platform": "uber",
+    "ruleId": "uber.screen.offer",
+    "classificationName": "offer",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 716,
+                                                                                                                                            "top": 833,
+                                                                                                                                            "right": 796,
+                                                                                                                                            "bottom": 978
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 716,
+                                                                                                                                                    "top": 833,
+                                                                                                                                                    "right": 796,
+                                                                                                                                                    "bottom": 913
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_custom_view",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 738,
+                                                                                                                                                            "top": 833,
+                                                                                                                                                            "right": 774,
+                                                                                                                                                            "bottom": 913
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 738,
+                                                                                                                                                                    "top": 833,
+                                                                                                                                                                    "right": 774,
+                                                                                                                                                                    "bottom": 913
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 752,
+                                                                                                                                                    "top": 911,
+                                                                                                                                                    "right": 761,
+                                                                                                                                                    "bottom": 940
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_anchor",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 738,
+                                                                                                                                                    "top": 938,
+                                                                                                                                                    "right": 774,
+                                                                                                                                                    "bottom": 974
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 471,
+                                                                                                                                            "top": 1104,
+                                                                                                                                            "right": 551,
+                                                                                                                                            "bottom": 1249
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 471,
+                                                                                                                                                    "top": 1104,
+                                                                                                                                                    "right": 551,
+                                                                                                                                                    "bottom": 1184
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_custom_view",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 493,
+                                                                                                                                                            "top": 1104,
+                                                                                                                                                            "right": 529,
+                                                                                                                                                            "bottom": 1184
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 493,
+                                                                                                                                                                    "top": 1104,
+                                                                                                                                                                    "right": 529,
+                                                                                                                                                                    "bottom": 1184
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 507,
+                                                                                                                                                    "top": 1182,
+                                                                                                                                                    "right": 516,
+                                                                                                                                                    "bottom": 1211
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_anchor",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 493,
+                                                                                                                                                    "top": 1209,
+                                                                                                                                                    "right": 529,
+                                                                                                                                                    "bottom": 1245
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 11,
+                                                                                                                                            "top": 595,
+                                                                                                                                            "right": 91,
+                                                                                                                                            "bottom": 740
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 11,
+                                                                                                                                                    "top": 595,
+                                                                                                                                                    "right": 91,
+                                                                                                                                                    "bottom": 675
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_custom_view",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 33,
+                                                                                                                                                            "top": 595,
+                                                                                                                                                            "right": 69,
+                                                                                                                                                            "bottom": 675
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 33,
+                                                                                                                                                                    "top": 595,
+                                                                                                                                                                    "right": 69,
+                                                                                                                                                                    "bottom": 675
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 47,
+                                                                                                                                                    "top": 673,
+                                                                                                                                                    "right": 56,
+                                                                                                                                                    "bottom": 702
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_anchor",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 33,
+                                                                                                                                                    "top": 700,
+                                                                                                                                                    "right": 69,
+                                                                                                                                                    "bottom": 736
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1477,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 1509,
+                                                                                                            "right": 1044,
+                                                                                                            "bottom": 2307
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 1509,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 2307
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/primary_touch_area",
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 1509,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 2307
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "androidx.cardview.widget.CardView",
+                                                                                                                                "isClickable": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1509,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 2307
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1509,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 2307
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/message_content_overlay",
+                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 107,
+                                                                                                                                                    "top": 1840,
+                                                                                                                                                    "right": 973,
+                                                                                                                                                    "bottom": 1976
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "text": "This request is no longer available",
+                                                                                                                                                        "id": "com.ubercab.driver:id/image_message_text",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 143,
+                                                                                                                                                            "top": 1876,
+                                                                                                                                                            "right": 937,
+                                                                                                                                                            "bottom": 1940
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1509,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 2307
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1509,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1856
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 72,
+                                                                                                                                                            "top": 1545,
+                                                                                                                                                            "right": 1008,
+                                                                                                                                                            "bottom": 1829
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 72,
+                                                                                                                                                                    "top": 1545,
+                                                                                                                                                                    "right": 1008,
+                                                                                                                                                                    "bottom": 1829
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 72,
+                                                                                                                                                                            "top": 1545,
+                                                                                                                                                                            "right": 1008,
+                                                                                                                                                                            "bottom": 1623
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 72,
+                                                                                                                                                                                    "top": 1545,
+                                                                                                                                                                                    "right": 379,
+                                                                                                                                                                                    "bottom": 1623
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 90,
+                                                                                                                                                                                            "top": 1566,
+                                                                                                                                                                                            "right": 126,
+                                                                                                                                                                                            "bottom": 1602
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "text": "Delivery (2)",
+                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 144,
+                                                                                                                                                                                            "top": 1545,
+                                                                                                                                                                                            "right": 379,
+                                                                                                                                                                                            "bottom": 1623
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 72,
+                                                                                                                                                                            "top": 1623,
+                                                                                                                                                                            "right": 354,
+                                                                                                                                                                            "bottom": 1751
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "text": "$13.31",
+                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 72,
+                                                                                                                                                                                    "top": 1623,
+                                                                                                                                                                                    "right": 354,
+                                                                                                                                                                                    "bottom": 1751
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 72,
+                                                                                                                                                                            "top": 1751,
+                                                                                                                                                                            "right": 1008,
+                                                                                                                                                                            "bottom": 1829
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 72,
+                                                                                                                                                                                    "top": 1751,
+                                                                                                                                                                                    "right": 513,
+                                                                                                                                                                                    "bottom": 1829
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "text": "Includes expected tip",
+                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 72,
+                                                                                                                                                                                            "top": 1751,
+                                                                                                                                                                                            "right": 513,
+                                                                                                                                                                                            "bottom": 1829
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1856,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1858
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1858,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1967
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 72,
+                                                                                                                                                            "top": 1885,
+                                                                                                                                                            "right": 1008,
+                                                                                                                                                            "bottom": 1949
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 72,
+                                                                                                                                                                    "top": 1885,
+                                                                                                                                                                    "right": 555,
+                                                                                                                                                                    "bottom": 1949
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 72,
+                                                                                                                                                                            "top": 1890,
+                                                                                                                                                                            "right": 125,
+                                                                                                                                                                            "bottom": 1943
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "text": "27 min (5.9 mi) total",
+                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 143,
+                                                                                                                                                                            "top": 1885,
+                                                                                                                                                                            "right": 555,
+                                                                                                                                                                            "bottom": 1949
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1967,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1969
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1969,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 2147
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 72,
+                                                                                                                                                            "top": 1987,
+                                                                                                                                                            "right": 1008,
+                                                                                                                                                            "bottom": 2129
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 72,
+                                                                                                                                                                    "top": 1987,
+                                                                                                                                                                    "right": 871,
+                                                                                                                                                                    "bottom": 2129
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 72,
+                                                                                                                                                                            "top": 1987,
+                                                                                                                                                                            "right": 871,
+                                                                                                                                                                            "bottom": 2058
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 72,
+                                                                                                                                                                                    "top": 1996,
+                                                                                                                                                                                    "right": 125,
+                                                                                                                                                                                    "bottom": 2049
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 143,
+                                                                                                                                                                                    "top": 1994,
+                                                                                                                                                                                    "right": 871,
+                                                                                                                                                                                    "bottom": 2050
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 143,
+                                                                                                                                                                                            "top": 1994,
+                                                                                                                                                                                            "right": 574,
+                                                                                                                                                                                            "bottom": 2050
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "Po Po Trattoria Pizzeria",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 143,
+                                                                                                                                                                                                    "top": 1994,
+                                                                                                                                                                                                    "right": 574,
+                                                                                                                                                                                                    "bottom": 2050
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 72,
+                                                                                                                                                                            "top": 2058,
+                                                                                                                                                                            "right": 871,
+                                                                                                                                                                            "bottom": 2129
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 72,
+                                                                                                                                                                                    "top": 2067,
+                                                                                                                                                                                    "right": 125,
+                                                                                                                                                                                    "bottom": 2120
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 143,
+                                                                                                                                                                                    "top": 2065,
+                                                                                                                                                                                    "right": 871,
+                                                                                                                                                                                    "bottom": 2121
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 143,
+                                                                                                                                                                                            "top": 2065,
+                                                                                                                                                                                            "right": 871,
+                                                                                                                                                                                            "bottom": 2121
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "[redacted:19c9]",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 143,
+                                                                                                                                                                                                    "top": 2065,
+                                                                                                                                                                                                    "right": 871,
+                                                                                                                                                                                                    "bottom": 2121
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Match",
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 72,
+                                                                                                                                                    "top": 2165,
+                                                                                                                                                    "right": 1008,
+                                                                                                                                                    "bottom": 2271
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.Button",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 902,
+                                                                                                                                            "top": 1545,
+                                                                                                                                            "right": 1008,
+                                                                                                                                            "bottom": 1651
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.Button",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 902,
+                                                                                                                                            "top": 1545,
+                                                                                                                                            "right": 1008,
+                                                                                                                                            "bottom": 1651
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/fixtures/uber_offer_expiry_overlay/2026-07-23_19-39-59-512__uber__accessibility.window__UNKNOWN__894217.json
+++ b/app/src/test/resources/fixtures/uber_offer_expiry_overlay/2026-07-23_19-39-59-512__uber__accessibility.window__UNKNOWN__894217.json
@@ -1,0 +1,2588 @@
+{
+    "captureId": "c0644ac0-37cb-4032-a1e2-6d2b45eeb567",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784853599498,
+    "platform": "uber",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 410,
+                                                                                                                                            "top": 2390,
+                                                                                                                                            "right": 820,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Bayseas Seafood - Jones Maltsberger",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 410,
+                                                                                                                                                    "top": 2390,
+                                                                                                                                                    "right": 820,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 236,
+                                                                                                                                            "top": 2010,
+                                                                                                                                            "right": 646,
+                                                                                                                                            "bottom": 2105
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Full House Chinese Restaurant",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 236,
+                                                                                                                                                    "top": 2010,
+                                                                                                                                                    "right": 646,
+                                                                                                                                                    "bottom": 2105
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 703,
+                                                                                                                                            "top": 901,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 996
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Taziki's Mediterranean Cafe",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 703,
+                                                                                                                                                    "top": 901,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 996
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 50,
+                                                                                                                                            "top": 1074,
+                                                                                                                                            "right": 103,
+                                                                                                                                            "bottom": 1127
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 50,
+                                                                                                                                                    "top": 1074,
+                                                                                                                                                    "right": 103,
+                                                                                                                                                    "bottom": 1127
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 63,
+                                                                                                                                                            "top": 1087,
+                                                                                                                                                            "right": 90,
+                                                                                                                                                            "bottom": 1114
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 72,
+                                                                                                                                                    "top": 1124,
+                                                                                                                                                    "right": 81,
+                                                                                                                                                    "bottom": 1124
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 847,
+                                                                                                                                            "top": 2183,
+                                                                                                                                            "right": 900,
+                                                                                                                                            "bottom": 2236
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 847,
+                                                                                                                                                    "top": 2183,
+                                                                                                                                                    "right": 900,
+                                                                                                                                                    "bottom": 2236
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 860,
+                                                                                                                                                            "top": 2196,
+                                                                                                                                                            "right": 887,
+                                                                                                                                                            "bottom": 2223
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 869,
+                                                                                                                                                    "top": 2233,
+                                                                                                                                                    "right": 878,
+                                                                                                                                                    "bottom": 2233
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 607,
+                                                                                                                                            "top": 900,
+                                                                                                                                            "right": 660,
+                                                                                                                                            "bottom": 953
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 607,
+                                                                                                                                                    "top": 900,
+                                                                                                                                                    "right": 660,
+                                                                                                                                                    "bottom": 953
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 620,
+                                                                                                                                                            "top": 913,
+                                                                                                                                                            "right": 647,
+                                                                                                                                                            "bottom": 940
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 629,
+                                                                                                                                                    "top": 950,
+                                                                                                                                                    "right": 638,
+                                                                                                                                                    "bottom": 950
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 410,
+                                                                                                                                            "top": 1600,
+                                                                                                                                            "right": 463,
+                                                                                                                                            "bottom": 1653
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 410,
+                                                                                                                                                    "top": 1600,
+                                                                                                                                                    "right": 463,
+                                                                                                                                                    "bottom": 1653
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 423,
+                                                                                                                                                            "top": 1613,
+                                                                                                                                                            "right": 450,
+                                                                                                                                                            "bottom": 1640
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 432,
+                                                                                                                                                    "top": 1650,
+                                                                                                                                                    "right": 441,
+                                                                                                                                                    "bottom": 1650
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 548,
+                                                                                                                                            "top": 1896,
+                                                                                                                                            "right": 601,
+                                                                                                                                            "bottom": 1949
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 548,
+                                                                                                                                                    "top": 1896,
+                                                                                                                                                    "right": 601,
+                                                                                                                                                    "bottom": 1949
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 561,
+                                                                                                                                                            "top": 1909,
+                                                                                                                                                            "right": 588,
+                                                                                                                                                            "bottom": 1936
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 570,
+                                                                                                                                                    "top": 1946,
+                                                                                                                                                    "right": 579,
+                                                                                                                                                    "bottom": 1946
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 882,
+                                                                                                                                            "top": 1019,
+                                                                                                                                            "right": 935,
+                                                                                                                                            "bottom": 1072
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 882,
+                                                                                                                                                    "top": 1019,
+                                                                                                                                                    "right": 935,
+                                                                                                                                                    "bottom": 1072
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 895,
+                                                                                                                                                            "top": 1032,
+                                                                                                                                                            "right": 922,
+                                                                                                                                                            "bottom": 1059
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 904,
+                                                                                                                                                    "top": 1069,
+                                                                                                                                                    "right": 913,
+                                                                                                                                                    "bottom": 1069
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 301,
+                                                                                                                                            "top": 1768,
+                                                                                                                                            "right": 354,
+                                                                                                                                            "bottom": 1821
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 301,
+                                                                                                                                                    "top": 1768,
+                                                                                                                                                    "right": 354,
+                                                                                                                                                    "bottom": 1821
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 314,
+                                                                                                                                                            "top": 1781,
+                                                                                                                                                            "right": 341,
+                                                                                                                                                            "bottom": 1808
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 323,
+                                                                                                                                                    "top": 1818,
+                                                                                                                                                    "right": 332,
+                                                                                                                                                    "bottom": 1818
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 677,
+                                                                                                                                            "top": 1645,
+                                                                                                                                            "right": 730,
+                                                                                                                                            "bottom": 1698
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 677,
+                                                                                                                                                    "top": 1645,
+                                                                                                                                                    "right": 730,
+                                                                                                                                                    "bottom": 1698
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 690,
+                                                                                                                                                            "top": 1658,
+                                                                                                                                                            "right": 717,
+                                                                                                                                                            "bottom": 1685
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 699,
+                                                                                                                                                    "top": 1695,
+                                                                                                                                                    "right": 708,
+                                                                                                                                                    "bottom": 1695
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 665,
+                                                                                                                                            "top": 2031,
+                                                                                                                                            "right": 718,
+                                                                                                                                            "bottom": 2084
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 665,
+                                                                                                                                                    "top": 2031,
+                                                                                                                                                    "right": 718,
+                                                                                                                                                    "bottom": 2084
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 678,
+                                                                                                                                                            "top": 2044,
+                                                                                                                                                            "right": 705,
+                                                                                                                                                            "bottom": 2071
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 687,
+                                                                                                                                                    "top": 2081,
+                                                                                                                                                    "right": 696,
+                                                                                                                                                    "bottom": 2081
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 201,
+                                                                                                                                            "top": 1068,
+                                                                                                                                            "right": 254,
+                                                                                                                                            "bottom": 1121
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 201,
+                                                                                                                                                    "top": 1068,
+                                                                                                                                                    "right": 254,
+                                                                                                                                                    "bottom": 1121
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 214,
+                                                                                                                                                            "top": 1081,
+                                                                                                                                                            "right": 241,
+                                                                                                                                                            "bottom": 1108
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 223,
+                                                                                                                                                    "top": 1118,
+                                                                                                                                                    "right": 232,
+                                                                                                                                                    "bottom": 1118
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 263,
+                                                                                                                                            "top": 434,
+                                                                                                                                            "right": 316,
+                                                                                                                                            "bottom": 487
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 263,
+                                                                                                                                                    "top": 434,
+                                                                                                                                                    "right": 316,
+                                                                                                                                                    "bottom": 487
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 276,
+                                                                                                                                                            "top": 447,
+                                                                                                                                                            "right": 303,
+                                                                                                                                                            "bottom": 474
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 285,
+                                                                                                                                                    "top": 484,
+                                                                                                                                                    "right": 294,
+                                                                                                                                                    "bottom": 484
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 240,
+                                                                                                                                            "top": 623,
+                                                                                                                                            "right": 293,
+                                                                                                                                            "bottom": 676
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 240,
+                                                                                                                                                    "top": 623,
+                                                                                                                                                    "right": 293,
+                                                                                                                                                    "bottom": 676
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 253,
+                                                                                                                                                            "top": 636,
+                                                                                                                                                            "right": 280,
+                                                                                                                                                            "bottom": 663
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 262,
+                                                                                                                                                    "top": 673,
+                                                                                                                                                    "right": 271,
+                                                                                                                                                    "bottom": 673
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 333,
+                                                                                                                                            "top": 1651,
+                                                                                                                                            "right": 386,
+                                                                                                                                            "bottom": 1704
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 333,
+                                                                                                                                                    "top": 1651,
+                                                                                                                                                    "right": 386,
+                                                                                                                                                    "bottom": 1704
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 346,
+                                                                                                                                                            "top": 1664,
+                                                                                                                                                            "right": 373,
+                                                                                                                                                            "bottom": 1691
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 355,
+                                                                                                                                                    "top": 1701,
+                                                                                                                                                    "right": 364,
+                                                                                                                                                    "bottom": 1701
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1153,
+                                                                                                                                            "top": 811,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 864
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1153,
+                                                                                                                                                    "top": 811,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 864
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1166,
+                                                                                                                                                            "top": 824,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 851
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1175,
+                                                                                                                                                    "top": 861,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 861
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 423,
+                                                                                                                                            "top": 2327,
+                                                                                                                                            "right": 476,
+                                                                                                                                            "bottom": 2380
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 423,
+                                                                                                                                                    "top": 2327,
+                                                                                                                                                    "right": 476,
+                                                                                                                                                    "bottom": 2380
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 436,
+                                                                                                                                                            "top": 2340,
+                                                                                                                                                            "right": 463,
+                                                                                                                                                            "bottom": 2367
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 445,
+                                                                                                                                                    "top": 2377,
+                                                                                                                                                    "right": 454,
+                                                                                                                                                    "bottom": 2377
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 242,
+                                                                                                                                            "top": 1907,
+                                                                                                                                            "right": 295,
+                                                                                                                                            "bottom": 1960
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 242,
+                                                                                                                                                    "top": 1907,
+                                                                                                                                                    "right": 295,
+                                                                                                                                                    "bottom": 1960
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 255,
+                                                                                                                                                            "top": 1920,
+                                                                                                                                                            "right": 282,
+                                                                                                                                                            "bottom": 1947
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 264,
+                                                                                                                                                    "top": 1957,
+                                                                                                                                                    "right": 273,
+                                                                                                                                                    "bottom": 1957
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 262,
+                                                                                                                                            "top": 1415,
+                                                                                                                                            "right": 315,
+                                                                                                                                            "bottom": 1468
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 262,
+                                                                                                                                                    "top": 1415,
+                                                                                                                                                    "right": 315,
+                                                                                                                                                    "bottom": 1468
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 275,
+                                                                                                                                                            "top": 1428,
+                                                                                                                                                            "right": 302,
+                                                                                                                                                            "bottom": 1455
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 284,
+                                                                                                                                                    "top": 1465,
+                                                                                                                                                    "right": 293,
+                                                                                                                                                    "bottom": 1465
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 339,
+                                                                                                                                            "top": 2411,
+                                                                                                                                            "right": 392,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 339,
+                                                                                                                                                    "top": 2411,
+                                                                                                                                                    "right": 392,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 352,
+                                                                                                                                                            "top": 2424,
+                                                                                                                                                            "right": 379,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 361,
+                                                                                                                                                    "top": 2461,
+                                                                                                                                                    "right": 370,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 813,
+                                                                                                                                            "right": -17,
+                                                                                                                                            "bottom": 866
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 813,
+                                                                                                                                                    "right": -17,
+                                                                                                                                                    "bottom": 866
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 826,
+                                                                                                                                                            "right": -30,
+                                                                                                                                                            "bottom": 853
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 863,
+                                                                                                                                                    "right": -39,
+                                                                                                                                                    "bottom": 863
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 567,
+                                                                                                                                            "top": 249,
+                                                                                                                                            "right": 620,
+                                                                                                                                            "bottom": 302
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 567,
+                                                                                                                                                    "top": 249,
+                                                                                                                                                    "right": 620,
+                                                                                                                                                    "bottom": 302
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 580,
+                                                                                                                                                            "top": 262,
+                                                                                                                                                            "right": 607,
+                                                                                                                                                            "bottom": 289
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 589,
+                                                                                                                                                    "top": 299,
+                                                                                                                                                    "right": 598,
+                                                                                                                                                    "bottom": 299
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1152,
+                                                                                                                                            "top": 2400,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1152,
+                                                                                                                                                    "top": 2400,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1165,
+                                                                                                                                                            "top": 2413,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1174,
+                                                                                                                                                    "top": 2450,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 499,
+                                                                                                                                            "top": 1174,
+                                                                                                                                            "right": 552,
+                                                                                                                                            "bottom": 1227
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 499,
+                                                                                                                                                    "top": 1174,
+                                                                                                                                                    "right": 552,
+                                                                                                                                                    "bottom": 1227
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 512,
+                                                                                                                                                            "top": 1187,
+                                                                                                                                                            "right": 539,
+                                                                                                                                                            "bottom": 1214
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 521,
+                                                                                                                                                    "top": 1224,
+                                                                                                                                                    "right": 530,
+                                                                                                                                                    "bottom": 1224
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 314,
+                                                                                                                                            "top": 1907,
+                                                                                                                                            "right": 713,
+                                                                                                                                            "bottom": 1959
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Willie's Grill & Icehouse",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 314,
+                                                                                                                                                    "top": 1907,
+                                                                                                                                                    "right": 713,
+                                                                                                                                                    "bottom": 1959
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 134,
+                                                                                                                                            "top": 1688,
+                                                                                                                                            "right": 520,
+                                                                                                                                            "bottom": 1740
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Saltgrass Steak House",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 134,
+                                                                                                                                                    "top": 1688,
+                                                                                                                                                    "right": 520,
+                                                                                                                                                    "bottom": 1740
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 751,
+                                                                                                                                            "top": 811,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 863
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Ravello Italian Cuisine",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 751,
+                                                                                                                                                    "top": 811,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 863
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 40,
+                                                                                                                                            "top": 988,
+                                                                                                                                            "right": 415,
+                                                                                                                                            "bottom": 1040
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Smokey MO'S TX BBQ",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 40,
+                                                                                                                                                    "top": 988,
+                                                                                                                                                    "right": 415,
+                                                                                                                                                    "bottom": 1040
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 334,
+                                                                                                                                            "top": 1415,
+                                                                                                                                            "right": 616,
+                                                                                                                                            "bottom": 1467
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Tacos Carnivoro",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 334,
+                                                                                                                                                    "top": 1415,
+                                                                                                                                                    "right": 616,
+                                                                                                                                                    "bottom": 1467
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 122,
+                                                                                                                                            "top": 1074,
+                                                                                                                                            "right": 395,
+                                                                                                                                            "bottom": 1126
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Curry Boys BBQ",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 122,
+                                                                                                                                                    "top": 1074,
+                                                                                                                                                    "right": 395,
+                                                                                                                                                    "bottom": 1126
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 872,
+                                                                                                                                            "top": 2400,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Longhorn Cafe",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 872,
+                                                                                                                                                    "top": 2400,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 576,
+                                                                                                                                            "top": 2183,
+                                                                                                                                            "right": 827,
+                                                                                                                                            "bottom": 2235
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Dollar General",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 576,
+                                                                                                                                                    "top": 2183,
+                                                                                                                                                    "right": 827,
+                                                                                                                                                    "bottom": 2235
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 165,
+                                                                                                                                            "top": 354,
+                                                                                                                                            "right": 414,
+                                                                                                                                            "bottom": 406
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Sonic Drive-In",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 165,
+                                                                                                                                                    "top": 354,
+                                                                                                                                                    "right": 414,
+                                                                                                                                                    "bottom": 406
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 2,
+                                                                                                                                            "top": 813,
+                                                                                                                                            "right": 237,
+                                                                                                                                            "bottom": 865
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Whataburger",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 2,
+                                                                                                                                                    "top": 813,
+                                                                                                                                                    "right": 237,
+                                                                                                                                                    "bottom": 865
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 256,
+                                                                                                                                            "top": 1174,
+                                                                                                                                            "right": 479,
+                                                                                                                                            "bottom": 1226
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "McDonald's®",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 256,
+                                                                                                                                                    "top": 1174,
+                                                                                                                                                    "right": 479,
+                                                                                                                                                    "bottom": 1226
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 466,
+                                                                                                                                            "top": 1816,
+                                                                                                                                            "right": 683,
+                                                                                                                                            "bottom": 1868
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Dairy Queen",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 466,
+                                                                                                                                                    "top": 1816,
+                                                                                                                                                    "right": 683,
+                                                                                                                                                    "bottom": 1868
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 200,
+                                                                                                                                            "top": 2327,
+                                                                                                                                            "right": 402,
+                                                                                                                                            "bottom": 2379
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Gogi Street",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 200,
+                                                                                                                                                    "top": 2327,
+                                                                                                                                                    "right": 402,
+                                                                                                                                                    "bottom": 2379
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 313,
+                                                                                                                                            "top": 623,
+                                                                                                                                            "right": 515,
+                                                                                                                                            "bottom": 675
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Laurel Cafe",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 313,
+                                                                                                                                                    "top": 623,
+                                                                                                                                                    "right": 515,
+                                                                                                                                                    "bottom": 675
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 609,
+                                                                                                                                            "top": 1565,
+                                                                                                                                            "right": 798,
+                                                                                                                                            "bottom": 1617
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Cheba Hut",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 609,
+                                                                                                                                                    "top": 1565,
+                                                                                                                                                    "right": 798,
+                                                                                                                                                    "bottom": 1617
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 406,
+                                                                                                                                            "top": 900,
+                                                                                                                                            "right": 586,
+                                                                                                                                            "bottom": 952
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Grimaldi's",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 406,
+                                                                                                                                                    "top": 900,
+                                                                                                                                                    "right": 586,
+                                                                                                                                                    "bottom": 952
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 388,
+                                                                                                                                            "top": 249,
+                                                                                                                                            "right": 546,
+                                                                                                                                            "bottom": 301
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "7-Eleven",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 388,
+                                                                                                                                                    "top": 249,
+                                                                                                                                                    "right": 546,
+                                                                                                                                                    "bottom": 301
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 369,
+                                                                                                                                            "top": 1520,
+                                                                                                                                            "right": 503,
+                                                                                                                                            "bottom": 1572
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Pei Wei",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 369,
+                                                                                                                                                    "top": 1520,
+                                                                                                                                                    "right": 503,
+                                                                                                                                                    "bottom": 1572
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 189,
+                                                                                                                                            "top": 1651,
+                                                                                                                                            "right": 311,
+                                                                                                                                            "bottom": 1703
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Chuy's",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 189,
+                                                                                                                                                    "top": 1651,
+                                                                                                                                                    "right": 311,
+                                                                                                                                                    "bottom": 1703
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 68,
+                                                                                                                                            "top": 1565,
+                                                                                                                                            "right": 104,
+                                                                                                                                            "bottom": 1601
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 586,
+                                                                                                                                            "top": 1009,
+                                                                                                                                            "right": 622,
+                                                                                                                                            "bottom": 1045
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1103,
+                                                                                                                                            "top": 2488,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 713,
+                                                                                                                                            "top": 2020,
+                                                                                                                                            "right": 749,
+                                                                                                                                            "bottom": 2056
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 985,
+                                                                                                                                            "top": 1651,
+                                                                                                                                            "right": 1021,
+                                                                                                                                            "bottom": 1687
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 199,
+                                                                                                                                            "top": 2232,
+                                                                                                                                            "right": 235,
+                                                                                                                                            "bottom": 2268
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/driver_offers_job_board_content_container",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2347
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/driver_offers_job_board_recycler_view",
+                                                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 250,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2347
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 305,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 537
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "More trip requests",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 35,
+                                                                                                                                            "top": 340,
+                                                                                                                                            "right": 510,
+                                                                                                                                            "bottom": 411
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "Some may be outside your preferences",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 35,
+                                                                                                                                            "top": 428,
+                                                                                                                                            "right": 752,
+                                                                                                                                            "bottom": 484
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 18,
+                                                                                                                                    "top": 546,
+                                                                                                                                    "right": 1062,
+                                                                                                                                    "bottom": 1344
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "androidx.cardview.widget.CardView",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 18,
+                                                                                                                                            "top": 546,
+                                                                                                                                            "right": 1062,
+                                                                                                                                            "bottom": 1344
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 18,
+                                                                                                                                                    "top": 546,
+                                                                                                                                                    "right": 1062,
+                                                                                                                                                    "bottom": 1344
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/message_content_overlay",
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 89,
+                                                                                                                                                            "top": 877,
+                                                                                                                                                            "right": 991,
+                                                                                                                                                            "bottom": 1013
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "This request is no longer available",
+                                                                                                                                                                "id": "com.ubercab.driver:id/image_message_text",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 125,
+                                                                                                                                                                    "top": 913,
+                                                                                                                                                                    "right": 955,
+                                                                                                                                                                    "bottom": 977
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 18,
+                                                                                                                                                    "top": 546,
+                                                                                                                                                    "right": 1062,
+                                                                                                                                                    "bottom": 1344
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 18,
+                                                                                                                                                            "top": 546,
+                                                                                                                                                            "right": 1062,
+                                                                                                                                                            "bottom": 893
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 54,
+                                                                                                                                                                    "top": 582,
+                                                                                                                                                                    "right": 1026,
+                                                                                                                                                                    "bottom": 866
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 54,
+                                                                                                                                                                            "top": 582,
+                                                                                                                                                                            "right": 1026,
+                                                                                                                                                                            "bottom": 866
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 54,
+                                                                                                                                                                                    "top": 582,
+                                                                                                                                                                                    "right": 1026,
+                                                                                                                                                                                    "bottom": 660
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 54,
+                                                                                                                                                                                            "top": 582,
+                                                                                                                                                                                            "right": 299,
+                                                                                                                                                                                            "bottom": 660
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 72,
+                                                                                                                                                                                                    "top": 603,
+                                                                                                                                                                                                    "right": 108,
+                                                                                                                                                                                                    "bottom": 639
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "Delivery",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 126,
+                                                                                                                                                                                                    "top": 582,
+                                                                                                                                                                                                    "right": 299,
+                                                                                                                                                                                                    "bottom": 660
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 54,
+                                                                                                                                                                                    "top": 660,
+                                                                                                                                                                                    "right": 309,
+                                                                                                                                                                                    "bottom": 788
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "text": "$6.09",
+                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 54,
+                                                                                                                                                                                            "top": 660,
+                                                                                                                                                                                            "right": 309,
+                                                                                                                                                                                            "bottom": 788
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 54,
+                                                                                                                                                                                    "top": 788,
+                                                                                                                                                                                    "right": 1026,
+                                                                                                                                                                                    "bottom": 866
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 54,
+                                                                                                                                                                                            "top": 788,
+                                                                                                                                                                                            "right": 495,
+                                                                                                                                                                                            "bottom": 866
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "Includes expected tip",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 54,
+                                                                                                                                                                                                    "top": 788,
+                                                                                                                                                                                                    "right": 495,
+                                                                                                                                                                                                    "bottom": 866
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 18,
+                                                                                                                                                            "top": 893,
+                                                                                                                                                            "right": 1062,
+                                                                                                                                                            "bottom": 895
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 18,
+                                                                                                                                                            "top": 895,
+                                                                                                                                                            "right": 1062,
+                                                                                                                                                            "bottom": 1004
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 54,
+                                                                                                                                                                    "top": 922,
+                                                                                                                                                                    "right": 1026,
+                                                                                                                                                                    "bottom": 986
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 54,
+                                                                                                                                                                            "top": 922,
+                                                                                                                                                                            "right": 541,
+                                                                                                                                                                            "bottom": 986
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 54,
+                                                                                                                                                                                    "top": 927,
+                                                                                                                                                                                    "right": 107,
+                                                                                                                                                                                    "bottom": 980
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "text": "24 min (8.9 mi) total",
+                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 125,
+                                                                                                                                                                                    "top": 922,
+                                                                                                                                                                                    "right": 541,
+                                                                                                                                                                                    "bottom": 986
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 18,
+                                                                                                                                                            "top": 1004,
+                                                                                                                                                            "right": 1062,
+                                                                                                                                                            "bottom": 1006
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 18,
+                                                                                                                                                            "top": 1006,
+                                                                                                                                                            "right": 1062,
+                                                                                                                                                            "bottom": 1184
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 54,
+                                                                                                                                                                    "top": 1024,
+                                                                                                                                                                    "right": 1026,
+                                                                                                                                                                    "bottom": 1166
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 54,
+                                                                                                                                                                            "top": 1024,
+                                                                                                                                                                            "right": 997,
+                                                                                                                                                                            "bottom": 1166
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 54,
+                                                                                                                                                                                    "top": 1024,
+                                                                                                                                                                                    "right": 997,
+                                                                                                                                                                                    "bottom": 1095
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 54,
+                                                                                                                                                                                            "top": 1033,
+                                                                                                                                                                                            "right": 107,
+                                                                                                                                                                                            "bottom": 1086
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 125,
+                                                                                                                                                                                            "top": 1031,
+                                                                                                                                                                                            "right": 997,
+                                                                                                                                                                                            "bottom": 1087
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 125,
+                                                                                                                                                                                                    "top": 1031,
+                                                                                                                                                                                                    "right": 658,
+                                                                                                                                                                                                    "bottom": 1087
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "Sonic (2314 Thousand Oaks)",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 125,
+                                                                                                                                                                                                            "top": 1031,
+                                                                                                                                                                                                            "right": 658,
+                                                                                                                                                                                                            "bottom": 1087
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 54,
+                                                                                                                                                                                    "top": 1095,
+                                                                                                                                                                                    "right": 997,
+                                                                                                                                                                                    "bottom": 1166
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 54,
+                                                                                                                                                                                            "top": 1104,
+                                                                                                                                                                                            "right": 107,
+                                                                                                                                                                                            "bottom": 1157
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 125,
+                                                                                                                                                                                            "top": 1102,
+                                                                                                                                                                                            "right": 997,
+                                                                                                                                                                                            "bottom": 1158
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 125,
+                                                                                                                                                                                                    "top": 1102,
+                                                                                                                                                                                                    "right": 997,
+                                                                                                                                                                                                    "bottom": 1158
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "Sample St & Sample Ave, San Antonio",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 125,
+                                                                                                                                                                                                            "top": 1102,
+                                                                                                                                                                                                            "right": 997,
+                                                                                                                                                                                                            "bottom": 1158
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "text": "Match",
+                                                                                                                                                        "class": "android.widget.Button",
+                                                                                                                                                        "isClickable": true,
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 54,
+                                                                                                                                                            "top": 1202,
+                                                                                                                                                            "right": 1026,
+                                                                                                                                                            "bottom": 1308
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 946,
+                                                                                                                                                    "top": 582,
+                                                                                                                                                    "right": 1026,
+                                                                                                                                                    "bottom": 662
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 946,
+                                                                                                                                                    "top": 582,
+                                                                                                                                                    "right": 1026,
+                                                                                                                                                    "bottom": 662
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1353,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2347
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/driver_offers_job_board_toolbar_background",
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 278
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/driver_offers_job_board_toolbar",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 278
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "desc": "Back",
+                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 144,
+                                                                                                                            "right": 125,
+                                                                                                                            "bottom": 269
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Trip Radar",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 133,
+                                                                                                                            "top": 179,
+                                                                                                                            "right": 347,
+                                                                                                                            "bottom": 235
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/matchers/rules/uber.json5
+++ b/matchers/rules/uber.json5
@@ -187,6 +187,39 @@
                     }
                   ]
                 }
+              },
+              // #858 LAYER 1 (primary): the expiry overlay disqualifies the frame.
+              // When a request dies, Uber renders `message_content_overlay` /
+              // `image_message_text` ("This request is no longer available") INSIDE
+              // primary_touch_area, over the still-present, dimmed card — every other
+              // require arm (touch area, a "$N.NN", the Match/Accept button) still
+              // holds, so the rule kept matching a dead offer. It then read the
+              // message TextView as the store (it is the first card TextView that is
+              // not a price/badge/duration/dropoff line), which shipped
+              // `merchantName = "This request is no longer available"` into
+              // offer_records, spoke it over TTS, named a screenshot with it, and —
+              // because presentationKey = sha256(storeNames|orders.size|orderTypes)
+              // — poisoned the #830 offer identity into a spurious REPLACE +
+              // OFFER_TIMEOUT("Replaced by new offer") + a phantom offer row.
+              //
+              // Fail-direction: an overlay-bearing frame now matches NO rule and
+              // falls UNKNOWN, so the pipeline DROPS it before the state machine.
+              // That is deliberate — the overlay is the platform saying "this
+              // request is gone", and nothing about it should mint OFFER_RECEIVED or
+              // re-identify the presentation. The already-pending offer simply stays
+              // live until the next real frame or its own OFFER_EXPIRY timer
+              // resolves it (the timer exists precisely for an offer that vanishes
+              // without a frame), which is strictly better than acting on a lie.
+              //
+              // NOT recognized as its own flow on purpose: an explicit
+              // "offer:expired" witness — the platform's own "this was not a
+              // decline" testimony, which #786's outcome resolution would like — is
+              // #251's H3a and is deferred to the Trip Radar / multi-offer board
+              // design. This rule only refuses to lie; it does not yet testify.
+              {
+                "notExists": {
+                  "hasIdSuffix": "image_message_text"
+                }
               }
             ]
           },
@@ -281,6 +314,25 @@
                           },
                           {
                             "hasTextContaining": ", "
+                          },
+                          // #858 LAYER 2 (defense in depth): never let the expiry
+                          // overlay win the store read. Layer 1 (the require
+                          // `notExists` above) already stops an overlay-bearing
+                          // frame from matching at all, so on today's shape this
+                          // is unreachable — it is here so a FUTURE overlay
+                          // variant that slips past layer 1 still cannot poison
+                          // the store. The two arms are deliberately independent
+                          // of each other and of layer 1's anchor: the id catches
+                          // a re-worded message, the text catches a re-id'd node.
+                          // Written as an ordinary negation entry (no store-
+                          // specific matching, platform chrome only) so the #251
+                          // Trip Radar board rule — the overlay also renders
+                          // per-card there — can lift the same two arms verbatim.
+                          {
+                            "hasIdSuffix": "image_message_text"
+                          },
+                          {
+                            "hasTextContaining": "no longer available"
                           }
                         ]
                       }
@@ -341,6 +393,21 @@
                               },
                               {
                                 "hasTextContaining": ", "
+                              },
+                              // #858 LAYER 2, orders[] half — same two arms as the
+                              // top-level storeName negation above. This one is the
+                              // load-bearing copy for offer IDENTITY: presentationKey
+                              // = sha256(storeNames|orders.size|orderTypes) is built
+                              // from orders[].storeName, so an overlay winning HERE is
+                              // what turned a live re-quote into a spurious #830
+                              // REPLACE. (The lists are duplicated because the DSL has
+                              // no shared-predicate form; they must be edited in
+                              // lockstep — see the top-level block for the rationale.)
+                              {
+                                "hasIdSuffix": "image_message_text"
+                              },
+                              {
+                                "hasTextContaining": "no longer available"
                               }
                             ]
                           }


### PR DESCRIPTION
Closes #858.

## Mechanism

When an Uber request dies, the platform renders `message_content_overlay` / `image_message_text` = **"This request is no longer available"** *over the still-present, dimmed card* — and critically **inside `primary_touch_area`**. `uber.screen.offer` has no `validate` block and a presence-only `require`, so all three arms still held on the dying frame (the touch area exists, a `$N.NN` exists, the `Match`/`Accept` button exists) and the rule kept matching a dead offer.

The `storeName` parse then read the message TextView: the negation list excludes prices, `+` badges, `min`, `Accept`/`Match`, `Delivery`, the promo/`items` labels and the `", <City>"` dropoff line — but not the overlay, and the overlay is the **first** card TextView, so it won the first-match.

Receipts (2026-07-25 pull, frame `…5a0d26.json`):
- `offer_records` seq 735: `merchantName = "This request is no longer available"`, pay 13.31
- TTS spoke it; an evidence screenshot was named `Offer - This request is no longer available.png`
- `presentationKey = sha256(storeNames|orders.size|orderTypes)` is built from `orders[].storeName`, so the poisoned store changed the presentation identity → the #830 enrich-as-variant merge saw a *different* presentation → spurious **REPLACE** → `OFFER_TIMEOUT("Replaced by new offer")` on the real live offer + a phantom offer row. #830 worked exactly as specced; the parse fed it a lie.

## The fix — two layers, both rule data (`matchers/rules/uber.json5`)

**Layer 1 (primary), in the offer rule's `require`:**

```json5
{
  "notExists": {
    "hasIdSuffix": "image_message_text"
  }
}
```

An overlay-bearing frame now matches **no** rule and falls **UNKNOWN**, so `AccessibilityPipeline.output()` drops it before the state machine.

**Layer 2 (defense in depth), appended to BOTH `storeName` negation lists** — the top-level one (screenshot-prefix interpolation) and the `orders[]` extract one (the load-bearing copy for offer identity):

```json5
{
  "hasIdSuffix": "image_message_text"
},
{
  "hasTextContaining": "no longer available"
}
```

The two arms are deliberately independent of each other **and** of layer 1's anchor: the **id** arm catches a re-worded message, the **text** arm catches a re-id'd node. On today's shape layer 2 is unreachable (layer 1 already rejects the frame); it exists so a future overlay variant that slips past layer 1 still cannot poison the store.

Both layers are documented inline in the rule's comment blocks, including the deferral and residual notes below.

## Fail-direction rationale (why UNKNOWN, not "recognize and skip")

UNKNOWN is the **correct** fail-direction here, not a fallback:

- The overlay *is* the platform saying "this request is gone". Nothing on that frame should mint `OFFER_RECEIVED`, name a screenshot, speak, or re-identify a presentation.
- The already-pending offer is **not** harmed by the frame disappearing from recognition — it stays live until the next real frame or its own per-offer `OFFER_EXPIRY` timer resolves it. That timer exists precisely for "an overlay offer that vanishes without a frame", which is exactly this situation.
- The alternative (keep matching, just fix the store read) would still emit a live-offer observation off a dead card — a smaller lie, but still a lie. Refusing to speak is strictly better than speaking wrongly.

## Deliberately NOT done: recognizing the overlay as its own flow

An explicit `offer:expired`-style classification would be the platform's own **"this was not a decline" witness** — genuinely valuable to #786's offer-outcome resolution and to the #810 orphan-offer tiers, since it distinguishes "expired out from under me" from "I declined". That is **#251's H3a** and is **deferred to the Trip Radar / multi-offer board design**, not smuggled in here. This PR only makes the rule refuse to lie; it does not yet make it testify.

## Board-variant residual (#251)

The overlay also renders **per-card on the Trip Radar board** (`driver_offers_job_board_recycler_view`). All 16 of the fielded UNKNOWN overlay frames are board frames — they carry no `primary_touch_area` at all, which is why they were already UNKNOWN (there is no board rule today, so they are unrecognized for an unrelated reason). When #251 adds a board rule it **must carry the same guard**; the layer-2 entries are written as ordinary, platform-chrome-only negation arms specifically so that rule can lift them verbatim. One board frame is committed as a fixture to make that residual visible and to fail loudly if a future board rule ever matches an expiring card.

## Fixtures + tests

New fixtures dir **outside** `snapshots/` (the PR #872 pattern — these must never enter the golden corpus, since a corpus folder means "this must classify as that folder"):

`app/src/test/resources/fixtures/uber_offer_expiry_overlay/`
- `2026-07-23_18-48-34-589__…__offer__5a0d26.json` — **the specimen**: the one fielded overlay frame that classified `offer` and produced seq 735.
- `2026-07-23_19-39-59-512__…__UNKNOWN__894217.json` — the Trip Radar board variant.

New `UberOfferExpiryOverlayTest` (registered in `AllMatchersSuite`), `@RunWith(Enclosed)`:
- `OverlayFramesStayUnknown` (parameterized, 3 assertions × 2 fixtures) — (a) precondition pin that the fixture really carries `image_message_text` (so the UNKNOWN assertion can't pass vacuously on an unrelated tree), (b) classifies UNKNOWN, (c) `SnapshotSecurityScanner` not toxic — same bar as committed corpus.
- `CleanOfferStillRecognized` — the **over-rejection counterweight**: a `notExists` that is too broad silently deletes recognition, so every committed `snapshots/offer/*__uber__*` capture must still classify `offer` **and** parse a real, non-overlay `storeName`.

## Fixture PII confirmation

Manually swept both fixtures (every `text`/`desc` value enumerated, not just grepped):

- `5a0d26` — clean as captured: 9 text nodes, store `Po Po Trattoria Pizzeria` (merchant, driver-owned), and the dropoff line **already** arrives as `[redacted:19c9]` (the #813(b) rule-declared `redact` fired because the frame was recognized). No raw customer token.
- `894217` — the board frame was UNKNOWN on device, so no rule `redact` applied and it carried **one raw customer cross-street**: `Ridge Cave St & Ridge Country St, San Antonio`. **Replaced with the standing placeholder `Sample St & Sample Ave, San Antonio`.**

Everything remaining is merchant names, platform chrome (`Trip Radar`, `More trip requests`, `Match`, `Back`), money/time/distance, and the hashed mask. No customer names, no `Deliver to`/`Pickup for`/`Meet at` shapes, no PINs, no gate codes, no street-number addresses. `Sonic (2314 Thousand Oaks)` is a merchant store form (the #773 running-key shape), not a customer address.

## Golden status

**`ParseOutputGoldenTest` UNCHANGED — no regeneration.** Verified two ways: the committed corpus contains **zero** frames carrying `image_message_text` (`grep -rl` over `app/src/test/resources/snapshots/` → 0), and `approved-parse-output.json` shows no diff after a full run. The issue's expectation of a golden regen does not apply — the overlay frames were never in the corpus, and this PR deliberately does not add them there.

## Fielded-frame census under the new rule

All 17 overlay-bearing captures in the 2026-07-25 pull, re-classified against the compiled post-fix ruleset:

| | before | after |
|---|---|---|
| classified `offer` | 1 | **0** |
| UNKNOWN | 16 | **17** |

Every one now returns `intent = UNKNOWN`, `ruleId = null`, `storeName = null`. Same run confirmed the 4 committed clean uber offer snapshots still classify `offer` with their real stores (`Costco Wholesale (Sonterra Park)`, `Buttermilk Sky Pie`, `BJ's Restaurant & Brewhouse (San Antonio #480)`, `Thai Buri (8728401)`).

## Tests

- `:app:testDebugUnitTest --tests "*AllMatchersSuite*"` — **green** (new test: 6 + 1 assertions, 0 failures).
- Full `./gradlew testDebugUnitTest :domain:test` — **green**.

### Design-goal review

- **P8 (platform-agnostic core) — conforms.** The entire behavioral change is **rule data** in `matchers/rules/uber.json5`; zero Kotlin changed in `:core:pipeline` / `:core:state` / `:domain`. No new platform literal, no new wire vocabulary, no `when` branch. The predicates used (`notExists`, `hasIdSuffix`, `hasTextContaining`) are all pre-existing compiler vocabulary. The only Kotlin added is test code.
- **P6 (security & privacy first) — conforms, fail-closed direction.** The change makes the offer rule strictly *narrower*: a frame that used to be recognized (and therefore parsed, logged, spoken, screenshotted) now falls UNKNOWN and is dropped. It cannot downgrade the sensitive-block side (untouched) and it cannot start storing more customer PII — it stores strictly less. One nuance recorded honestly: the specimen frame was recognized on device and therefore got its dropoff line masked by the #813(b) `redact`; under the new rule that same frame lands on the UNKNOWN capture path instead, where the `CustomerTextMarkers` backstop (#806) applies but the prefix-less `", <City>"` dropoff line is the documented residual class — i.e. an overlay frame's dropoff line can now reach a debug-only UNKNOWN capture unmasked, the same residual every other unrecognized Uber card already has (release builds bind `NoOpCaptureBus`). That is the known #806-direction-1 residual, not a new class; the committed board fixture is exactly such a frame and was hand-scrubbed before commit.
- **P5 (SSOT) — conforms, with a noted duplication that is pre-existing.** The negation entries are written **once per existing list** and phrased as reusable platform-chrome arms so the future #251 board rule copies them rather than inventing its own. The two `storeName` negation lists were already duplicated before this PR (the rule DSL has no shared-predicate form); the diff adds an explicit lockstep-edit note at both sites rather than silently widening the drift.
- **P3 (single responsibility / clean code) — conforms.** One rule, one guard, one focused test class; the fixtures live in their own directory outside the golden corpus so the "folder name == expected intent" contract stays intact.
- **P7 (semantic, PII-safe logging)** — no log sites added or moved.
- Untouched by this diff: P1 (UDF — no reducer/effect change), P2, P4, Reactive UI.

### Follow-up not in this PR (scoped out by the build brief: rule + fixtures + tests only)

- A `## Next field test — things to look for` checklist item for #858 (watch: an Uber offer that expires while on screen should produce **no** new offer row / no TTS / no `OFFER_TIMEOUT("Replaced by new offer")` on the live offer, and the dying frame should show up as an UNKNOWN capture; `Confirmed: 0/2`).
- Memory upkeep.
