### PR TITLE
rules(doordash): #865 close the three performance-hub recognition gaps (acceptance detail, scrolled last-100 list, customer-rating detail)

### DIFF
--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -269,6 +269,18 @@
         "shape": null,
         "fields": {}
     },
+    "customer_rating_detail/customer_rating_detail.json": {
+        "ruleId": "doordash.screen.customer_rating_detail",
+        "intent": "customer_rating_detail",
+        "shape": null,
+        "fields": {}
+    },
+    "customer_rating_detail/customer_rating_detail_loading.json": {
+        "ruleId": "doordash.screen.customer_rating_detail",
+        "intent": "customer_rating_detail",
+        "shape": null,
+        "fields": {}
+    },
     "dash_along_the_way/2026-04-25_18-52-07__ON_DASH_ALONG_THE_WAY__28f8873e.json": {
         "ruleId": "doordash.screen.dash_along_the_way",
         "intent": "dash_along_the_way",
@@ -3287,6 +3299,30 @@
     "performance_orders_list/performance_orders_list.json": {
         "ruleId": "doordash.screen.performance_orders_list",
         "intent": "performance_orders_list",
+        "shape": null,
+        "fields": {}
+    },
+    "performance_orders_list/performance_orders_list_scrolled.json": {
+        "ruleId": "doordash.screen.performance_orders_list",
+        "intent": "performance_orders_list",
+        "shape": null,
+        "fields": {}
+    },
+    "performance_orders_list/performance_orders_list_scrolled_tail.json": {
+        "ruleId": "doordash.screen.performance_orders_list",
+        "intent": "performance_orders_list",
+        "shape": null,
+        "fields": {}
+    },
+    "performance_rate_detail/performance_rate_acceptance.json": {
+        "ruleId": "doordash.screen.performance_rate_detail",
+        "intent": "performance_rate_detail",
+        "shape": null,
+        "fields": {}
+    },
+    "performance_rate_detail/performance_rate_acceptance_loading.json": {
+        "ruleId": "doordash.screen.performance_rate_detail",
+        "intent": "performance_rate_detail",
         "shape": null,
         "fields": {}
     },

--- a/app/src/test/resources/snapshots/customer_rating_detail/customer_rating_detail.json
+++ b/app/src/test/resources/snapshots/customer_rating_detail/customer_rating_detail.json
@@ -1,0 +1,1346 @@
+{
+    "captureId": "cf297955-29c5-4167-8aa1-6a6463c8f258",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784948641536,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Navigate up",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 144,
+                                                                            "right": 125,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "text": "Customer rating",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 133,
+                                                                            "top": 175,
+                                                                            "right": 528,
+                                                                            "bottom": 238
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 1080,
+                                                                            "top": 144,
+                                                                            "right": 1080,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/fragment",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 278,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 278,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 278,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 278,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/rating",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 278,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 966
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/star_rating_container",
+                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 447,
+                                                                                                    "top": 331,
+                                                                                                    "right": 634,
+                                                                                                    "bottom": 415
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "4.97",
+                                                                                                        "id": "com.doordash.driverapp:id/star_rating",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 447,
+                                                                                                            "top": 331,
+                                                                                                            "right": 589,
+                                                                                                            "bottom": 415
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/rating_icon",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 598,
+                                                                                                            "top": 356,
+                                                                                                            "right": 634,
+                                                                                                            "bottom": 389
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Based on your 100 most recent delivery ratings Learn More",
+                                                                                                "id": "com.doordash.driverapp:id/rating_info",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 433,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 535
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_top_extra_space",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 535,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 562
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_five",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 589,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 629
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 27,
+                                                                                                            "top": 589,
+                                                                                                            "right": 1053,
+                                                                                                            "bottom": 629
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "5",
+                                                                                                                "id": "com.doordash.driverapp:id/rating",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 27,
+                                                                                                                    "top": 589,
+                                                                                                                    "right": 79,
+                                                                                                                    "bottom": 626
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "98%",
+                                                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 98,
+                                                                                                                    "top": 599,
+                                                                                                                    "right": 995,
+                                                                                                                    "bottom": 617
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "98",
+                                                                                                                "id": "com.doordash.driverapp:id/rating_count",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 999,
+                                                                                                                    "top": 589,
+                                                                                                                    "right": 1052,
+                                                                                                                    "bottom": 629
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_four",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 656,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 696
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 27,
+                                                                                                            "top": 656,
+                                                                                                            "right": 1053,
+                                                                                                            "bottom": 696
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "4",
+                                                                                                                "id": "com.doordash.driverapp:id/rating",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 27,
+                                                                                                                    "top": 656,
+                                                                                                                    "right": 78,
+                                                                                                                    "bottom": 693
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "1%",
+                                                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 98,
+                                                                                                                    "top": 666,
+                                                                                                                    "right": 995,
+                                                                                                                    "bottom": 684
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "1",
+                                                                                                                "id": "com.doordash.driverapp:id/rating_count",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 999,
+                                                                                                                    "top": 656,
+                                                                                                                    "right": 1052,
+                                                                                                                    "bottom": 696
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_three",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 723,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 763
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 27,
+                                                                                                            "top": 723,
+                                                                                                            "right": 1053,
+                                                                                                            "bottom": 763
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "3",
+                                                                                                                "id": "com.doordash.driverapp:id/rating",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 27,
+                                                                                                                    "top": 723,
+                                                                                                                    "right": 77,
+                                                                                                                    "bottom": 760
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "1%",
+                                                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 98,
+                                                                                                                    "top": 733,
+                                                                                                                    "right": 995,
+                                                                                                                    "bottom": 751
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "1",
+                                                                                                                "id": "com.doordash.driverapp:id/rating_count",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 999,
+                                                                                                                    "top": 723,
+                                                                                                                    "right": 1052,
+                                                                                                                    "bottom": 763
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_two",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 790,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 830
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 27,
+                                                                                                            "top": 790,
+                                                                                                            "right": 1053,
+                                                                                                            "bottom": 830
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "2",
+                                                                                                                "id": "com.doordash.driverapp:id/rating",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 27,
+                                                                                                                    "top": 790,
+                                                                                                                    "right": 77,
+                                                                                                                    "bottom": 827
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "0%",
+                                                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 98,
+                                                                                                                    "top": 800,
+                                                                                                                    "right": 995,
+                                                                                                                    "bottom": 818
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "0",
+                                                                                                                "id": "com.doordash.driverapp:id/rating_count",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 999,
+                                                                                                                    "top": 790,
+                                                                                                                    "right": 1052,
+                                                                                                                    "bottom": 830
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_one",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 857,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 897
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 27,
+                                                                                                            "top": 857,
+                                                                                                            "right": 1053,
+                                                                                                            "bottom": 897
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "1",
+                                                                                                                "id": "com.doordash.driverapp:id/rating",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 27,
+                                                                                                                    "top": 857,
+                                                                                                                    "right": 71,
+                                                                                                                    "bottom": 894
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "0%",
+                                                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 98,
+                                                                                                                    "top": 867,
+                                                                                                                    "right": 995,
+                                                                                                                    "bottom": 885
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "0",
+                                                                                                                "id": "com.doordash.driverapp:id/rating_count",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 999,
+                                                                                                                    "top": 857,
+                                                                                                                    "right": 1052,
+                                                                                                                    "bottom": 897
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/unfair_ratings_container",
+                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 27,
+                                                                                                    "top": 924,
+                                                                                                    "right": 429,
+                                                                                                    "bottom": 966
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/shield_icon",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 27,
+                                                                                                            "top": 927,
+                                                                                                            "right": 63,
+                                                                                                            "bottom": 963
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "0 ratings excluded",
+                                                                                                        "id": "com.doordash.driverapp:id/unfair_ratings_text",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 81,
+                                                                                                            "top": 924,
+                                                                                                            "right": 384,
+                                                                                                            "bottom": 966
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/unfair_ratings_more_info",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 393,
+                                                                                                            "top": 927,
+                                                                                                            "right": 429,
+                                                                                                            "bottom": 963
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/customer_feedback",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 966,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1626
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Customer Feedback",
+                                                                                                "id": "com.doordash.driverapp:id/feedback_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1037,
+                                                                                                    "right": 498,
+                                                                                                    "bottom": 1094
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/feedback_category_tiles",
+                                                                                                "class": "androidx.recyclerview.widget.StaggeredGridLayoutManager",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 18,
+                                                                                                    "top": 1130,
+                                                                                                    "right": 1062,
+                                                                                                    "bottom": 1626
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/category_item_compose_view",
+                                                                                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 18,
+                                                                                                            "top": 1130,
+                                                                                                            "right": 540,
+                                                                                                            "bottom": 1350
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 18,
+                                                                                                                    "top": 1130,
+                                                                                                                    "right": 540,
+                                                                                                                    "bottom": 1350
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 1148,
+                                                                                                                            "right": 522,
+                                                                                                                            "bottom": 1332
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Communication",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 63,
+                                                                                                                                    "top": 1175,
+                                                                                                                                    "right": 495,
+                                                                                                                                    "bottom": 1222
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 63,
+                                                                                                                                    "top": 1264,
+                                                                                                                                    "right": 99,
+                                                                                                                                    "bottom": 1300
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "7",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 108,
+                                                                                                                                    "top": 1258,
+                                                                                                                                    "right": 130,
+                                                                                                                                    "bottom": 1305
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 166,
+                                                                                                                                    "top": 1264,
+                                                                                                                                    "right": 202,
+                                                                                                                                    "bottom": 1300
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "–",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 211,
+                                                                                                                                    "top": 1258,
+                                                                                                                                    "right": 232,
+                                                                                                                                    "bottom": 1305
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "right_arrow",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 459,
+                                                                                                                                    "top": 1264,
+                                                                                                                                    "right": 495,
+                                                                                                                                    "bottom": 1300
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/category_item_compose_view",
+                                                                                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 18,
+                                                                                                            "top": 1350,
+                                                                                                            "right": 540,
+                                                                                                            "bottom": 1570
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 18,
+                                                                                                                    "top": 1350,
+                                                                                                                    "right": 540,
+                                                                                                                    "bottom": 1570
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 1368,
+                                                                                                                            "right": 522,
+                                                                                                                            "bottom": 1552
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Order Handling",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 63,
+                                                                                                                                    "top": 1395,
+                                                                                                                                    "right": 495,
+                                                                                                                                    "bottom": 1442
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 63,
+                                                                                                                                    "top": 1484,
+                                                                                                                                    "right": 99,
+                                                                                                                                    "bottom": 1520
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "8",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 108,
+                                                                                                                                    "top": 1478,
+                                                                                                                                    "right": 134,
+                                                                                                                                    "bottom": 1525
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 170,
+                                                                                                                                    "top": 1484,
+                                                                                                                                    "right": 206,
+                                                                                                                                    "bottom": 1520
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "–",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 215,
+                                                                                                                                    "top": 1478,
+                                                                                                                                    "right": 236,
+                                                                                                                                    "bottom": 1525
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "right_arrow",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 459,
+                                                                                                                                    "top": 1484,
+                                                                                                                                    "right": 495,
+                                                                                                                                    "bottom": 1520
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/category_item_compose_view",
+                                                                                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 540,
+                                                                                                            "top": 1130,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 1406
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 540,
+                                                                                                                    "top": 1130,
+                                                                                                                    "right": 1062,
+                                                                                                                    "bottom": 1406
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 558,
+                                                                                                                            "top": 1148,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1388
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Followed Delivery Instructions",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 585,
+                                                                                                                                    "top": 1175,
+                                                                                                                                    "right": 1017,
+                                                                                                                                    "bottom": 1278
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 585,
+                                                                                                                                    "top": 1320,
+                                                                                                                                    "right": 621,
+                                                                                                                                    "bottom": 1356
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "8",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 630,
+                                                                                                                                    "top": 1314,
+                                                                                                                                    "right": 656,
+                                                                                                                                    "bottom": 1361
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 692,
+                                                                                                                                    "top": 1320,
+                                                                                                                                    "right": 728,
+                                                                                                                                    "bottom": 1356
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "–",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 737,
+                                                                                                                                    "top": 1314,
+                                                                                                                                    "right": 758,
+                                                                                                                                    "bottom": 1361
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "right_arrow",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 981,
+                                                                                                                                    "top": 1320,
+                                                                                                                                    "right": 1017,
+                                                                                                                                    "bottom": 1356
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/category_item_compose_view",
+                                                                                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 540,
+                                                                                                            "top": 1406,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 1626
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 540,
+                                                                                                                    "top": 1406,
+                                                                                                                    "right": 1062,
+                                                                                                                    "bottom": 1626
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 558,
+                                                                                                                            "top": 1424,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1608
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Friendliness",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 585,
+                                                                                                                                    "top": 1451,
+                                                                                                                                    "right": 1017,
+                                                                                                                                    "bottom": 1498
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 585,
+                                                                                                                                    "top": 1540,
+                                                                                                                                    "right": 621,
+                                                                                                                                    "bottom": 1576
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "8",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 630,
+                                                                                                                                    "top": 1534,
+                                                                                                                                    "right": 656,
+                                                                                                                                    "bottom": 1581
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 692,
+                                                                                                                                    "top": 1540,
+                                                                                                                                    "right": 728,
+                                                                                                                                    "bottom": 1576
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "–",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 737,
+                                                                                                                                    "top": 1534,
+                                                                                                                                    "right": 758,
+                                                                                                                                    "bottom": 1581
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "right_arrow",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 981,
+                                                                                                                                    "top": 1540,
+                                                                                                                                    "right": 1017,
+                                                                                                                                    "bottom": 1576
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/customer_compliments",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1626,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2299
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Customer Compliments",
+                                                                                                "id": "com.doordash.driverapp:id/compliment_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1697,
+                                                                                                    "right": 579,
+                                                                                                    "bottom": 1754
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/ic_compliments",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 1790,
+                                                                                                    "right": 196,
+                                                                                                    "bottom": 1950
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Above and Beyond",
+                                                                                                "id": "com.doordash.driverapp:id/above_beyond",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 214,
+                                                                                                    "top": 1807,
+                                                                                                    "right": 557,
+                                                                                                    "bottom": 1854
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "5",
+                                                                                                "id": "com.doordash.driverapp:id/above_beyond_count",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 87,
+                                                                                                    "top": 1910,
+                                                                                                    "right": 145,
+                                                                                                    "bottom": 1971
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Number of times customers thought you went 'Above and Beyond'.",
+                                                                                                "id": "com.doordash.driverapp:id/above_beyond_desc",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 214,
+                                                                                                    "top": 1858,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1952
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Quotes from customers",
+                                                                                                "id": "com.doordash.driverapp:id/quotes_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 2042,
+                                                                                                    "right": 478,
+                                                                                                    "bottom": 2089
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/quotes_recycler",
+                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 2125,
+                                                                                                    "right": 44,
+                                                                                                    "bottom": 2125
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Customer quotes from 5-star reviews will appear here.",
+                                                                                                "id": "com.doordash.driverapp:id/no_compliments",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 2125,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 2299
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/learn_more",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 2299,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Learn more",
+                                                                                                "id": "com.doordash.driverapp:id/learn_more_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 2370,
+                                                                                                    "right": 296,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/learn_more_section_compose_view",
+                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 2445,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 2445,
+                                                                                                            "right": 1044,
+                                                                                                            "bottom": 2799
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 2445,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 2546
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "How we're collecting data",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 2472,
+                                                                                                                            "right": 501,
+                                                                                                                            "bottom": 2519
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 2494,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 2546
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 2546,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 2651
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "How we calculate Customer Ratings",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 2575,
+                                                                                                                            "right": 688,
+                                                                                                                            "bottom": 2622
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 2597,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 2651
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 2651,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 2799
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Deactivation Policy",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 2678,
+                                                                                                                            "right": 386,
+                                                                                                                            "bottom": 2725
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Eligible if below 4.2",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 2729,
+                                                                                                                            "right": 354,
+                                                                                                                            "bottom": 2772
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/customer_rating_detail/customer_rating_detail_loading.json
+++ b/app/src/test/resources/snapshots/customer_rating_detail/customer_rating_detail_loading.json
@@ -1,0 +1,917 @@
+{
+    "captureId": "7829d62a-3e7c-4fb1-a2a8-509f5503208f",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784948640944,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Navigate up",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 144,
+                                                                            "right": 125,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 1080,
+                                                                            "top": 144,
+                                                                            "right": 1080,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/fragment",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 278,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 278,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 278,
+                                                                            "right": 1080,
+                                                                            "bottom": 2288
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 278,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2288
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/rating",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 278,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 911
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/star_rating_container",
+                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 518,
+                                                                                                    "top": 331,
+                                                                                                    "right": 563,
+                                                                                                    "bottom": 415
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/star_rating",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 518,
+                                                                                                            "top": 331,
+                                                                                                            "right": 518,
+                                                                                                            "bottom": 415
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/rating_icon",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 527,
+                                                                                                            "top": 356,
+                                                                                                            "right": 563,
+                                                                                                            "bottom": 389
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/rating_info",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 513,
+                                                                                                    "top": 433,
+                                                                                                    "right": 567,
+                                                                                                    "bottom": 480
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_five",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 534,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 574
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 183,
+                                                                                                            "top": 534,
+                                                                                                            "right": 1209,
+                                                                                                            "bottom": 574
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "5",
+                                                                                                                "id": "com.doordash.driverapp:id/rating",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 183,
+                                                                                                                    "top": 534,
+                                                                                                                    "right": 235,
+                                                                                                                    "bottom": 571
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "50%",
+                                                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 254,
+                                                                                                                    "top": 544,
+                                                                                                                    "right": 1151,
+                                                                                                                    "bottom": 562
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "12",
+                                                                                                                "id": "com.doordash.driverapp:id/rating_count",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 1155,
+                                                                                                                    "top": 534,
+                                                                                                                    "right": 1208,
+                                                                                                                    "bottom": 574
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_four",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 156,
+                                                                                                    "top": 601,
+                                                                                                    "right": 1236,
+                                                                                                    "bottom": 641
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 183,
+                                                                                                            "top": 601,
+                                                                                                            "right": 1209,
+                                                                                                            "bottom": 641
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "4",
+                                                                                                                "id": "com.doordash.driverapp:id/rating",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 183,
+                                                                                                                    "top": 601,
+                                                                                                                    "right": 234,
+                                                                                                                    "bottom": 638
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "50%",
+                                                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 254,
+                                                                                                                    "top": 611,
+                                                                                                                    "right": 1151,
+                                                                                                                    "bottom": 629
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "12",
+                                                                                                                "id": "com.doordash.driverapp:id/rating_count",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 1155,
+                                                                                                                    "top": 601,
+                                                                                                                    "right": 1208,
+                                                                                                                    "bottom": 641
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_three",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 156,
+                                                                                                    "top": 668,
+                                                                                                    "right": 1236,
+                                                                                                    "bottom": 708
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 183,
+                                                                                                            "top": 668,
+                                                                                                            "right": 1209,
+                                                                                                            "bottom": 708
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "3",
+                                                                                                                "id": "com.doordash.driverapp:id/rating",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 183,
+                                                                                                                    "top": 668,
+                                                                                                                    "right": 233,
+                                                                                                                    "bottom": 705
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "50%",
+                                                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 254,
+                                                                                                                    "top": 678,
+                                                                                                                    "right": 1151,
+                                                                                                                    "bottom": 696
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "12",
+                                                                                                                "id": "com.doordash.driverapp:id/rating_count",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 1155,
+                                                                                                                    "top": 668,
+                                                                                                                    "right": 1208,
+                                                                                                                    "bottom": 708
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_two",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 156,
+                                                                                                    "top": 735,
+                                                                                                    "right": 1236,
+                                                                                                    "bottom": 775
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 183,
+                                                                                                            "top": 735,
+                                                                                                            "right": 1209,
+                                                                                                            "bottom": 775
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "2",
+                                                                                                                "id": "com.doordash.driverapp:id/rating",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 183,
+                                                                                                                    "top": 735,
+                                                                                                                    "right": 233,
+                                                                                                                    "bottom": 772
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "50%",
+                                                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 254,
+                                                                                                                    "top": 745,
+                                                                                                                    "right": 1151,
+                                                                                                                    "bottom": 763
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "12",
+                                                                                                                "id": "com.doordash.driverapp:id/rating_count",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 1155,
+                                                                                                                    "top": 735,
+                                                                                                                    "right": 1208,
+                                                                                                                    "bottom": 775
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_one",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 156,
+                                                                                                    "top": 802,
+                                                                                                    "right": 1236,
+                                                                                                    "bottom": 842
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 183,
+                                                                                                            "top": 802,
+                                                                                                            "right": 1209,
+                                                                                                            "bottom": 842
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "1",
+                                                                                                                "id": "com.doordash.driverapp:id/rating",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 183,
+                                                                                                                    "top": 802,
+                                                                                                                    "right": 227,
+                                                                                                                    "bottom": 839
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "50%",
+                                                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 254,
+                                                                                                                    "top": 812,
+                                                                                                                    "right": 1151,
+                                                                                                                    "bottom": 830
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "12",
+                                                                                                                "id": "com.doordash.driverapp:id/rating_count",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 1155,
+                                                                                                                    "top": 802,
+                                                                                                                    "right": 1208,
+                                                                                                                    "bottom": 842
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/unfair_ratings_container",
+                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 183,
+                                                                                                    "top": 869,
+                                                                                                    "right": 282,
+                                                                                                    "bottom": 911
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/shield_icon",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 183,
+                                                                                                            "top": 872,
+                                                                                                            "right": 219,
+                                                                                                            "bottom": 908
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/unfair_ratings_text",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 237,
+                                                                                                            "top": 869,
+                                                                                                            "right": 237,
+                                                                                                            "bottom": 911
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/unfair_ratings_more_info",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 246,
+                                                                                                            "top": 872,
+                                                                                                            "right": 282,
+                                                                                                            "bottom": 908
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/customer_feedback",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 156,
+                                                                                            "top": 911,
+                                                                                            "right": 1236,
+                                                                                            "bottom": 1075
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Customer Feedback",
+                                                                                                "id": "com.doordash.driverapp:id/feedback_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 192,
+                                                                                                    "top": 982,
+                                                                                                    "right": 654,
+                                                                                                    "bottom": 1039
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/feedback_category_tiles",
+                                                                                                "class": "androidx.recyclerview.widget.StaggeredGridLayoutManager",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 174,
+                                                                                                    "top": 1075,
+                                                                                                    "right": 1218,
+                                                                                                    "bottom": 1075
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/customer_compliments",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 156,
+                                                                                            "top": 1075,
+                                                                                            "right": 1236,
+                                                                                            "bottom": 1574
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Customer Compliments",
+                                                                                                "id": "com.doordash.driverapp:id/compliment_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 192,
+                                                                                                    "top": 1146,
+                                                                                                    "right": 735,
+                                                                                                    "bottom": 1203
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/ic_compliments",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 192,
+                                                                                                    "top": 1239,
+                                                                                                    "right": 352,
+                                                                                                    "bottom": 1399
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Above and Beyond",
+                                                                                                "id": "com.doordash.driverapp:id/above_beyond",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 370,
+                                                                                                    "top": 1256,
+                                                                                                    "right": 713,
+                                                                                                    "bottom": 1303
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/above_beyond_count",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 254,
+                                                                                                    "top": 1359,
+                                                                                                    "right": 290,
+                                                                                                    "bottom": 1420
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Number of times customers thought you went 'Above and Beyond'.",
+                                                                                                "id": "com.doordash.driverapp:id/above_beyond_desc",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 370,
+                                                                                                    "top": 1307,
+                                                                                                    "right": 1200,
+                                                                                                    "bottom": 1401
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Quotes from customers",
+                                                                                                "id": "com.doordash.driverapp:id/quotes_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 192,
+                                                                                                    "top": 1491,
+                                                                                                    "right": 634,
+                                                                                                    "bottom": 1538
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "desc": "See all",
+                                                                                                "id": "com.doordash.driverapp:id/see_all",
+                                                                                                "class": "android.widget.Button",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 1037,
+                                                                                                    "top": 1478,
+                                                                                                    "right": 1200,
+                                                                                                    "bottom": 1551
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "See all",
+                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 1064,
+                                                                                                            "top": 1487,
+                                                                                                            "right": 1173,
+                                                                                                            "bottom": 1542
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/quotes_recycler",
+                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 156,
+                                                                                                    "top": 1574,
+                                                                                                    "right": 200,
+                                                                                                    "bottom": 1574
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/learn_more",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 192,
+                                                                                            "top": 1574,
+                                                                                            "right": 1200,
+                                                                                            "bottom": 2074
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Learn more",
+                                                                                                "id": "com.doordash.driverapp:id/learn_more_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 192,
+                                                                                                    "top": 1645,
+                                                                                                    "right": 452,
+                                                                                                    "bottom": 1702
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/learn_more_section_compose_view",
+                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 192,
+                                                                                                    "top": 1720,
+                                                                                                    "right": 1200,
+                                                                                                    "bottom": 2074
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 192,
+                                                                                                            "top": 1720,
+                                                                                                            "right": 1200,
+                                                                                                            "bottom": 2074
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 192,
+                                                                                                                    "top": 1720,
+                                                                                                                    "right": 1200,
+                                                                                                                    "bottom": 1821
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "How we're collecting data",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 192,
+                                                                                                                            "top": 1747,
+                                                                                                                            "right": 657,
+                                                                                                                            "bottom": 1794
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 192,
+                                                                                                                            "top": 1769,
+                                                                                                                            "right": 1200,
+                                                                                                                            "bottom": 1821
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 192,
+                                                                                                                    "top": 1821,
+                                                                                                                    "right": 1200,
+                                                                                                                    "bottom": 1926
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "How we calculate Customer Ratings",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 192,
+                                                                                                                            "top": 1850,
+                                                                                                                            "right": 844,
+                                                                                                                            "bottom": 1897
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 192,
+                                                                                                                            "top": 1872,
+                                                                                                                            "right": 1200,
+                                                                                                                            "bottom": 1926
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 192,
+                                                                                                                    "top": 1926,
+                                                                                                                    "right": 1200,
+                                                                                                                    "bottom": 2074
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Deactivation Policy",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 192,
+                                                                                                                            "top": 1953,
+                                                                                                                            "right": 542,
+                                                                                                                            "bottom": 2000
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Eligible if below 4.2",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 192,
+                                                                                                                            "top": 2004,
+                                                                                                                            "right": 510,
+                                                                                                                            "bottom": 2047
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/performance_orders_list/performance_orders_list_scrolled.json
+++ b/app/src/test/resources/snapshots/performance_orders_list/performance_orders_list_scrolled.json
@@ -1,0 +1,1653 @@
+{
+    "captureId": "c8fbac90-088b-40cd-8809-89ecaed31840",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784948632429,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/dasher_workflow_host_fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/dasher_workflow_host_fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 278,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 278,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 278,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 433
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 278,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 431
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 278,
+                                                                                                                                    "right": 972,
+                                                                                                                                    "bottom": 431
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "CAVA",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 305,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 352
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 361,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 404
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Jul 23 · ",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 361,
+                                                                                                                                                    "right": 157,
+                                                                                                                                                    "bottom": 404
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "No issues",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 157,
+                                                                                                                                                    "top": 361,
+                                                                                                                                                    "right": 318,
+                                                                                                                                                    "bottom": 404
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1008,
+                                                                                                                                    "top": 337,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 373
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 379,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 433
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 433,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 588
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 433,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 586
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 433,
+                                                                                                                                    "right": 972,
+                                                                                                                                    "bottom": 586
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Chipotle Mexican Grill",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 460,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 507
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 516,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 559
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Jul 23 · ",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 516,
+                                                                                                                                                    "right": 157,
+                                                                                                                                                    "bottom": 559
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "No issues",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 157,
+                                                                                                                                                    "top": 516,
+                                                                                                                                                    "right": 318,
+                                                                                                                                                    "bottom": 559
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1008,
+                                                                                                                                    "top": 492,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 528
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 534,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 588
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 588,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 743
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 588,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 741
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 588,
+                                                                                                                                    "right": 972,
+                                                                                                                                    "bottom": 741
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Lupe Tortilla",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 615,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 662
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 671,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 714
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Jul 23 · ",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 671,
+                                                                                                                                                    "right": 157,
+                                                                                                                                                    "bottom": 714
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "No issues",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 157,
+                                                                                                                                                    "top": 671,
+                                                                                                                                                    "right": 318,
+                                                                                                                                                    "bottom": 714
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1008,
+                                                                                                                                    "top": 647,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 683
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 689,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 743
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 743,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 898
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 743,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 896
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 743,
+                                                                                                                                    "right": 972,
+                                                                                                                                    "bottom": 896
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Panera Bread",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 770,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 817
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 826,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 869
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Jul 23 · ",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 826,
+                                                                                                                                                    "right": 157,
+                                                                                                                                                    "bottom": 869
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "No issues",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 157,
+                                                                                                                                                    "top": 826,
+                                                                                                                                                    "right": 318,
+                                                                                                                                                    "bottom": 869
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1008,
+                                                                                                                                    "top": 802,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 838
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 844,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 898
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 898,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 1053
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 898,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 1051
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 898,
+                                                                                                                                    "right": 972,
+                                                                                                                                    "bottom": 1051
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "McDonald's",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 925,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 972
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 981,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 1024
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Jul 21 · ",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 981,
+                                                                                                                                                    "right": 151,
+                                                                                                                                                    "bottom": 1024
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "No issues",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 151,
+                                                                                                                                                    "top": 981,
+                                                                                                                                                    "right": 312,
+                                                                                                                                                    "bottom": 1024
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1008,
+                                                                                                                                    "top": 957,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 993
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 999,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1053
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1053,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 1208
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1053,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 1206
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1053,
+                                                                                                                                    "right": 972,
+                                                                                                                                    "bottom": 1206
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Pei Wei",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1080,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 1127
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1136,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 1179
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Jul 17 · ",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1136,
+                                                                                                                                                    "right": 150,
+                                                                                                                                                    "bottom": 1179
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "No issues",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 150,
+                                                                                                                                                    "top": 1136,
+                                                                                                                                                    "right": 311,
+                                                                                                                                                    "bottom": 1179
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1008,
+                                                                                                                                    "top": 1112,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1148
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 1154,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1208
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1208,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 1363
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1208,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 1361
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1208,
+                                                                                                                                    "right": 972,
+                                                                                                                                    "bottom": 1361
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Pei Wei",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1235,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 1282
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1291,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 1334
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Jul 17 · ",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1291,
+                                                                                                                                                    "right": 150,
+                                                                                                                                                    "bottom": 1334
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "No issues",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 150,
+                                                                                                                                                    "top": 1291,
+                                                                                                                                                    "right": 311,
+                                                                                                                                                    "bottom": 1334
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1008,
+                                                                                                                                    "top": 1267,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1303
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 1309,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1363
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1363,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 1518
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1363,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 1516
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1363,
+                                                                                                                                    "right": 972,
+                                                                                                                                    "bottom": 1516
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Parry’s Pizzeria & Taphouse",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1390,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 1437
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1446,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 1489
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Jul 12 · ",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1446,
+                                                                                                                                                    "right": 151,
+                                                                                                                                                    "bottom": 1489
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "No issues",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 151,
+                                                                                                                                                    "top": 1446,
+                                                                                                                                                    "right": 312,
+                                                                                                                                                    "bottom": 1489
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1008,
+                                                                                                                                    "top": 1422,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1458
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 1464,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1518
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1518,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 1673
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1518,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 1671
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1518,
+                                                                                                                                    "right": 972,
+                                                                                                                                    "bottom": 1671
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Sonic Drive-In",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1545,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 1592
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1601,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 1644
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Jul 8 · ",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1601,
+                                                                                                                                                    "right": 139,
+                                                                                                                                                    "bottom": 1644
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "No issues",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 139,
+                                                                                                                                                    "top": 1601,
+                                                                                                                                                    "right": 300,
+                                                                                                                                                    "bottom": 1644
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1008,
+                                                                                                                                    "top": 1577,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1613
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 1619,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1673
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1673,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 1828
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1673,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 1826
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1673,
+                                                                                                                                    "right": 972,
+                                                                                                                                    "bottom": 1826
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Willie's Grill & Icehouse",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1700,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 1747
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1756,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 1799
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Jul 8 · ",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1756,
+                                                                                                                                                    "right": 139,
+                                                                                                                                                    "bottom": 1799
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "No issues",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 139,
+                                                                                                                                                    "top": 1756,
+                                                                                                                                                    "right": 300,
+                                                                                                                                                    "bottom": 1799
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1008,
+                                                                                                                                    "top": 1732,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1768
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 1774,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1828
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1828,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 1983
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1828,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 1981
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1828,
+                                                                                                                                    "right": 972,
+                                                                                                                                    "bottom": 1981
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Mama Margies",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1855,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 1902
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1911,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 1954
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Jul 5 · ",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1911,
+                                                                                                                                                    "right": 138,
+                                                                                                                                                    "bottom": 1954
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "No issues",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 138,
+                                                                                                                                                    "top": 1911,
+                                                                                                                                                    "right": 299,
+                                                                                                                                                    "bottom": 1954
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1008,
+                                                                                                                                    "top": 1887,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1923
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 1929,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1983
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1983,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2138
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1983,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2136
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1983,
+                                                                                                                                    "right": 972,
+                                                                                                                                    "bottom": 2136
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Bill Miller BBQ",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 2010,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 2057
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 2066,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 2109
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Jul 5 · ",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 2066,
+                                                                                                                                                    "right": 138,
+                                                                                                                                                    "bottom": 2109
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "No issues",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 138,
+                                                                                                                                                    "top": 2066,
+                                                                                                                                                    "right": 299,
+                                                                                                                                                    "bottom": 2109
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1008,
+                                                                                                                                    "top": 2042,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 2078
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 2084,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 2138
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 2138,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2293
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 2138,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2291
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 2138,
+                                                                                                                                    "right": 972,
+                                                                                                                                    "bottom": 2291
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "BJ's Restaurant & Brewhouse",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 2165,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 2212
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 2221,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 2264
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Jun 30 · ",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 2221,
+                                                                                                                                                    "right": 173,
+                                                                                                                                                    "bottom": 2264
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "No issues",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 173,
+                                                                                                                                                    "top": 2221,
+                                                                                                                                                    "right": 334,
+                                                                                                                                                    "bottom": 2264
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1008,
+                                                                                                                                    "top": 2197,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 2233
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 2239,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 2293
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 2293,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2347
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 2293,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2347
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 2293,
+                                                                                                                                    "right": 972,
+                                                                                                                                    "bottom": 2347
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Pizza Hut",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 2320,
+                                                                                                                                            "right": 972,
+                                                                                                                                            "bottom": 2347
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 278
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 278
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 9,
+                                                                                                                    "top": 153,
+                                                                                                                    "right": 116,
+                                                                                                                    "bottom": 260
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "desc": "Close",
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 180,
+                                                                                                                            "right": 89,
+                                                                                                                            "bottom": 233
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.Button",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 18,
+                                                                                                                            "top": 162,
+                                                                                                                            "right": 107,
+                                                                                                                            "bottom": 251
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 382,
+                                                                                                                    "top": 154,
+                                                                                                                    "right": 699,
+                                                                                                                    "bottom": 260
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Last 100 orders",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 382,
+                                                                                                                            "top": 181,
+                                                                                                                            "right": 699,
+                                                                                                                            "bottom": 233
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/performance_orders_list/performance_orders_list_scrolled_tail.json
+++ b/app/src/test/resources/snapshots/performance_orders_list/performance_orders_list_scrolled_tail.json
@@ -1,0 +1,367 @@
+{
+    "captureId": "901ac99f-9c51-425e-afac-369358d40812",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784948635644,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/dasher_workflow_host_fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/dasher_workflow_host_fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 278,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 278,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 278,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 341
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 278,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 365
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 225,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 297
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 278,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 375
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 225,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 318
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 278,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 324
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 278,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 345
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 225,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 343
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 278,
+                                                                                                                                    "right": 972,
+                                                                                                                                    "bottom": 343
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 278
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 278
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 9,
+                                                                                                                    "top": 153,
+                                                                                                                    "right": 116,
+                                                                                                                    "bottom": 260
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "desc": "Close",
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 180,
+                                                                                                                            "right": 89,
+                                                                                                                            "bottom": 233
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.Button",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 18,
+                                                                                                                            "top": 162,
+                                                                                                                            "right": 107,
+                                                                                                                            "bottom": 251
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 382,
+                                                                                                                    "top": 154,
+                                                                                                                    "right": 699,
+                                                                                                                    "bottom": 260
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Last 100 orders",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 382,
+                                                                                                                            "top": 181,
+                                                                                                                            "right": 699,
+                                                                                                                            "bottom": 233
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/performance_rate_detail/performance_rate_acceptance.json
+++ b/app/src/test/resources/snapshots/performance_rate_detail/performance_rate_acceptance.json
@@ -1,0 +1,504 @@
+{
+    "captureId": "534321e3-2f61-4398-b103-744aaaec46be",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784948577414,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 8,
+                    "top": 0,
+                    "right": 1088,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 8,
+                            "top": 136,
+                            "right": 1088,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 8,
+                                    "top": 136,
+                                    "right": 1088,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 8,
+                                            "top": 136,
+                                            "right": 1088,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/main_content",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 8,
+                                                    "top": 136,
+                                                    "right": 1088,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 8,
+                                                            "top": 136,
+                                                            "right": 1088,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 8,
+                                                                    "top": 136,
+                                                                    "right": 1088,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Navigate up",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 8,
+                                                                            "top": 144,
+                                                                            "right": 133,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "text": "Acceptance rate",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 141,
+                                                                            "top": 175,
+                                                                            "right": 540,
+                                                                            "bottom": 238
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 1088,
+                                                                            "top": 144,
+                                                                            "right": 1088,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 8,
+                                                            "top": 278,
+                                                            "right": 1088,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 8,
+                                                                    "top": 278,
+                                                                    "right": 1088,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 8,
+                                                                            "top": 278,
+                                                                            "right": 1088,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.widget.ScrollView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 8,
+                                                                                    "top": 278,
+                                                                                    "right": 1088,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "19%",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 482,
+                                                                                            "top": 367,
+                                                                                            "right": 614,
+                                                                                            "bottom": 451
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Very low",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 452,
+                                                                                            "top": 451,
+                                                                                            "right": 645,
+                                                                                            "bottom": 508
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 8,
+                                                                                            "top": 563,
+                                                                                            "right": 1088,
+                                                                                            "bottom": 669
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Last 100 offers",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 44,
+                                                                                            "top": 689,
+                                                                                            "right": 375,
+                                                                                            "bottom": 746
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 44,
+                                                                                            "top": 768,
+                                                                                            "right": 1052,
+                                                                                            "bottom": 874
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Accepted",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 44,
+                                                                                                    "top": 782,
+                                                                                                    "right": 227,
+                                                                                                    "bottom": 829
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "19",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 966,
+                                                                                                    "top": 782,
+                                                                                                    "right": 1007,
+                                                                                                    "bottom": 829
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "state": "19 percent.",
+                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 44,
+                                                                                                    "top": 847,
+                                                                                                    "right": 1052,
+                                                                                                    "bottom": 860
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 44,
+                                                                                            "top": 882,
+                                                                                            "right": 1052,
+                                                                                            "bottom": 988
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Declined",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 44,
+                                                                                                    "top": 896,
+                                                                                                    "right": 213,
+                                                                                                    "bottom": 943
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "81",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 965,
+                                                                                                    "top": 896,
+                                                                                                    "right": 1007,
+                                                                                                    "bottom": 943
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "state": "81 percent.",
+                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 44,
+                                                                                                    "top": 961,
+                                                                                                    "right": 1052,
+                                                                                                    "bottom": 974
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 44,
+                                                                                            "top": 983,
+                                                                                            "right": 391,
+                                                                                            "bottom": 1090
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "0 offers excluded",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 44,
+                                                                                                    "top": 1015,
+                                                                                                    "right": 329,
+                                                                                                    "bottom": 1058
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 44,
+                                                                                            "top": 1117,
+                                                                                            "right": 361,
+                                                                                            "bottom": 1206
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.widget.Button",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 44,
+                                                                                                    "top": 1117,
+                                                                                                    "right": 361,
+                                                                                                    "bottom": 1206
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "View all offers",
+                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 71,
+                                                                                                            "top": 1132,
+                                                                                                            "right": 334,
+                                                                                                            "bottom": 1192
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "About acceptance rate",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 44,
+                                                                                            "top": 1278,
+                                                                                            "right": 551,
+                                                                                            "bottom": 1335
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 44,
+                                                                                            "top": 1371,
+                                                                                            "right": 1052,
+                                                                                            "bottom": 1583
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "The number of offers you accept and decline determines your acceptance rate. Your rating is calculated based on your past 100 offers and updates as you receive new offers.",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 44,
+                                                                                                    "top": 1371,
+                                                                                                    "right": 1052,
+                                                                                                    "bottom": 1583
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 80,
+                                                                                            "top": 1655,
+                                                                                            "right": 1016,
+                                                                                            "bottom": 2135
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Example Acceptance Rate",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 80,
+                                                                                                    "top": 1655,
+                                                                                                    "right": 927,
+                                                                                                    "bottom": 1698
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "No longer in calculation",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 72,
+                                                                                                    "top": 2038,
+                                                                                                    "right": 469,
+                                                                                                    "bottom": 2081
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Tips to increase your rating",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 44,
+                                                                                            "top": 2243,
+                                                                                            "right": 646,
+                                                                                            "bottom": 2300
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 9,
+                                                                                            "top": 2310,
+                                                                                            "right": 115,
+                                                                                            "bottom": 2347
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Raise your app/ringer volume to avoid missing incoming offers",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 98,
+                                                                                            "top": 2345,
+                                                                                            "right": 1052,
+                                                                                            "bottom": 2347
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/performance_rate_detail/performance_rate_acceptance_loading.json
+++ b/app/src/test/resources/snapshots/performance_rate_detail/performance_rate_acceptance_loading.json
@@ -1,0 +1,514 @@
+{
+    "captureId": "c4963cff-bcf0-4fca-adce-0dd71991b8c6",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784948583477,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/main_content",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Navigate up",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 144,
+                                                                            "right": 125,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "text": "Acceptance rate",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 133,
+                                                                            "top": 175,
+                                                                            "right": 532,
+                                                                            "bottom": 238
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 1080,
+                                                                            "top": 144,
+                                                                            "right": 1080,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 278,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 278,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 278,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.widget.ScrollView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 278,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Last 100 offers",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 294,
+                                                                                            "right": 367,
+                                                                                            "bottom": 351
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 373,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 479
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Accepted",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 387,
+                                                                                                    "right": 219,
+                                                                                                    "bottom": 434
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "19",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 958,
+                                                                                                    "top": 387,
+                                                                                                    "right": 999,
+                                                                                                    "bottom": 434
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "state": "19 percent.",
+                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 452,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 465
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 487,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 593
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Declined",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 501,
+                                                                                                    "right": 205,
+                                                                                                    "bottom": 548
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "81",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 957,
+                                                                                                    "top": 501,
+                                                                                                    "right": 999,
+                                                                                                    "bottom": 548
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "state": "81 percent.",
+                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 566,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 579
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 588,
+                                                                                            "right": 383,
+                                                                                            "bottom": 695
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "0 offers excluded",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 620,
+                                                                                                    "right": 321,
+                                                                                                    "bottom": 663
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 722,
+                                                                                            "right": 353,
+                                                                                            "bottom": 811
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.widget.Button",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 722,
+                                                                                                    "right": 353,
+                                                                                                    "bottom": 811
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "View all offers",
+                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 63,
+                                                                                                            "top": 737,
+                                                                                                            "right": 326,
+                                                                                                            "bottom": 797
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "About acceptance rate",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 883,
+                                                                                            "right": 543,
+                                                                                            "bottom": 940
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 976,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 1188
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "The number of offers you accept and decline determines your acceptance rate. Your rating is calculated based on your past 100 offers and updates as you receive new offers.",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 976,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 1188
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 72,
+                                                                                            "top": 1260,
+                                                                                            "right": 1008,
+                                                                                            "bottom": 1740
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Example Acceptance Rate",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 72,
+                                                                                                    "top": 1260,
+                                                                                                    "right": 919,
+                                                                                                    "bottom": 1303
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "No longer in calculation",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 72,
+                                                                                                    "top": 1643,
+                                                                                                    "right": 469,
+                                                                                                    "bottom": 1686
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Tips to increase your rating",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 1848,
+                                                                                            "right": 638,
+                                                                                            "bottom": 1905
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 1,
+                                                                                            "top": 1915,
+                                                                                            "right": 107,
+                                                                                            "bottom": 2021
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Raise your app/ringer volume to avoid missing incoming offers",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 90,
+                                                                                            "top": 1950,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2053
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 1,
+                                                                                            "top": 2054,
+                                                                                            "right": 107,
+                                                                                            "bottom": 2160
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Pause your dash if you need to take a break",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 90,
+                                                                                            "top": 2089,
+                                                                                            "right": 867,
+                                                                                            "bottom": 2136
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 1,
+                                                                                            "top": 2137,
+                                                                                            "right": 107,
+                                                                                            "bottom": 2243
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Respond to offers when they arrive, since timeouts also count toward your rating",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 90,
+                                                                                            "top": 2172,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2275
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/matchers/rules/doordash/ratings-feedback.json5
+++ b/matchers/rules/doordash/ratings-feedback.json5
@@ -233,26 +233,44 @@
       }
     },
     {
-      "comment": "#796 — a performance-metric DETAIL screen (Completion rate / On-time rate / Quality rate): a metric header + score, a 'Last 100 orders' breakdown, a 'View all orders' button, and an 'About <metric> rate' explainer. RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse — the app already ships doordash.screen.ratings (the combined ratings hub); these are the single-metric drill-downs, which that rule's four-way 'ratings'+'acceptance rate'+'completion rate'+'overall' conjunct legitimately does NOT match. Anchored on 'Last 100 orders' + 'View all orders' together (both corpus-unique, 0 other snapshots); the sibling list modal shares 'Last 100 orders' but has NO 'View all orders' button, so the two never collide. PRIVACY: no customer PII — merchant/store names + dates only, both driver-owned and kept.",
+      "comment": "#796/#865 — a performance-metric DETAIL screen (Completion rate / On-time rate / Quality rate / Acceptance rate): a metric header + score, a 'Last 100 <unit>' breakdown, a 'View all <unit>' button, and an 'About <metric> rate' explainer. RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse — the app already ships doordash.screen.ratings (the combined ratings hub); these are the single-metric drill-downs, which that rule's four-way 'ratings'+'acceptance rate'+'completion rate'+'overall' conjunct legitimately does NOT match. #865 BROADENED the anchor to the two UNIT variants of the SAME screen family: the order-denominated metrics render 'Last 100 orders' + 'View all orders', the offer-denominated Acceptance rate renders 'Last 100 offers' + 'View all offers' (the only textual difference — the layout, the 'About …' explainer and the tips section are identical), so it stays ONE intent rather than a near-duplicate sibling rule. All four anchor strings are corpus-unique (0 other snapshots); each variant requires its OWN header+button PAIR, so the sibling list modal (which shares the header but has NO 'View all …' button) still never collides. PRIVACY: no customer PII — the dasher's own aggregate counters + fixed program copy.",
       "id": "doordash.screen.performance_rate_detail",
       "priority": 116,
       "require": {
-        "all": [
+        "any": [
           {
-            "exists": {
-              "hasTextContaining": "Last 100 orders"
-            }
+            "all": [
+              {
+                "exists": {
+                  "hasTextContaining": "Last 100 orders"
+                }
+              },
+              {
+                "exists": {
+                  "hasTextContaining": "View all orders"
+                }
+              }
+            ]
           },
           {
-            "exists": {
-              "hasTextContaining": "View all orders"
-            }
+            "all": [
+              {
+                "exists": {
+                  "hasTextContaining": "Last 100 offers"
+                }
+              },
+              {
+                "exists": {
+                  "hasTextContaining": "View all offers"
+                }
+              }
+            ]
           }
         ]
       }
     },
     {
-      "comment": "#796 — the 'Last 100 orders' LIST modal reached from a metric detail's 'View all orders' (a tab row All / Completed / Unassigned / Excluded over a store+date order list, with a Close affordance). RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse. Anchored on 'Last 100 orders' + the exact-text tabs 'All' and 'Excluded' (both corpus-unique). The metric-detail screen also renders 'Last 100 orders' but has no exact 'All'/'Excluded' tab nodes (its 'excluded' appears only fused as '0 orders excluded'), so the exact-text tab conjunct keeps the two apart; hasText (exact) not hasTextContaining is load-bearing here. PRIVACY: no customer PII — merchant/store names + dates only, driver-owned and kept.",
+      "comment": "#796/#865 — the 'Last 100 orders' LIST modal reached from a metric detail's 'View all orders' (a tab row All / Completed / Unassigned / Excluded over a store+date order list, with a Close affordance). RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse. #865 RE-ANCHORED off the tab row: the All/Completed/Unassigned/Excluded chips scroll out of the accessibility tree as soon as the driver scrolls the list, so every scrolled frame fell out of recognition (6 fielded UNKNOWNs). The scroll-stable pair is the pinned modal chrome — the 'Last 100 orders' header + the exact-desc 'Close' affordance — which survives to the extreme scrolled frame that renders NOTHING else (capture …UNKNOWN__4f4914). The metric-detail sibling also renders 'Last 100 orders' but has no 'Close' (it is a pushed screen with a 'Navigate up' toolbar, not a modal), so the two stay apart; and even a hypothetical detail-in-a-modal would be claimed first by performance_rate_detail's lower priority number. PRIVACY: no customer PII — merchant/store names + dates + 'No issues' status only, all driver-owned and kept.",
       "id": "doordash.screen.performance_orders_list",
       "priority": 117,
       "require": {
@@ -264,12 +282,7 @@
           },
           {
             "exists": {
-              "hasText": "All"
-            }
-          },
-          {
-            "exists": {
-              "hasText": "Excluded"
+              "hasDesc": "Close"
             }
           }
         ]
@@ -283,6 +296,25 @@
         "exists": {
           "hasIdSuffix": "reward_info_epoxy_recyclerview"
         }
+      }
+    },
+    {
+      "comment": "#865 — the Customer rating DETAIL drill-down from the ratings hub: the hero star score + the 5→1 star histogram, an 'N ratings excluded' unfair-ratings row, a 'Customer Feedback' category grid (Communication / Order Handling / Followed Delivery Instructions / Friendliness), a 'Customer Compliments' block ('Above and Beyond' count + 'Quotes from customers'), and a 'Learn more' section. RECOGNIZE-ONLY: no state.flow, no parse — same posture as the sibling performance_rate_detail / dasher_rewards drill-downs (the aggregate customerRating is already parsed off doordash.screen.ratings, the combined hub, which this screen is reached FROM and which its four-way 'ratings'+'acceptance rate'+'completion rate'+'overall' conjunct does not match). Anchored on the structural viewId pair `star_rating_container` + `progress_bar_five` — the hero score container and the 5-star histogram row. Both are corpus-unique (0 other snapshots, incl. all 15 ratings/ hub frames) and both are unconditional CHROME of this screen, present even on the still-loading frame whose score/count TextViews are still empty (capture …UNKNOWN__ce3033) — deliberately used INSTEAD of the 'Customer Compliments' / 'Above and Beyond' copy, which is data-conditional. PRIVACY: no customer PII in either fielded frame — the dasher's own aggregate rating counters, fixed category labels and fixed program copy. DOCUMENTED RESIDUAL: `quotes_recycler` is EMPTY in both fielded frames (the second renders the empty-state 'Customer quotes from 5-star reviews will appear here.'), but a dasher WITH compliments would render customer-authored free-text quotes there. DoorDash renders those quotes unattributed (no name, no address), so they are not the customer-identity PII the hash-at-edge chain covers; they are also not scoped-addressable by a `redact` predicate today (the quote TextViews carry no viewId and nodePredicate has no parent/descendant scoping), so no redact is declared. If a non-empty quotes frame is ever fielded, revisit — either a scoping predicate or a marker-backstop entry.",
+      "id": "doordash.screen.customer_rating_detail",
+      "priority": 126,
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "star_rating_container"
+            }
+          },
+          {
+            "exists": {
+              "hasIdSuffix": "progress_bar_five"
+            }
+          }
+        ]
       }
     }
   ]


### PR DESCRIPTION
Closes #865.

Three DoorDash performance/ratings-hub surfaces that were still UNKNOWN on `ddd9e7ff` after the #837 batch — 14 fielded frames in the 2026-07-25 pull. All three are driver-own-performance surfaces: **recognize-only**, no `state` block, no `parse`, no `bind`, exactly matching the posture of the sibling `performance_rate_detail` / `performance_orders_list` / `dasher_rewards` rules they join (those rules declare no `state` at all, so neither do these).

Only `matchers/rules/doordash/ratings-feedback.json5` + snapshots + the parse golden are touched.

## Per-surface anchor rationale

### 1. Acceptance-rate detail (6 frames) — broadened `performance_rate_detail`

The acceptance drill-down is structurally the **same screen** as the completion / on-time / quality drill-downs the rule already covers: same metric header + score, same `Last 100 …` breakdown, same `View all …` button, same `About <metric> rate` explainer, same tips section. The only textual difference is the **denominator unit** — `Last 100 offers` / `View all offers` instead of `…orders`.

So rather than a near-duplicate sibling rule, the `require` became an `any` over the two header+button **pairs**:

```
any: [ all[ exists "Last 100 orders", exists "View all orders" ],
       all[ exists "Last 100 offers", exists "View all offers" ] ]
```

- All four anchor strings are **corpus-unique** — `Last 100 offers` and `View all offers` appear in 0 prior snapshots; `Last 100 orders` in 3 (the 2 rate-detail + 1 orders-list frames), `View all orders` in 2 (rate-detail only).
- The pair requirement is load-bearing and preserved: the sibling **list modal** shares the header but has no `View all …` button, so it still cannot collide.
- One intent, not two — this is a metric drill-down whichever metric it is, and nothing downstream branches on it.

### 2. Last-100-orders list, scrolled (6 frames) — re-anchored `performance_orders_list`

The old anchor was `Last 100 orders` + the exact-text tabs `All` and `Excluded`. Those chips **leave the accessibility tree the moment the driver scrolls**, so only the very first frame recognized and every scrolled frame fell out.

New anchor is the **pinned modal chrome** — `Last 100 orders` (header) + `hasDesc: "Close"` (exact contentDescription):

- Verified scroll-stable: capture `…UNKNOWN__4f4914` is a scrolled frame that renders **nothing else at all** — its entire text/desc content is exactly those two nodes. Anything narrower than this pair does not exist on that frame.
- Separation from the metric-detail sibling holds: the detail is a *pushed screen* with a `Navigate up` toolbar and has **no** `Close` (confirmed on both corpus rate-detail frames and all 6 fielded acceptance frames).
- Belt-and-braces: even a hypothetical detail-rendered-in-a-modal would be claimed first by `performance_rate_detail`'s lower priority number (116 < 117).
- The existing committed `performance_orders_list.json` fixture already carries `desc=Close`, so the old representative keeps recognizing.

### 3. Customer-rating detail (2 frames) — new `doordash.screen.customer_rating_detail` (priority 126)

The ratings-hub drill-down: hero star score + 5→1 star histogram, an `N ratings excluded` unfair-ratings row, a `Customer Feedback` category grid, a `Customer Compliments` block, a `Learn more` section.

Anchored on the **structural viewId pair** `star_rating_container` + `progress_bar_five`:

- Both are **corpus-unique** (0 of the 558 prior golden entries, including all 15 `ratings/` hub frames).
- Both are **unconditional chrome** — present even on the still-loading frame (`…UNKNOWN__ce3033`) whose score/count TextViews are still empty. Deliberately chosen over the `Customer Compliments` / `Above and Beyond` copy, which is data-conditional (a dasher with no compliments may not render it).
- Priority 126 was a free slot (111–125 and 130+ were taken); no priority collision in the section.
- The existing `doordash.screen.ratings` hub rule does **not** match this screen (its four-way `ratings`+`acceptance rate`+`completion rate`+`overall` conjunct fails), and the new rule does not steal any `ratings/` frame — verified by the corpus-uniqueness scan above and by the golden diff showing 0 CHANGED entries.

### Coverage verification

A predicate simulation of the three new `require` blocks was run over **all 117** UNKNOWN captures in the pull: the 6 acceptance frames match `performance_rate_detail` only, the 6 scrolled-list frames match `performance_orders_list` only, the 2 rating frames match `customer_rating_detail` only. **Zero cross-matches, zero frames matching two rules, zero other UNKNOWNs swept in.**

## PII check — per surface

The issue said "no customer PII observed"; this was **independently verified**, not taken on trust. A manual sweep (the CLAUDE.local.md recipe: two-capitalized-words, the `Firstname I.` shape, `Deliver to `/`Pickup for `/`For <Name>`/`Message from `, `pin \d{3,}` + gate/access codes, street addresses, phone numbers, apt/unit, `Customer Notes:`) was run against **all 14 fielded frames** and again against the **6 committed fixtures** post-`SnapshotRedactor`. Envelope `metadata` blocks were inspected too (engine/pipeline versions + device fingerprint only).

| Surface | Result |
|---|---|
| Acceptance-rate detail | **Clean.** Only the dasher's own aggregate counters (`19%`, `Accepted 19`, `Declined 81`, `0 offers excluded`) and fixed DoorDash explainer/tips copy. Sole pattern hit is the literal UI string `Example Acceptance Rate`. |
| Scrolled orders list | **Clean.** Merchant names + dates + `No issues` only — all driver-owned and kept by policy (the two-cap-words hits are `Chipotle Mexican Grill`, `Panera Bread`, `Bill Miller BBQ`, …). No customer names, no addresses. |
| Customer-rating detail | **Clean.** The dasher's own rating counters, fixed category labels (`Communication`, `Order Handling`, `Followed Delivery Instructions`, `Friendliness`) and fixed program copy (`How we calculate Customer Ratings`, `Deactivation Policy`). |

**No `redact` block is declared on any of the three rules**, because no frame carries redactable customer text.

**Documented residual (recorded in the rule comment, not hidden):** the customer-rating detail's `quotes_recycler` is **empty in both fielded frames** — the second even renders the empty state, `"Customer quotes from 5-star reviews will appear here."`. A dasher *with* compliments would render customer-authored free-text quotes there. Those quotes are rendered **unattributed** by DoorDash (no name, no address), so they are not the customer-identity PII the hash-at-edge chain exists to cover; and they are **not scoped-addressable** by a `redact` predicate today — the quote TextViews carry no viewId, and `nodePredicate` has no parent/descendant scoping, so the only expressible entry would be an over-broad one. The rule comment records this explicitly with the revisit condition (if a non-empty quotes frame is ever fielded, either add a scoping predicate or a marker-backstop entry).

## Golden diff summary

`approved-parse-output.json`: **558 → 564 entries — 6 NEW, 0 CHANGED, 0 GONE.**

```
NEW  customer_rating_detail/customer_rating_detail.json               → doordash.screen.customer_rating_detail,  shape=null, fields={}
NEW  customer_rating_detail/customer_rating_detail_loading.json       → doordash.screen.customer_rating_detail,  shape=null, fields={}
NEW  performance_orders_list/performance_orders_list_scrolled.json    → doordash.screen.performance_orders_list, shape=null, fields={}
NEW  performance_orders_list/performance_orders_list_scrolled_tail.json → doordash.screen.performance_orders_list, shape=null, fields={}
NEW  performance_rate_detail/performance_rate_acceptance.json         → doordash.screen.performance_rate_detail,  shape=null, fields={}
NEW  performance_rate_detail/performance_rate_acceptance_loading.json → doordash.screen.performance_rate_detail,  shape=null, fields={}
```

Every new entry carries `shape: null` / `fields: {}` — the machine-checkable confirmation that all three rules are genuinely recognize-only. **Zero CHANGED keys** is the load-bearing signal that the two broadenings did not re-classify or re-parse a single existing corpus frame.

Corpus additions are capped-additions-only: 2 fixtures per surface (a loaded shape and a loading/scrolled shape), **no existing representative evicted** — each folder ends at 4 / 3 / 2 files, far under the librarian's 15-variant retention limit, and the sort ran with no `CLEANUP` prune.

## Tests

- `./gradlew :app:testDebugUnitTest --tests "*InboxProcessorTest*"` — all 6 fixtures IDENTIFIED and sorted into folders whose names equal their intents; INBOX drained; no prune.
- `./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` — **784 tests, green.**
- `./gradlew testDebugUnitTest :domain:test` — full unit suite across all modules, **green**.

### Design-goal review

- **P8 (platform-agnostic core, mandatory — this diff is rule JSON).** No Kotlin touched: `:core:state`, `:core:pipeline` and `:domain` are untouched, and recognition stays data. Every anchor is **platform chrome** — DoorDash's own fixed program copy (`Last 100 offers`, `View all offers`, `Close`) and its own layout viewIds (`star_rating_container`, `progress_bar_five`). No merchant name, no store name, no customer string, no dasher-identity string is used as a match key (the *feedback-no-store-specific-rules* doctrine); merchant names appear in the fixtures only as parsed-through data. No new rule↔state vocabulary is introduced — no `state`, no `flow`, no `mode`, no effect intent — so nothing needed to go through `StateMachineContract`, and the new intent is inert to the state machine by construction. Both platform files remain independent: `uber.json5` is untouched.
- **P6 (security & privacy first) — posture statement.** *Trusted:* nothing new; the accessibility tree remains untrusted input and all three rules are pure boolean predicates over it with no new ingestion surface, no regex, and no unbounded traversal. *Gated:* nothing new is gated because nothing new fires — all three rules are recognize-only (no `state`, no `parse`, no `bind`, no target bindings), so they cannot reach the effect engine, cannot request actuation (#425 unchanged), and cannot enumerate a capability. The block side is strictly untouched: no `sensitive.*` rule is modified and no anchor overlaps a sensitive surface, so the fail-closed gate (#432) and its load-time checks are unaffected. *Scrubbed:* these 14 frames previously reached disk as **UNKNOWN** envelopes, protected only by the debug-only `NoOpCaptureBus` + the marker backstops; recognizing them is a net privacy **improvement**, since the frames now pass through the recognized-capture path where a rule-declared `redact` would apply. None is needed — verified frame-by-frame above, zero customer PII, only the documented empty-`quotes_recycler` residual. No `sha256` transform is used, so the compile-time "hash implies non-empty redact" invariant is not engaged. No logging site added, so P7 is untouched.
- **P5 (SSOT).** The acceptance-rate variant was folded into the existing `performance_rate_detail` rule as a second unit-pair rather than copied into a near-identical sibling rule — one definition of "this is a metric drill-down", no parallel copy to drift. Likewise the orders-list anchor was *replaced*, not duplicated alongside the chips.
- **P3 (single responsibility).** One rule per surface family; each `require` is a small, readable predicate; every rule carries a `comment` recording the anchor choice, the rejected alternatives, and the privacy posture, matching the #796/#837 house style.

*(Reactive UI rules, P1/P2/P4: not touched — no Kotlin, no UI, no state.)*

### Adversarial review

Pending — to be run before merge per the #589 loop (`/code-review` + `/security-review` at fable tier). **Do not merge** until that block is filled in.
