### PR TITLE
fix(effects): #859 dedupe offer screenshots on the presentation, and never save a literal {token} filename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,7 +319,13 @@ wins over it. Rules also carry `require` predicates, `bind` blocks, `parse`
 blocks that produce typed fields via `ParsedFieldsFactory`, and an optional `redact` block
 (#598) — node predicates whose matched text is masked in the capture envelope (a screen rule
 that hashes PII via the `sha256` transform MUST declare a non-empty `redact`, enforced at compile;
-the mask keeps a `keepPrefix` marker so recognition on replay is unchanged). There are no Kotlin matcher classes —
+the mask keeps a `keepPrefix` marker so recognition on replay is unchanged). An effect's `dedupeKey`
+interpolates `{field}` against the branch's RAW parse plus two DERIVED reserved tokens resolved
+post-factory by the classifier (`DedupeTokens`, the lint's SSOT): `{parsedHash}` = the parse's
+CONTENT identity (#427) and `{presentationHash}` = its PRESENTATION identity (#859,
+`ParsedFields.presentationHash` — for an offer, #830's `presentationKey`, fail-closed to
+`offerHash`), so a surface that live-re-quotes itself fires its effects once per showing rather
+than once per quote. There are no Kotlin matcher classes —
 changing recognition means editing rule JSON plus corpus tests. **Rules cannot declare actuation**
 (#425): the compiler rejects `click`/gesture effect verbs; rules instead expose well-known *target
 bindings* (`acceptButton`, `declineButton`, `expandButton`) that the app-owned `RuleAction`
@@ -347,6 +353,19 @@ enumeration, every capability lands *undecided* until the user opts in via the c
 Handlers: `OdometerEffectHandler`, `ScreenShotHandler`, `TipEffectHandler`, `TtsEffectHandler`,
 `UiInteractionHandler` (package-scoped, label-verified `RuleAction` taps — the only path that ever
 clicks a third-party app, #425), `OfferActionReceiver` (notification Accept/Decline actions).
+**Dedupe granularity is the rule's to declare (#859).** The durable `effects_fired` row is
+"at most once per 48h"; a rule effect that declares its own `throttleMs` opts OUT of it and
+into that declared window (the engine's wall-clock throttle, keyed by the same `effectKey`) —
+one declared value, one gate. Without that, the strictly-stronger row silently subsumed the
+declaration, making a *stable* dedupe key destructive (`offer-ss-{presentationHash}` would
+capture one offer per store per 48h — 161 Uber offers across 92 merchants in the 07-25 pull).
+Residual: the throttle map is in-memory, so a process restart re-arms it (at most one extra
+capture). App-emitted keyed effects (bubbles, sessions, `EffectMap` captures) declare nothing
+and keep the 48h idempotency unchanged. Evidence **filenames** are sanitized at the one
+evidence gate (`EvidenceFilename.sanitizePrefix`): a rule's `"Offer - {storeName}"` whose
+field parsed null saves as `Offer`, never the literal token (331 `Offer - {storeName}.png`
+files on the device were the receipt) — a fail-safe under, not a replacement for, the
+`ParseOutputGoldenTest` arg-template lint that still flags the un-interpolating rule.
 
 ### 5. Analytics Read-Model (`core/data/.../analytics/`, `core/database/.../analytics/`, #314)
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/EvidenceFilename.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/EvidenceFilename.kt
@@ -1,0 +1,43 @@
+package cloud.trotter.dashbuddy.state.effects
+
+/**
+ * Filename policy for evidence captures (#859).
+ *
+ * A rule declares its screenshot name as a template (`"Offer - {storeName}"`), interpolated
+ * against the branch's parse fields. A field that parsed null does NOT interpolate — by
+ * design, so the ruleset lint can see which template failed on which corpus frame — and the
+ * un-interpolated token used to reach the gallery verbatim: **331 files named
+ * `Offer - {storeName}.png`** accumulated on the dev's device.
+ *
+ * A filename is a leaf output, so the honest degrade is to drop what could not be resolved
+ * and keep what could: `"Offer - {storeName}"` → `"Offer"`. Generic over every rule and
+ * platform — this sanitizes any template shape, and knows nothing about offers, stores, or
+ * which ruleset authored the prefix.
+ *
+ * This is a fail-safe, not the primary control: the primary control stays the
+ * `ParseOutputGoldenTest` arg-template lint, which still sees the literal token and still
+ * fails when a rule introduces a new never-interpolating template.
+ */
+object EvidenceFilename {
+
+    /** Used when nothing survives sanitization — matches the engine's untemplated default. */
+    const val FALLBACK_PREFIX = "Rule"
+
+    /** `{field}` — the exact shape [cloud.trotter.dashbuddy.core.pipeline.rules.Ruleset] leaves behind. */
+    private val UNRESOLVED_TOKEN = Regex("""\{\w*}""")
+
+    /** Separator punctuation left dangling once a token is dropped (`"Offer - "` → `"Offer"`). */
+    private const val DANGLING = " \t-–—:,;|/_"
+
+    /**
+     * Sanitize a rule-declared filename prefix: no literal `{token}` ever reaches a saved
+     * file, and no dangling separator is left where one was dropped.
+     */
+    fun sanitizePrefix(raw: String?): String {
+        val stripped = (raw ?: "")
+            .replace(UNRESOLVED_TOKEN, "")
+            .replace(Regex("\\s+"), " ")
+            .trim { it in DANGLING }
+        return stripped.ifBlank { FALLBACK_PREFIX }
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -181,7 +181,19 @@ class SideEffectEngine @Inject constructor(
         // effects on re-observation because the check was recovery-only. The
         // table is pruned at 48h, so a key is "already fired" only within that
         // window (matching the snapshot horizon recovery replays over).
-        val key = effect.effectKey
+        //
+        // …EXCEPT for a rule effect that declares its own repeat cadence (#859): a
+        // `throttleMs` in the ruleset says "at most once per N ms", and the durable row is
+        // strictly stronger ("at most once per 48h"), so it silently subsumed the
+        // declaration — making `throttleMs` unreachable as a gate and any *stable* dedupe
+        // key destructive (`offer-ss-{presentationHash}` would capture one offer per store
+        // per 48h; the 2026-07-25 pull had 161 Uber offers across 92 merchants, so ~43% of
+        // the evidence would silently vanish). A declared cadence therefore opts the effect
+        // out of the durable row entirely and into its own window, enforced by the
+        // wall-clock throttle in [AppEffect.RequestEffect]'s branch below — ONE declared
+        // value, one gate. Residual: the throttle map is in-memory, so a process restart
+        // re-arms it and the surface on screen can be re-captured once.
+        val key = effect.effectKey?.takeUnless { effect.declaresOwnCadence() }
         if (key != null && effectsFiredDao.hasBeenFired(key)) {
             Timber.tag("Effects").d("Skipping already-fired effect: %s", key)
             return
@@ -543,7 +555,16 @@ class SideEffectEngine @Inject constructor(
             Timber.tag("Effects").d("Suppressed capture prefix: %s", effect.filenamePrefix)
             return false
         }
-        screenShotHandler.capture(engineScope, effect)
+        // #859: the gate is also where the filename is made honest. A rule-declared prefix is
+        // a template ("Offer - {storeName}") and a field that parsed null does not
+        // interpolate, so the raw token used to reach the gallery verbatim (331 files named
+        // `Offer - {storeName}.png` on the device). Sanitizing HERE — the one choke point
+        // every capture passes, rule-declared or EffectMap-emitted — keeps it to one policy
+        // for one property, with no per-rule knowledge.
+        screenShotHandler.capture(
+            engineScope,
+            effect.copy(filenamePrefix = EvidenceFilename.sanitizePrefix(effect.filenamePrefix)),
+        )
         return true
     }
 
@@ -674,6 +695,18 @@ class SideEffectEngine @Inject constructor(
         // Keyed by (type, platform) to mirror the rule-driven schedule (#438 item 1).
         activeTimers[TimerKey(type, platform)]?.cancel()
     }
+
+    /**
+     * True when the effect carries a ruleset-declared repeat cadence (#859).
+     *
+     * Only a rule-originated [AppEffect.RequestEffect] can: `throttleMs` is ruleset data, and
+     * declaring it is the rule author saying "this may fire again after N ms". App-emitted
+     * effects (bubbles, sessions, captures from [EffectMap]) declare nothing and keep the
+     * durable 48h idempotency unchanged. Generic over every verb and platform — the engine
+     * reads the declaration, it never asks which rule or which platform wrote it.
+     */
+    private fun AppEffect.declaresOwnCadence(): Boolean =
+        this is AppEffect.RequestEffect && effect.throttleMs != null
 
     private fun isExternalEffect(effect: AppEffect): Boolean = when (effect) {
         is AppEffect.UpdateBubble,

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
@@ -480,6 +480,51 @@ class DefaultRulesIntegrationTest {
         assertEquals("re-observation must dedupe against the same key", first, resolveOnce())
     }
 
+    @Test
+    fun `the uber offer card resolves a PRESENTATION-scoped screenshot key (#859)`() {
+        // #859 moved uber's offer screenshot from `offer-ss-{parsedHash}` (content identity —
+        // it churns on every live re-quote, so ONE offer fired up to 6 captures) to
+        // `offer-ss-{presentationHash}`. That only helps if the fielded card actually yields
+        // a presentation identity: a null #830 presentationKey fails closed BACK to the
+        // churning offerHash, which would restore the bug silently. Pin both halves.
+        val snapshots = TestResourceLoader.loadSnapshots("snapshots/offer")
+        assertTrue("uber offer corpus must not be empty", snapshots.isNotEmpty())
+
+        val keysByFile = snapshots.mapNotNull { (fn, tree, _) ->
+            val result = screenRuleset.matchFirst(tree, platformWire = "uber")
+                ?: return@mapNotNull null
+            val parsed = ParsedFieldsFactory.create(result.shape, result.fields)
+            val offer = (parsed as? cloud.trotter.dashbuddy.domain.state.ParsedFields.OfferFields)
+                ?: return@mapNotNull null
+            assertNotNull(
+                "$fn: the offer card must yield a #830 presentationKey — without one the " +
+                    "dedupe key degrades to the re-quote-churning offerHash",
+                offer.parsedOffer.presentationKey,
+            )
+            val key = DedupeTokens.resolve(result.effects, parsed)
+                .firstNotNullOfOrNull { e -> e.dedupeKey?.takeIf { it.startsWith("offer-ss-") } }
+                ?: return@mapNotNull null
+            assertEquals(
+                "$fn: the screenshot key must BE the presentation identity",
+                "offer-ss-${offer.presentationHash()}",
+                key,
+            )
+            fn to key
+        }
+
+        assertTrue("expected uber offer screenshots with dedupe keys", keysByFile.size >= 2)
+        assertTrue(
+            "no unresolved template tokens may survive resolution: $keysByFile",
+            keysByFile.none { (_, k) -> k.contains('{') },
+        )
+        assertEquals(
+            "the corpus holds distinct presentations (different stores), so they must NOT " +
+                "collapse onto one key: $keysByFile",
+            keysByFile.size,
+            keysByFile.map { it.second }.toSet().size,
+        )
+    }
+
     // =========================================================================
     // Helpers
     // =========================================================================

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/EvidenceFilenameTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/EvidenceFilenameTest.kt
@@ -1,0 +1,65 @@
+package cloud.trotter.dashbuddy.state.effects
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * #859 — a rule-declared filename template whose field parsed null must never reach the
+ * gallery as a literal `{token}` (331 `Offer - {storeName}.png` files on the dev's device).
+ */
+class EvidenceFilenameTest {
+
+    @Test
+    fun `an unresolvable field degrades to the resolvable half - never a literal brace`() {
+        val out = EvidenceFilename.sanitizePrefix("Offer - {storeName}")
+        assertEquals("Offer", out)
+        assertFalse("no literal template may survive into a filename", out.contains('{'))
+        assertFalse(out.contains('}'))
+    }
+
+    @Test
+    fun `a fully resolved prefix is passed through untouched`() {
+        assertEquals("Offer - 12.50", EvidenceFilename.sanitizePrefix("Offer - 12.50"))
+        assertEquals(
+            "DashSummary - 87.50",
+            EvidenceFilename.sanitizePrefix("DashSummary - 87.50"),
+        )
+    }
+
+    @Test
+    fun `every rule-declared prefix shape survives sanitization brace-free`() {
+        // The shapes shipped today (both platforms), each with its field unresolved.
+        val shipped = listOf(
+            "Offer - {storeName}" to "Offer",
+            "Offer - {payAmount}" to "Offer",
+            "Delivery - {totalPay}" to "Delivery",
+            "DeliveryBreakdown - {totalPay}" to "DeliveryBreakdown",
+            "DashSummary - {totalEarnings}" to "DashSummary",
+        )
+        for ((template, expected) in shipped) {
+            val out = EvidenceFilename.sanitizePrefix(template)
+            assertEquals(template, expected, out)
+            assertFalse(template, out.contains('{') || out.contains('}'))
+        }
+    }
+
+    @Test
+    fun `a mid-string token collapses without leaving double separators`() {
+        assertEquals("Offer - Target", EvidenceFilename.sanitizePrefix("Offer - {pay} Target"))
+        assertEquals("A B", EvidenceFilename.sanitizePrefix("A {x} B"))
+    }
+
+    @Test
+    fun `a prefix that is nothing but a token falls back rather than saving a nameless file`() {
+        assertEquals(EvidenceFilename.FALLBACK_PREFIX, EvidenceFilename.sanitizePrefix("{storeName}"))
+        assertEquals(EvidenceFilename.FALLBACK_PREFIX, EvidenceFilename.sanitizePrefix("  -  "))
+        assertEquals(EvidenceFilename.FALLBACK_PREFIX, EvidenceFilename.sanitizePrefix(""))
+        assertEquals(EvidenceFilename.FALLBACK_PREFIX, EvidenceFilename.sanitizePrefix(null))
+    }
+
+    @Test
+    fun `a degenerate empty token is stripped too`() {
+        assertEquals("Offer", EvidenceFilename.sanitizePrefix("Offer - {}"))
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -414,6 +414,83 @@ class SideEffectEngineTest {
     }
 
     // =========================================================================
+    // #859 — a rule-declared cadence governs its own repeats; filenames stay honest
+    // =========================================================================
+
+    private fun throttledShot(key: String, prefix: String = "Offer - Chipotle") =
+        AppEffect.RequestEffect(
+            RequestedEffect(
+                verb = EffectVerb.SCREENSHOT,
+                ruleId = "uber.screen.offer",
+                args = mapOf("prefix" to prefix, "category" to "offer"),
+                dedupeKey = key,
+                throttleMs = 60_000L,
+            ),
+        )
+
+    @Test
+    fun `a rule effect declaring a cadence is not swallowed by the durable 48h row`() = runTest {
+        // The whole point of a PRESENTATION-stable dedupe key (offer-ss-{presentationHash}):
+        // the same key legitimately recurs on the NEXT offer from that store. The durable
+        // effects_fired row would suppress it for 48h — the rule declared 60s.
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        val effect = throttledShot("offer-ss-1234")
+        whenever { effectsFiredDao.hasBeenFired(effect.effectKey) }.thenReturn(true)
+
+        engine.process(effect)
+        runCurrent()
+
+        verify(screenShotHandler, times(1)).capture(any(), any())
+        // …and it writes no durable row either — the declared window is the ONE gate.
+        verifyBlocking(effectsFiredDao, never()) { markFired(any()) }
+    }
+
+    @Test
+    fun `a rule effect with no declared cadence keeps the durable idempotency`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        val effect = AppEffect.RequestEffect(
+            RequestedEffect(
+                verb = EffectVerb.SCREENSHOT,
+                ruleId = "uber.screen.offer",
+                args = mapOf("prefix" to "Offer - Chipotle", "category" to "offer"),
+                dedupeKey = "offer-ss-nocadence",
+            ),
+        )
+        whenever { effectsFiredDao.hasBeenFired(effect.effectKey) }.thenReturn(true)
+
+        engine.process(effect)
+        runCurrent()
+
+        verify(screenShotHandler, never()).capture(any(), any())
+    }
+
+    @Test
+    fun `a re-quoted presentation resolves to one key and captures once`() = runTest {
+        // Three frames of ONE Uber offer re-quoting itself: {presentationHash} makes them
+        // one key, and the declared window collapses them to a single capture.
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+
+        repeat(3) {
+            engine.process(throttledShot("offer-ss-presA"))
+            runCurrent()
+        }
+
+        verify(screenShotHandler, times(1)).capture(any(), any())
+    }
+
+    @Test
+    fun `an unresolvable filename token never reaches the screenshot handler`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+
+        engine.process(throttledShot("offer-ss-presB", prefix = "Offer - {storeName}"))
+        runCurrent()
+
+        val captor = argumentCaptor<AppEffect.CaptureScreenshot>()
+        verify(screenShotHandler).capture(any(), captor.capture())
+        assertEquals("Offer", captor.firstValue.filenamePrefix)
+    }
+
+    // =========================================================================
     // #436 — engine latency + dedupe pack
     // =========================================================================
 

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/DedupeTokens.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/DedupeTokens.kt
@@ -16,31 +16,61 @@ import cloud.trotter.dashbuddy.domain.state.ParsedFields
  *
  * [PARSED_HASH] is the shape-agnostic fix: the classifier resolves it from
  * [ParsedFields.dedupeHash] — the typed parse's content identity — once the
- * factory has run. Deterministic across runs and replay (String/Double
- * hashCode are specified), so recovery dedupe keys match the live run's.
+ * factory has run. [PRESENTATION_HASH] is its coarser sibling (#859), resolved
+ * from [ParsedFields.presentationHash]: the identity of one *showing* of the
+ * surface rather than of its current content, so a live-re-quoting card
+ * (Uber's offer, which re-renders pay/miles/minutes every few seconds) fires a
+ * per-presentation effect ONCE instead of once per quote.
+ *
+ * Both are deterministic across runs and replay (String/Double hashCode are
+ * specified), so recovery dedupe keys match the live run's. Both are DERIVED —
+ * never raw parse fields — which is why [RESERVED_FIELD_NAMES] exists: the
+ * dedupeKey template lint skips them as a class rather than as one-offs.
  */
 object DedupeTokens {
 
     /** Resolves to `ParsedFields.dedupeHash()` of the observation's typed parse. */
     const val PARSED_HASH = "{parsedHash}"
 
+    /** Resolves to `ParsedFields.presentationHash()` of the observation's typed parse (#859). */
+    const val PRESENTATION_HASH = "{presentationHash}"
+
+    /**
+     * Token → resolver over the typed parse. The single enumeration every other
+     * member derives from (names, the fast-path scan, the replacement loop) —
+     * adding a token here is the whole change.
+     */
+    private val RESOLVERS: Map<String, (ParsedFields) -> Int> = mapOf(
+        PARSED_HASH to { parsed -> parsed.dedupeHash() },
+        PRESENTATION_HASH to { parsed -> parsed.presentationHash() },
+    )
+
     /** Names treated as reserved (never raw parse fields) — lint/tooling SSOT. */
-    val RESERVED_FIELD_NAMES = setOf("parsedHash")
+    val RESERVED_FIELD_NAMES: Set<String> =
+        RESOLVERS.keys.mapTo(mutableSetOf()) { it.removeSurrounding("{", "}") }
 
     /**
      * Resolve reserved tokens in [effects]' dedupe keys against [parsed].
      * No-op (same list instance) when nothing references a token.
      */
     fun resolve(effects: List<RequestedEffect>, parsed: ParsedFields): List<RequestedEffect> {
-        if (effects.none { it.dedupeKey?.contains(PARSED_HASH) == true }) return effects
-        val hash = parsed.dedupeHash().toString()
+        if (effects.none { effect -> effect.dedupeKey?.let(::referencesToken) == true }) return effects
         return effects.map { effect ->
             val key = effect.dedupeKey
-            if (key != null && key.contains(PARSED_HASH)) {
-                effect.copy(dedupeKey = key.replace(PARSED_HASH, hash))
-            } else {
+            if (key == null || !referencesToken(key)) {
                 effect
+            } else {
+                var resolved: String = key
+                for ((token, hashOf) in RESOLVERS) {
+                    if (resolved.contains(token)) {
+                        resolved = resolved.replace(token, hashOf(parsed).toString())
+                    }
+                }
+                effect.copy(dedupeKey = resolved)
             }
         }
     }
+
+    private fun referencesToken(key: String): Boolean =
+        RESOLVERS.keys.any { token -> key.contains(token) }
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DedupeTokensTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DedupeTokensTest.kt
@@ -1,0 +1,112 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.pipeline.EffectVerb
+import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #427 ({parsedHash}) + #859 ({presentationHash}) — the reserved dedupeKey tokens.
+ *
+ * The pair is what lets a ruleset choose its dedupe granularity: CONTENT identity (one key
+ * per distinct parse) or PRESENTATION identity (one key for as long as the same physical
+ * showing is on screen, however much it re-quotes itself).
+ */
+class DedupeTokensTest {
+
+    private fun offer(
+        hash: String,
+        presentation: String? = null,
+    ) = ParsedFields.OfferFields(
+        parsedOffer = ParsedOffer(offerHash = hash, presentationKey = presentation),
+    )
+
+    private fun effect(key: String) = RequestedEffect(
+        verb = EffectVerb.SCREENSHOT,
+        dedupeKey = key,
+        ruleId = "test.screen.offer",
+    )
+
+    private fun resolveKey(key: String, parsed: ParsedFields): String? =
+        DedupeTokens.resolve(listOf(effect(key)), parsed).single().dedupeKey
+
+    @Test
+    fun `a re-quoted offer keeps ONE presentation key while its content key churns`() {
+        // Same physical presentation, three live re-quotes: store/order subset identical,
+        // economics (and so offerHash) different on every frame.
+        val frames = listOf(
+            offer(hash = "h-quote-1", presentation = "pres-A"),
+            offer(hash = "h-quote-2", presentation = "pres-A"),
+            offer(hash = "h-quote-3", presentation = "pres-A"),
+        )
+
+        val presentationKeys = frames.map { resolveKey("offer-ss-{presentationHash}", it) }.toSet()
+        val contentKeys = frames.map { resolveKey("offer-ss-{parsedHash}", it) }.toSet()
+
+        assertEquals("one presentation ⇒ one dedupe key", 1, presentationKeys.size)
+        assertEquals("the churn the effect used to re-fire on", 3, contentKeys.size)
+    }
+
+    @Test
+    fun `a different presentation resolves to a different key`() {
+        assertNotEquals(
+            resolveKey("offer-ss-{presentationHash}", offer("h-1", "pres-A")),
+            resolveKey("offer-ss-{presentationHash}", offer("h-2", "pres-B")),
+        )
+    }
+
+    @Test
+    fun `a null presentation key fails closed to the per-quote identity`() {
+        // #830's fail-closed rule: no stable subset ⇒ no presentation identity ⇒ behave
+        // exactly as {parsedHash} does, never as a constant shared across offers.
+        val a = offer(hash = "h-1", presentation = null)
+        val b = offer(hash = "h-2", presentation = null)
+
+        assertEquals(resolveKey("offer-ss-{presentationHash}", a), resolveKey("offer-ss-{parsedHash}", a))
+        assertNotEquals(
+            resolveKey("offer-ss-{presentationHash}", a),
+            resolveKey("offer-ss-{presentationHash}", b),
+        )
+    }
+
+    @Test
+    fun `resolution leaves no literal token behind and keeps the surrounding key`() {
+        val resolved = resolveKey("offer-ss-{presentationHash}", offer("h", "pres-A"))!!
+        assertTrue(resolved.startsWith("offer-ss-"))
+        assertTrue("the token must be replaced, not kept", !resolved.contains("{"))
+    }
+
+    @Test
+    fun `both tokens resolve in one key`() {
+        val resolved = resolveKey("k-{parsedHash}-{presentationHash}", offer("h", "pres-A"))!!
+        assertTrue(!resolved.contains("{"))
+    }
+
+    @Test
+    fun `a key with no reserved token is returned untouched, same list instance`() {
+        val effects = listOf(effect("offer-ss-static"))
+        assertSame(effects, DedupeTokens.resolve(effects, offer("h", "pres-A")))
+    }
+
+    @Test
+    fun `every reserved name matches its token, so the lint skips exactly what resolves`() {
+        assertEquals(setOf("parsedHash", "presentationHash"), DedupeTokens.RESERVED_FIELD_NAMES)
+        assertEquals("{parsedHash}", DedupeTokens.PARSED_HASH)
+        assertEquals("{presentationHash}", DedupeTokens.PRESENTATION_HASH)
+    }
+
+    @Test
+    fun `a non-offer parse resolves the presentation token to its content identity`() {
+        // The default: shapes with no separate presentation identity behave as before.
+        val parsed = ParsedFields.None
+        assertEquals(
+            resolveKey("k-{parsedHash}", parsed),
+            resolveKey("k-{presentationHash}", parsed),
+        )
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -101,6 +101,19 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
     check — still needs dev eyes. Likely 4th capability left ungranted is accept (no automation
     accept line post-install; hashes-only logs can't prove identity).)
 
+- **🆕 NEW — #859 (H4 + placeholder filenames) — one offer screenshot per presentation, and no
+  `{storeName}` filenames.** The Uber offer screenshot now dedupes on the presentation (#830's
+  `presentationKey`) instead of the churning quote hash, and a rule filename template whose field
+  parsed null saves as `Offer` instead of the literal token.
+  **What to watch (Uber dash, evidence capture ON):** Pictures/DashBuddy holds roughly **one
+  `Offer - <store>.png` per offer you actually saw** — no runs of 3–6 near-identical shots of the
+  same card seconds apart; a *later* offer from the SAME store still gets its own shot (this is the
+  regression to watch for — a missing capture for a repeat store means the dedupe went too far).
+  **Desk (next pull):** `ls` the pulled `screenshots/` — (a) zero filenames containing `{`, (b)
+  offer-screenshot count ≈ offer count for that platform (was 140/112 on 07-25), (c) cross-check a
+  repeat-store hour in `offer_records` against the file list to confirm repeats were captured.
+  - Issue: #859. Confirmed: 0/2
+
 - **🆕 NEW — #428-B / PR #845 — multi-language TTS (system locale + settings override).**
   **What to watch:** Settings → Voice → Spoken offer language set to Español → the next offer reads
   in Spanish (voice AND words together); System default on an English phone stays English; if the

--- a/docs/rules.schema.json
+++ b/docs/rules.schema.json
@@ -1128,7 +1128,7 @@
         },
         "dedupeKey": {
           "type": "string",
-          "description": "Stable key for deduplication. Supports {fieldName} template interpolation against the branch's RAW parse fields, plus the reserved {parsedHash} token, resolved after typed parsing to the parse's content identity (ParsedFields.dedupeHash) — use it for per-offer/per-parse dedupe of fields the rule itself doesn't parse (#427)."
+          "description": "Stable key for deduplication. Supports {fieldName} template interpolation against the branch's RAW parse fields, plus two reserved tokens resolved after typed parsing: {parsedHash} = the parse's CONTENT identity (ParsedFields.dedupeHash) — per-offer/per-parse dedupe of fields the rule itself doesn't parse (#427); {presentationHash} = the parse's PRESENTATION identity (ParsedFields.presentationHash) — one key for as long as the same physical showing is on screen, so a surface that live-updates its own content (a re-quoting offer card) fires the effect once per showing instead of once per update (#859)."
         },
         "throttleMs": {
           "type": "integer",

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
@@ -34,6 +34,20 @@ sealed class ParsedFields {
     open fun dedupeHash(): Int = 0
 
     /**
+     * Hash of the PRESENTATION identity — the subset that stays stable for as long as ONE
+     * physical presentation of this surface is on screen, even while the surface live-updates
+     * its own content (#859).
+     *
+     * [dedupeHash] answers "is this the same content?"; this answers "is this the same
+     * showing?". They differ only on a re-quoting surface: an offer card that re-renders its
+     * pay/miles/minutes every few seconds churns [dedupeHash] while the driver is looking at
+     * ONE offer, so a per-content dedupe key re-fires the rule's effects several times per
+     * offer. Shapes with no distinct presentation identity fall back to [dedupeHash], so the
+     * default is exactly today's behaviour.
+     */
+    open fun presentationHash(): Int = dedupeHash()
+
+    /**
      * Structural fields for effect-gate evaluation (`onlyIf`, #345/#434) —
      * every constructor property EXCEPT the open [activity] discriminator
      * (rules gate on structural fields, not the classification tag).
@@ -99,6 +113,18 @@ sealed class ParsedFields {
         )
 
         override fun dedupeHash(): Int = parsedOffer.offerHash.hashCode()
+
+        /**
+         * The #830 `presentationKey` (sha256 of the STABLE subset — store names, order count,
+         * order types) IS the offer's presentation identity: it is what the state machine
+         * already uses to tell "the same offer, re-quoted" from "a different offer".
+         *
+         * Fail-CLOSED, exactly as #830 defines it: a null key (digest failure, or a frame with
+         * no content-bearing stable subset) degrades to the per-quote [offerHash] — i.e. back
+         * to today's churn — never to a shared constant that would merge distinct offers.
+         */
+        override fun presentationHash(): Int =
+            (parsedOffer.presentationKey ?: parsedOffer.offerHash).hashCode()
     }
 
     @Serializable

--- a/matchers/rules/uber.json5
+++ b/matchers/rules/uber.json5
@@ -425,11 +425,22 @@
           },
           "effects": [
             {
+              // #859: dedupe the evidence capture on the PRESENTATION, not the quote. Uber
+              // re-renders this card's pay/miles/minutes every few seconds, so
+              // `{parsedHash}` (offerHash — economics folded in) minted a fresh key per
+              // re-quote and re-fired the screenshot up to 6× for ONE offer (140 captures
+              // for 112 offers in the 2026-07-25 pull), each re-fire anchored on its own
+              // least-settled frame. `{presentationHash}` resolves to #830's
+              // presentationKey — the stable store/order subset the state machine already
+              // uses to tell "same offer, re-quoted" from "different offer" — so the
+              // capture fires once per showing. The declared 60s cadence is what keeps a
+              // LATER offer from the same store capturable (see the SideEffectEngine
+              // throttle-window rule): dedupe identity is per-presentation, not forever.
               "screenshot": {
                 "prefix": "Offer - {storeName}",
                 "category": "offer"
               },
-              "dedupeKey": "offer-ss-{parsedHash}",
+              "dedupeKey": "offer-ss-{presentationHash}",
               "throttleMs": 60000
             },
             {


### PR DESCRIPTION
Builds the tractable half of #859: **defect 2 (re-fire inflation, H4)** and **defect 3 (`{storeName}` placeholder filenames)**. Defect 1 / H1–H3 (settle timing) is deliberately **out of scope** — partially mooted by #876 (dying frames no longer re-fire); the coordinator notes the disposition on the issue.

## H4 — which option, and why

The issue's candidate was "dedupe on #830's `presentationKey`". Investigating the two constraints it depends on changed the shape of the fix:

1. **Is `{presentationKey}` reachable as a dedupeKey template field?** No — option (a) is structurally impossible. `Ruleset.resolveTemplate` interpolates against the branch's **raw** parse map; `presentationKey` is derived in `ParsedFieldsFactory`, so `{presentationKey}` would stay a literal (exactly the #427 bug that `{parsedHash}` was invented to fix).
2. **Would a presentation-stable key alone actually do the right thing?** **No — measured against the pull, it would have been a silent 43% evidence regression.** `SideEffectEngine.execute` consults `effects_fired` (48h retention) for every keyed effect **before** the throttle, so the durable row is strictly stronger than the rule-declared `throttleMs` and subsumes it — the declared cadence is currently unreachable as a gate. With a stable key that means *one screenshot per store per 48h*: the 2026-07-25 pull holds **161 Uber offers across 92 distinct merchants** (`SELECT count(*), count(distinct merchantName) FROM offer_records`), i.e. ~43% of offers would silently stop being captured. Option (c) (`offer-ss-{storeName}` + the 60s throttle) fails for the same reason and harder — the throttle it relies on never runs.

So: **option (b)**, plus the window fix that makes any stable key safe.

**(b) The derived-token allowance — generic, not a one-off.**
- `ParsedFields.presentationHash()` (`:domain`) — an `open fun` defaulting to `dedupeHash()`, so every shape without a separate presentation identity behaves exactly as today. `OfferFields` overrides it to `(presentationKey ?: offerHash).hashCode()` — **fail-closed in #830's own terms**: no stable subset ⇒ no presentation identity ⇒ degrade to the per-quote hash, never a constant shared across offers.
- `DedupeTokens` (`:core:pipeline`) gains `{presentationHash}` beside `{parsedHash}`, both driven by one `RESOLVERS` map; `RESERVED_FIELD_NAMES` is now **derived** from that map rather than hand-listed, so the golden dedupeKey lint skips derived fields **as a class** (no literal whitelist entry).
- `matchers/rules/uber.json5`: the offer screenshot's `dedupeKey` → `offer-ss-{presentationHash}` (with the rationale in-file). The sibling `offer-log-{parsedHash}` is left alone (a per-quote DEBUG line is informative and costs nothing). **DoorDash is unchanged** — its card doesn't re-quote (60/60 in the pull); it can adopt the token later if desired.
- `docs/rules.schema.json`: the `dedupeKey` description now documents both reserved tokens.

**The engine change shape (the second half of (b)).** In `SideEffectEngine.execute`, a rule effect that **declares its own repeat cadence** (`RequestEffect` with a non-null `throttleMs` — ruleset data, i.e. the author saying "this may fire again after N ms") opts **out** of the durable `effects_fired` row and **into** that declared window, which the existing wall-clock throttle already enforces on the same `effectKey`. It also writes no durable row (the row would only be read by the check it bypasses). One declared value, one gate. App-emitted keyed effects (bubbles, sessions, `EffectMap` captures) declare nothing and keep the 48h idempotency byte-for-byte. Net effect on the two shipped offer rules: an offer is captured once per *presentation*, and the **next** offer from the same store is still captured.

**Residual (documented, in code + CLAUDE.md):** the throttle map is in-memory, so a process restart re-arms it — at most one extra capture of a surface that is on screen across a restart. External effects are still suppressed during recovery replay, so this is not a recovery hazard.

## Placeholder-degrade behavior

`EvidenceFilename.sanitizePrefix` (new, pure, `:app`) strips any surviving `{token}`, collapses the whitespace it leaves, trims dangling separator punctuation, and falls back to `Rule` if nothing survives:

| declared prefix | field parsed null ⇒ saved as |
|---|---|
| `Offer - {storeName}` | `Offer` |
| `Delivery - {totalPay}` | `Delivery` |
| `DashSummary - {totalEarnings}` | `DashSummary` |
| `{storeName}` | `Rule` |

It runs at `captureEvidence` — the **one** choke point every screenshot passes (rule-declared *and* `EffectMap`-emitted), so it's one policy for one property with no per-rule or per-platform knowledge. A fully-resolved prefix is passed through untouched.

Deliberately **not** done in `Ruleset.resolveTemplate`: (i) the reserved-token chain depends on an unresolved `{parsedHash}` surviving interpolation for the classifier to resolve later, and (ii) `ParseOutputGoldenTest`'s arg-template lint detects a never-interpolating rule template *by seeing the literal token post-resolution* — dropping tokens upstream would blind it. The lint stays the primary control (rule-authoring quality); the engine is the fail-safe (no broken filename ever reaches disk).

## Tests

- `DedupeTokensTest` (new, `:core:pipeline`) — a re-quoted offer keeps ONE presentation key while its content key churns 3×; different presentations differ; a null `presentationKey` fails closed to the per-quote identity (and still separates two distinct offers); both tokens in one key; a token-free key returns the same list instance; the reserved names match the tokens.
- `DefaultRulesIntegrationTest` (new case) — over the real Uber offer corpus: the fielded card yields a **non-null** `presentationKey` (a null would silently restore the churn), the resolved key **is** `offer-ss-<presentationHash>`, no braces survive, and 4 distinct presentations do not collapse onto one key.
- `SideEffectEngineTest` (4 new cases) — a cadence-declaring effect fires even when `hasBeenFired` is true and writes no durable row; a cadence-less effect still obeys the durable row; three frames of one re-quoted presentation capture once; an unresolvable `{storeName}` never reaches the handler.
- `EvidenceFilenameTest` (new) — every shipped prefix shape, mid-string tokens, token-only prefixes, blank/null, degenerate `{}`.

`./gradlew testDebugUnitTest :domain:test` — **green**. `AllMatchersSuite` green. **Parse golden unchanged** (`approved-parse-output.json` not touched): dedupe keys are not parse output, and the dedupeKey lint skips reserved names as a class, so neither the golden nor the two ratchet sets moved.

## Design-goal review

- **P1 (UDF).** No reducer/stepper touched. The change lives at the effect edge (`SideEffectEngine`) and in the pure classification path (`DedupeTokens`); dedupe granularity is a rule declaration read at the edge, never state.
- **P3 (SRP).** The filename policy is its own 40-line object rather than another branch inside the engine; `DedupeTokens` grew a resolver map instead of a second copy of the replacement logic.
- **P5 (SSOT).** `RESERVED_FIELD_NAMES` is now *derived* from the resolver map (was a hand-maintained parallel list — exactly the drift class). Presentation identity has ONE definition (#830's `presentationKey`) now consumed by both the state machine and the dedupe key, rather than a second, weaker proxy (`storeName`). The repeat window has ONE declared value (the rule's `throttleMs`) and one gate, replacing "the rule declares 60s, the engine silently enforces 48h".
- **P6 (security/privacy).** No new capture surface, no new data persisted, no gate weakened: the #426 evidence gate is untouched and still runs *before* the sanitize step; the change strictly **reduces** what is written to disk (fewer screenshots, and a filename that no longer echoes a rule's internal field name). Screenshots stay debug-gated by `EvidenceConfig` (master default off). Dedupe keys carry hashes, never text.
- **P7 (logging).** No new log sites; the existing DEBUG-only prefix line is unchanged (a prefix can carry merchant text — it stays off INFO+).
- **P8 (platform-agnostic core).** No `Platform` literal or branch anywhere in the diff. `presentationHash()` is an open fun over the sealed parse hierarchy (any platform's offer benefits identically); `{presentationHash}` is ruleset vocabulary resolved through the enumerated `DedupeTokens` SSOT, not a magic string in a Kotlin `when`; the cadence rule reads a *declaration* (`throttleMs`), never which rule or platform wrote it. Uber and DoorDash differing in their declared key is ruleset data choosing granularity — the mechanism is identical for both.

## Field note

Added to the `## Next field test` checklist (#859, 0/2). Desk check on the next Uber pull: **~1 offer screenshot per physical presentation** (was 140/112), **zero filenames containing `{`**, and — the regression to watch — a *later* offer from the same store still produces its own screenshot.
