### PR TITLE
fix(privacy): #884 close the amount-bearing 'Transfer $<amt>' / 'Transfer in' marker gap

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveMarkerAssetCoverageTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveMarkerAssetCoverageTest.kt
@@ -237,9 +237,8 @@ class SensitiveMarkerAssetCoverageTest {
         private val KNOWN_GAPS = setOf(
             // "Withdraw" + "available" (an AND pair) — neither term overlaps a keyword.
             "doordash.screen.sensitive.known::sensitive.withdraw",
-            // The third OR-alternative, all["Transfer in", "available"], has no covered term
-            // ("Savings jar" and "You transferred" ARE keywords, but this alternative can fire alone).
-            "doordash.screen.sensitive.known::sensitive.savings",
+            // (`sensitive.savings` graduated off this list in #884 — "Transfer in" is now a
+            // keyword, so its third OR-alternative, all["Transfer in", "available"], is covered.)
             // "ready to start verification" is an OR-alternative with no keyword (the other four
             // alternatives of this branch are all keywords).
             "doordash.screen.sensitive.known::sensitive.id_verification",

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
@@ -63,6 +63,15 @@ object SensitiveTextMarkers {
         // on no recognized customer-facing surface in the corpus (verified per the #738
         // uniqueness discipline), so it cannot over-block a delivery screen.
         "Transfer out",
+        // The DasherDirect transfer surface's OTHER direction (#884): the "Transfer in"
+        // heading of the deposit-to-DasherDirect flow. The rule side already blocks it
+        // (the `sensitive.savings` branch's all["Transfer in", "available"] alternative),
+        // but the keyword was missing, so a "Transfer in" CLICK — whose envelope serializes
+        // the tapped node in ISOLATION, with no co-present "available" balance line for the
+        // AND-pair rule to fire on — had no backstop and reached disk on the 2026-07-24 build.
+        // Like "Transfer out", the phrase appears on no recognized customer-facing surface in
+        // the corpus (#738 uniqueness discipline), so it cannot over-block a delivery screen.
+        "Transfer in",
         // Alcohol-delivery DOCUMENT-capture surfaces only (#463): the license-scan
         // camera (an image of a government ID) and the signature pad/handoff.
         // The ID-CHECK instruction screen and the alcohol arrival card are NOT
@@ -103,8 +112,16 @@ object SensitiveTextMarkers {
     )
 
     /**
-     * Shaped-value patterns no keyword list can cover: SSNs and card PANs.
-     * Conservative shapes to avoid flagging ordinary money/IDs.
+     * Shaped-value patterns no keyword list can cover: SSNs, card PANs, and the
+     * amount-bearing DasherDirect transfer button.
+     *
+     * Matched against the NORMALIZED text (see [normalize]), so every pattern is written in
+     * lowercase with ASCII spaces — normalization already folded case, homoglyph whitespace,
+     * fullwidth digits/`＄`, and zero-width injections before the scan runs.
+     *
+     * Conservative shapes to avoid flagging ordinary money/IDs, and deliberately BOUNDED
+     * (no nested/unbounded quantifiers) so a hostile third-party string cannot make the scan
+     * backtrack: each is a linear scan with fixed-count repetitions only.
      *
      * `internal` (#862) so `MarkerLogIdTest` pins the LIVE patterns rather than a hand-copied
      * list — a shape added here is covered by the log-safety guard automatically.
@@ -114,6 +131,23 @@ object SensitiveTextMarkers {
         Regex("""\b\d{3}-\d{2}-\d{4}\b"""),
         // Card PAN: 4 groups of 4 separated by space/dash (16 digits)
         Regex("""\b\d{4}[ -]\d{4}[ -]\d{4}[ -]\d{4}\b"""),
+        // DasherDirect transfer CONFIRM button (#884): the label interpolates the dasher's own
+        // balance — "Transfer $45.66" / "Transfer $83.65" / "Transfer $68.52" all reached disk
+        // as UNKNOWN CLICK envelopes on the 2026-07-24 build. No keyword can own this: the
+        // amount is the variable part, and a bare "Transfer" keyword would be far too broad.
+        // The shape is the amount ADJACENCY — "transfer", optional spaces, "$", a digit — which
+        // is banking vocabulary wherever it appears, so a false hit costs at most one debug
+        // capture (fail toward privacy). The bounded ` {0,4}` gaps absorb the per-character
+        // space normalization (a tab/NBSP run normalizes to several ASCII spaces) and let the
+        // sibling-split form ("Transfer" | "$45.66") rejoin across the allText join.
+        //
+        // Sibling shapes deliberately NOT added: "Cash out $<amt>" needs nothing — the bare
+        // "Cash out" keyword above already substring-matches it. "Deposit $<amt>" is not
+        // fielded (0 hits across all twelve 2026-07 pulls; the only "deposit" text on the
+        // surface is the benign "deposited to your DoorDash …" earnings copy, which carries
+        // no adjacent "$"), so it stays out per the #738 uniqueness discipline — a marker is
+        // evidence-driven, not speculative. Revisit if a pull ever shows it.
+        Regex("""transfer {0,4}\$ {0,4}\d"""),
     )
 
     /**

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
@@ -124,6 +124,54 @@ class CaptureScrubTest {
         assertEquals(0L, stats.scrubbedUnknownCaptureCount)
     }
 
+    // #884: the fielded leak class. A DasherDirect transfer BUTTON is serialized in
+    // ISOLATION on the click path — the tapped node alone, with none of the window's
+    // co-present "$X.XX available" balance line — so the AND-pair sensitive RULE that
+    // blocks the window ("Transfer out"/"Transfer in" + "available") cannot fire here.
+    // The marker backstop is the only control on this envelope, and before #884 neither
+    // the amount-bearing label nor the "in" direction matched any marker: `Transfer
+    // $45.66` / `$83.65` / `$68.52` and `Transfer in` all reached disk on build ddd9e7ff.
+
+    private fun clickNode(text: String) = UiNode(text = text, isClickable = true)
+
+    private fun captureUnknownClick(node: UiNode) = writer.captureClick(
+        unknownClickObs(),
+        PipelineEvent.Click(timestamp = 1_000L, node = node, packageName = "com.doordash.driverapp"),
+        screenTarget = "side_nav_drawer",
+    )
+
+    @Test
+    fun `UNKNOWN click on an amount-bearing transfer button is never offered to the capture bus`() {
+        captureUnknownClick(clickNode("Transfer \$12.34"))
+
+        verify(captureBus, never()).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertEquals(1L, stats.scrubbedUnknownCaptureCount)
+    }
+
+    @Test
+    fun `UNKNOWN click on the Transfer in button is never offered to the capture bus`() {
+        captureUnknownClick(clickNode("Transfer in"))
+
+        verify(captureBus, never()).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertEquals(1L, stats.scrubbedUnknownCaptureCount)
+    }
+
+    @Test
+    fun `UNKNOWN click on the sibling Transfer out button is still dropped (#794 regression)`() {
+        captureUnknownClick(clickNode("Transfer out"))
+
+        verify(captureBus, never()).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertEquals(1L, stats.scrubbedUnknownCaptureCount)
+    }
+
+    @Test
+    fun `an ordinary money-bearing click label still captures - the shape needs the transfer word`() {
+        captureUnknownClick(clickNode("Add \$12.34 tip"))
+
+        verify(captureBus, times(1)).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertEquals(0L, stats.scrubbedUnknownCaptureCount)
+    }
+
     // #666 item 2c: the UNKNOWN-notification backstop must scan actionLabels too —
     // previously only the flat text fields (title/text/bigText/tickerText/subText)
     // were scanned, so a sensitive marker living ONLY in a push action button label

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkersTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkersTest.kt
@@ -22,6 +22,9 @@ class SensitiveTextMarkersTest {
         // DasherDirect Savings flow (#463) — the markers that leaked on 2026-06-12.
         assertEquals("Savings jar", SensitiveTextMarkers.findMarker(tree("Your transfer should now appear in your Savings jar")))
         assertEquals("You transferred", SensitiveTextMarkers.findMarker(tree("You transferred \$9.06")))
+        // #884 — the deposit direction of the DasherDirect transfer surface.
+        assertEquals("Transfer in", SensitiveTextMarkers.findMarker(tree("Transfer in")))
+        assertEquals("Transfer in", SensitiveTextMarkers.findMarker(tree("transfer in", "\$45.66 available")))
         // Alcohol DOCUMENT-capture surfaces only — license scanner + signature pad
         // (#463). The ID-check instruction + the arrival card are NOT markers: we
         // recognize those (customers are hashed, not blocked).
@@ -60,6 +63,30 @@ class SensitiveTextMarkersTest {
         assertNotNull(SensitiveTextMarkers.findMarker(tree("ID 123-45-6789 on file")))
         assertNotNull(SensitiveTextMarkers.findMarker(tree("4111 1111 1111 1111")))
         assertNotNull(SensitiveTextMarkers.findMarker(tree("4111-1111-1111-1111")))
+    }
+
+    @Test
+    fun `shaped values hit - amount-bearing transfer button (#884)`() {
+        // The fielded leak class: the confirm button interpolates the dasher's own balance,
+        // so no keyword can own it — the shape is "transfer" adjacent to a "$<digit>".
+        assertNotNull(SensitiveTextMarkers.findMarker(tree("Transfer \$45.66")))
+        assertNotNull(SensitiveTextMarkers.findMarker(tree("Transfer \$8.00")))
+        assertNotNull(SensitiveTextMarkers.findMarker(tree("TRANSFER \$1,234.56")))
+        // No space between label and amount, and an extra-spaced variant.
+        assertNotNull(SensitiveTextMarkers.findMarker(tree("Transfer\$45.66")))
+        assertNotNull(SensitiveTextMarkers.findMarker(tree("Transfer  \$ 45.66")))
+        // Split across sibling nodes — the allText join re-assembles it.
+        assertNotNull(SensitiveTextMarkers.findMarker(tree("Transfer", "\$45.66")))
+        // Flat (notification/log-sink) overload.
+        assertNotNull(SensitiveTextMarkers.findMarker("Transfer \$45.66"))
+    }
+
+    @Test
+    fun `the transfer amount shape does not fire on ordinary transfer-free money copy`() {
+        // The shape is amount-ADJACENCY, not the word "transfer" — a delivery screen that
+        // merely mentions a transfer with no adjacent amount must stay clean.
+        assertNull(SensitiveTextMarkers.findMarker(tree("Transfer of ownership", "\$45.66")))
+        assertNull(SensitiveTextMarkers.findMarker(tree("Order total \$45.66")))
     }
 
     @Test

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,20 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — #884 — the amount-bearing transfer button no longer evades the marker backstop.**
+  `SensitiveTextMarkers` gained `Transfer in` plus a `transfer $<digit>` amount-adjacency shape.
+  The leak channel was the CLICK envelope (the tapped button is serialized in isolation, so the
+  window-level AND-pair sensitive rule can't fire); `Transfer $45.66`/`$83.65`/`$68.52` and
+  `Transfer in` reached disk on build `ddd9e7ff`.
+  **What to watch:** nothing on-dash — but if you happen to open DasherDirect and tap a transfer
+  button, that's the exercise. **Desk:** run the new *Dasher-banking sweep* block in
+  `desk-validation-playbook.md` over the pull — `grep -rliE 'transfer +\$[0-9]' captures/` and the
+  `-e 'transfer in'` sweep must both return ZERO. Corroborate in `shareable.log`:
+  `grep 'Capture scrubbed:'` should show the drop with marker id `Tr11` (`Transfer in`) or
+  `sh30` (the amount shape) when the surface was touched. Over-match watch: no benign
+  delivery/offer frame should go missing from `captures/` (the shape needs the literal word
+  `transfer` adjacent to a `$`, so an ordinary money label must still capture).
+  - Confirmed: 0/2
 - **🆕 NEW — #843 — prompted per-capability automation consent (no auto-grant).** Automations are
   no longer pre-granted; each must be consented to individually via a prompt at the app's front
   door (Google Play policy). On upgrade, a one-shot migration clears the old auto-grants, so every

--- a/docs/field-testing/desk-validation-playbook.md
+++ b/docs/field-testing/desk-validation-playbook.md
@@ -107,7 +107,7 @@ SELECT taskId, realizedMiles FROM delivery_records;
 | #438 B4 | `grep 'OfferActionReceiver:'` | each tap line carries `(offer=<hash>)` (full hash, same rendering as OfferEffects) — exact-match it to the resolved `OFFER_*` event's hash; a mismatch = acted on the wrong offer |
 | #731 | `grep -i 'notification listener'` | the per-event lines are the PRIMARY record: first disconnect per process at WARN, the rest (and all connects) at INFO, each with a running count. `grep -c` them for the flap rate; per process, `connects − disconnects ≈ process deaths` (itself a diagnostic — a kill never logs its disconnect). The `PipelineStats` summary fields (`notifListenerConnects=`/`Disconnects=`) are corroboration ONLY — the summary emits per 50 forwarded observations, i.e. only while actively sensing, so it is blind exactly when the idle-time flap is worst |
 | #159 | `grep 'downgrade averted'` / `grep 'store-chain resolved'` | monotonic backstop held / shadow resolution milestones |
-| #862 | `grep -e 'Capture scrubbed:' -e 'Capture backstop:'` | the privacy layer firing, now readable IN `shareable.log` (pre-#862 these lines redacted themselves to `[scrubbed:<marker>]`). Each names the marker by **id** — first two alphanumerics + length (`Tr12` = `Transfer out`, `De11` = `Deliver to `); decode against `SensitiveTextMarkers.KEYWORDS` / `CustomerTextMarkers.MARKERS` (ids are pinned collision-free). A `[scrubbed:…]` line remaining in the export is now a REAL upstream leak, not our own diagnostic |
+| #862 | `grep -e 'Capture scrubbed:' -e 'Capture backstop:'` | the privacy layer firing, now readable IN `shareable.log` (pre-#862 these lines redacted themselves to `[scrubbed:<marker>]`). Each names the marker by **id** — first two alphanumerics + length (`Tr12` = `Transfer out`, `Tr11` = `Transfer in`, `De11` = `Deliver to `); decode against `SensitiveTextMarkers.KEYWORDS` / `CustomerTextMarkers.MARKERS` (ids are pinned collision-free). A `[scrubbed:…]` line remaining in the export is now a REAL upstream leak, not our own diagnostic |
 
 ## Capture-tree checks
 
@@ -118,6 +118,26 @@ SELECT taskId, realizedMiles FROM delivery_records;
   spot-check labeled frames are REAL zone screens (over-match check); exactly ONE
   `PICKUP_ARRIVED` per warehouse visit in `app_events` (the rule is recognize-only and must
   not steal the bin-scan anchor).
+
+### Dasher-banking sweep over the pull (#794 / #884)
+
+Run this on EVERY pull — the Pledge check that no dasher banking text reached disk. Deliberately
+outside the table above: these are raw copy-paste greps, and a `|` alternation inside a Markdown
+table cell has to be escaped, which silently corrupts the copied command (the #870 lesson). Use
+repeated `-e` instead of alternations, and run from the pull dir:
+
+```bash
+grep -rli -e 'available balance' -e 'dasherdirect' -e 'crimson' -e 'routing number' captures/
+grep -rli -e 'transfer out' -e 'transfer in' -e 'cash out' -e 'instant pay' captures/
+grep -rliE 'transfer +\$[0-9]' captures/      # the #884 amount-bearing button class
+```
+
+Expect **zero** hits in `captures/`. Hits in `shareable.log`/`app.log` are a different read: a
+`[scrubbed:Transfer out]` placeholder there is the sink DOING its job (the marker name is our own
+constant, not leaked text) — see the `#862` row above for how to tell that apart from a real leak.
+`Transfer $<amt>` and `Transfer in` are the shapes that evaded the sweep before #884 — the class
+leaks on the **click** path (the button node is serialized in isolation, so the window-level
+sensitive rule never fires), so check `captures/**/click/**` specifically, not just screen frames.
 
 ## Known non-desk residuals
 


### PR DESCRIPTION
Closes #884.

## The defect

The dasher-banking marker SSOT (`SensitiveTextMarkers`, `:core:pipeline`) carried the literal
`"Transfer out"` only. Two sibling DasherDirect labels matched no marker and reached disk as
UNKNOWN **click** envelopes on build `ddd9e7ff`:

- `Transfer $45.66` / `Transfer $83.65` / `Transfer $68.52` — the confirm button interpolates the
  dasher's own balance.
- `Transfer in` — the deposit direction.

The **click path is the leak channel by construction**: `CaptureWriter.captureClick` serializes the
tapped node in ISOLATION, so the AND-pair sensitive RULE that blocks the window
(`"Transfer out"`/`"Transfer in"` + a co-present `"$X.XX available"` line) cannot fire on a lone
button. On that envelope the marker backstop is the *only* control — and it had no entry for either
shape. The window side held (the 07-25/07-27 pulls carry zero banking text in `captures/`; the only
`transfer out` hits are in `shareable.log`/`app.log`, i.e. the sink's own `[scrubbed:…]` placeholder
doing its job).

## The additions

Both land in the one SSOT the runtime backstop, the shareable-log sink (`LogScrubber` →
`SensitiveTextMarkers::findMarker`), and the corpus `SnapshotSecurityScanner` all read:

```kotlin
// KEYWORDS
"Transfer in",

// SHAPE_PATTERNS
Regex("""transfer {0,4}\$ {0,4}\d"""),
```

The shape is **amount ADJACENCY**, not the word: the amount is the variable part, so no keyword can
own it, and a bare `"Transfer"` keyword would be far too broad. Properties:

- **Bounded / linear.** Fixed-count repetitions only (` {0,4}`), no nesting, no alternation — there
  is no backtracking path to blow up on hostile third-party text.
- **Normalization-aware.** `SHAPE_PATTERNS` run against the NFKC-folded, lowercased, dash-folded
  normalized text, so the pattern is written lowercase with ASCII spaces and inherits the full #590
  evasion resistance for free (fullwidth `＄`/digits, NBSP, zero-width injection).
- The ` {0,4}` gaps absorb the per-character space normalization (a tab/NBSP run normalizes to
  several ASCII spaces) and let the sibling-split form (`"Transfer"` | `"$45.66"`) rejoin across the
  `allText` join.

## Sibling decision (`Cash out $` / `Deposit $`)

- **`Cash out $<amt>` — no addition needed.** The bare `"Cash out"` keyword is already in KEYWORDS
  and the scan is a substring match, so `Cash out $45.66` already hits today. Adding a shape would
  be a second, redundant definition of the same rule (P5).
- **`Deposit $<amt>` — NOT added, documented as not-yet-fielded.** Bounded scan of all twelve
  2026-07 pulls (`grep -rlio 'deposit \$[0-9]' ~/dashbuddy/logs/2026/07/*/captures`) returned **0
  hits**. The only `deposit` text on the fielded surface is the benign `"deposited to your DoorDash
  …"` earnings copy (450 occurrences), which carries no adjacent `$` and would not match such a
  shape anyway. Per the #738 uniqueness discipline a marker is evidence-driven, not speculative, so
  it stays out with the receipt recorded in-file next to the shape. (`Cash out $` scan: also 0 hits
  — already covered regardless.)

Fielded census that *did* justify the two additions:

```
61 Transfer out      8 Transfer $10.45   5 Transfer $8.59   5 Transfer $8.00
 4 Transfer in       2 Transfer $55.78   + $6.99/$6.00/$56.71/$47.86/$12.74
```

`Transfer in` appears in the 07-19, 07-20 and 07-27 pulls — a live, recurring shape, not a one-off.

## Ripple check

| Rider | Result |
|---|---|
| `SensitiveMarkerAssetCoverageTest` | **Legitimately extended.** `"Transfer in"` becoming a keyword makes the `sensitive.savings` branch's third OR-alternative `all["Transfer in", "available"]` COVERED, so the whole unit stops being a GAP. The test's ratchet fails on a stale entry, so `doordash.screen.sensitive.known::sensitive.savings` is **removed** from `KNOWN_GAPS` (a shrink, per the list's shrink-only discipline). Green. |
| Scanner↔backstop parity (#590, `SnapshotSecurityScannerParityTest`) | Green with no edit — the scanner *delegates* to `findMarker` rather than mirroring the list, which is exactly what makes a marker addition impossible to diverge. |
| `MarkerLogIdTest` | Green. `"Transfer in"` → `Tr11` vs `"Transfer out"` → `Tr12` — lengths differ, so no collision; verified the union collision check (KEYWORDS ∪ `CustomerTextMarkers.MARKERS`) still passes, and no customer marker has a `Tr` head. The new shape's id is `sh30` (`shape:transfer {0,4}\$ {0,4}\d`, len 30), distinct from the SSN `sh27` and PAN `sh42`, and it is scan-clean (the shape does not match its own name). Because `SHAPE_PATTERNS` is `internal` + live-pinned (#870/#862), the new shape was covered by the log-safety guard with zero test edits. |
| `RuleIdLogSafetyTest` | Green. The only rule id containing "transfer" is `doordash.notification.transfer_complete`; it contains neither `transfer in` (underscore, not space) nor a `transfer $<digit>` run, so `findMarker` stays null on it. |
| `LogScrubber` / `LogRepositoryTest` / `ScrubDiagnosticSurvivesSinkTest` | Green. The sink is zero-trust and scans every byte; widening the marker set only widens what it redacts. The `[scrubbed:<marker>]` placeholder now also carries the new constants, which are safe (our own strings, never scanned text). |
| Golden corpus / `AllMatchersSuite` | Green. Every corpus file containing `transfer` text lives under `snapshots/SENSITIVE/` (incl. one carrying `Transfer $0.00` and one carrying `Transfer in`) — the additions only *strengthen* the toxicity guard there. No non-SENSITIVE fixture contains either token, so nothing new is flagged and no snapshot moved. |
| `InfoLogPiiGateReplayTest` / `ClassifyGateCaptureFuzzTest` | Green — no INFO+ line in the replayed session trips the widened scan. |

**Test runs** (`JAVA_HOME=/usr/lib/jvm/java-25`): `:core:pipeline:testDebugUnitTest`,
`:core:data:testDebugUnitTest`, and the **full** `:app:testDebugUnitTest` (which includes
`AllMatchersSuite`, the golden guard, the parse-output golden, and the inbox sorter) — all green,
working tree clean afterward (no corpus re-sort).

## New regression coverage

`CaptureScrubTest` (mirrors the existing #666/#806 click-path tests, driving the real
`CaptureWriter.captureClick` with `screenTarget = "side_nav_drawer"` — the fielded shape):

- an UNKNOWN click on `Transfer $12.34` is **never offered to the bus** (`scrubbedUnknownCaptureCount == 1`);
- ditto `Transfer in`;
- ditto `Transfer out` (a #794 regression pin, so the sibling can't be lost while editing this group);
- **over-match negative:** an ordinary money-bearing label (`Add $12.34 tip`) still captures for triage.

`SensitiveTextMarkersTest` adds the marker-level cases: the amount shape across spacing variants,
case, comma-grouped amounts, the sibling-split form and the flat (notification/sink) overload; plus
two negatives proving the shape needs the literal word adjacent to the `$`.

## Docs

- `desk-validation-playbook.md`: new **Dasher-banking sweep (#794 / #884)** block under Capture-tree
  checks, with `grep -rliE 'transfer +\$[0-9]' captures/` alongside the literal-marker greps, and a
  note that this class leaks on the **click** path specifically. Written as a fenced bullet block,
  **not** a table row, using repeated `-e` instead of `|` alternations — the #870 raw-copy lesson (a
  pipe inside a Markdown table cell has to be escaped, which silently corrupts a copy-pasted grep).
  The `#862` decode row also gains `Tr11` = `Transfer in`.
- `field-testing/README.md`: new `Confirmed: 0/2` checklist item with the desk verification recipe
  and the over-match watch.

## Security / privacy posture

- **Trusted:** nothing new. The scan input is still untrusted third-party accessibility text.
- **Gated:** unchanged — the backstop only ever *drops* an UNKNOWN capture; it cannot cause one.
- **Scrubbed:** strictly more than before. Two previously-invisible dasher-banking shapes now drop
  the capture on the screen, click, and notification paths, and redact the line at the shareable-log
  sink.
- **Fail-closed unchanged:** the normalize-throw sentinel still returns toxic, never null.

## Design-goal review

- **P3 (single responsibility).** Data-only change to an existing SSOT plus its tests; no new type,
  no new code path, no growth of any file's responsibility.
- **P5 (SSOT).** The whole point: ONE marker list, extended once. Both consumers that could have
  drifted are structurally derived — the corpus scanner *delegates* to `findMarker`, and
  `MarkerLogIdTest` pins the LIVE `SHAPE_PATTERNS`/`KEYWORDS` rather than a hand-copy — so this
  addition propagated to the parity gate and the log-safety guard with zero duplicated edits. The
  `Cash out $` decision is the same principle applied in reverse: an existing keyword already
  covers it, so adding a shape would have created a second definition of one rule. The `KNOWN_GAPS`
  removal keeps the ledger honest instead of letting a fixed gap linger as a stale exemption.
- **P6 (security & privacy first).** Closes a Pledge-class hole (the dasher's own banking figure on
  disk) and does so at the *rules-independent* layer, so a ruleset that fails to load or misses the
  variant cannot re-open it. **Fail toward privacy, and the over-match cost is deliberately tiny:**
  the marker layer only suppresses a debug-only capture (release binds `NoOpCaptureBus`), so a
  benign string that happens to read `Transfer $…` costs exactly one triage capture — never a lost
  event, a lost economic record, or any behavior change to recognition, the state machine, or the
  UI. That asymmetry is why the shape is written to over- rather than under-match on the margin.
  Regex ingestion stays bounded (fixed repetitions, linear scan) per the untrusted-input rule.
- **P7 (semantic, PII-safe logging).** No new log site. The existing WARNs name the marker by
  `MarkerLogId` (`Tr11` / `sh30`), never verbatim, so the diagnostics still survive the sink; the
  playbook's decode table is updated to match.
- **P8 (platform-agnostic core).** The marker SSOT is cross-platform DATA, and both additions are
  data. No `Platform` literal, no package name, no wire string, no Kotlin `when` — the scan is
  identical for every platform, exactly as the existing Uber/DoorDash entries are.
