### PR TITLE
test(security): #878 pin a seed per #590 property test so CI is deterministic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,12 @@ epics.)
 # Run a single recognition test (e.g. just the golden-corpus positive guard)
 ./gradlew :app:testDebugUnitTest --tests "*GoldenSnapshotRegressionTest"
 
+# Re-run the #590 security property/fuzz suite UNSEEDED at 10x samples (#878).
+# Every property pins a seed by default so PR CI is deterministic; this flag is the
+# exploration path — run it off the PR path (nightly/manual), and when it finds
+# something, paste the reported seed into that property's pinned SEED const.
+./gradlew :core:pipeline:testDebugUnitTest :app:testDebugUnitTest -Ddashbuddy.propExplore=true
+
 # Run instrumented tests (requires connected device/emulator)
 ./gradlew :app:connectedAndroidTest
 
@@ -867,7 +873,12 @@ touching untrusted input or the Pledges, `/security-review`. The adversary works
 3. **Security** — `/security-review` the branch; for diffs touching the untrusted-input boundaries
    (rule compile/ingest, accessibility-tree mapping, regex, PII/sensitive handling, capture/effects)
    confirm the fail-closed + bounded-ingestion + no-plaintext-leak properties still hold, backed by
-   the security property/fuzz suite (#590).
+   the security property/fuzz suite (#590). **That suite is seeded (#878)** — every kotest property
+   pins an explicit `PropSeeds.config(SEED)`, so PR CI draws the same samples on every run and a red
+   property is a reproducible finding, never a re-run-and-move-on flake (an unseeded
+   `TransformFuzzFailClosedTest` failed once on an unrelated PR and its counterexample was lost).
+   Bump a site's `SEED` **deliberately** to explore new samples, NEVER to turn a red run green; the
+   unseeded breadth lives behind `-Ddashbuddy.propExplore=true` (10× samples, off the PR path).
 
 **Same-tier rule:** the adversarial reviewer runs at the **session model tier** (Mythos/Fable
 class) — never downgraded to a lower tier. An adversary weaker than the author is theater; this is

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/ClassifyGateCaptureFuzzTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/ClassifyGateCaptureFuzzTest.kt
@@ -14,6 +14,7 @@ import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.pipeline.UNKNOWN_TARGET
+import cloud.trotter.dashbuddy.test.util.PropSeeds
 import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
 import io.kotest.property.Arb
 import io.kotest.property.RandomSource
@@ -44,9 +45,18 @@ import org.mockito.kotlin.mock
  * out of scope; this exercises the classify + capture-scrub path directly, mirroring
  * `CaptureScrubTest`'s wiring.
  *
- * A failing property prints its seed; pin it with `PropTestConfig(seed = ...)`.
+ * **Determinism (#878).** The seed below pins PR CI, so a failure is a reproducible
+ * finding rather than a dice roll; bump it **deliberately** to explore new samples.
+ * Unseeded breadth lives on the `-Ddashbuddy.propExplore=true` path ([PropSeeds]).
+ * NOTE the wall-clock budget in this property is machine-dependent by nature — the
+ * seed pins the INPUT trees, not the timing.
  */
 class ClassifyGateCaptureFuzzTest {
+
+    private companion object {
+        /** #878 pinned seed — pins PR CI. Bump deliberately to explore new samples. */
+        const val SEED = 0x0590_0009L
+    }
 
     private val pkg = "com.doordash.driverapp"
 
@@ -129,7 +139,7 @@ class ClassifyGateCaptureFuzzTest {
 
     @Test
     fun `property - adversarial trees never crash classify or capture, stay time-bounded, and never leak an UNKNOWN sensitive frame`() = runTest {
-        checkAll(200, treeArb) { tree ->
+        checkAll(PropSeeds.samples(200), PropSeeds.config(SEED), treeArb) { tree ->
             val bus = RecordingBus()
             val writer = CaptureWriter(bus, PipelineStats(), noRedaction)
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/PropSeeds.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/PropSeeds.kt
@@ -1,0 +1,42 @@
+package cloud.trotter.dashbuddy.test.util
+
+import io.kotest.common.ExperimentalKotest
+import io.kotest.property.PropTestConfig
+
+/**
+ * #878 — determinism control for the `:app` half of the #590 property/fuzz suite.
+ *
+ * **Mirror of `cloud.trotter.dashbuddy.core.pipeline.PropSeeds`, which is authoritative.**
+ * Duplicated by choice: there is no test-source dependency edge from `:app`'s test
+ * compilation to `:core:pipeline`'s, and standing up `testFixtures` for one 20-line
+ * object costs more build surface than the copy costs. Change the `:core:pipeline` copy
+ * first, then mirror it here.
+ *
+ * Rationale in full lives on that copy. In short: every property pins a seed so PR CI is
+ * deterministic and a failure is a reproducible finding rather than a dice roll; bump a
+ * seed deliberately to explore new samples; `-Ddashbuddy.propExplore=true` restores
+ * unseeded exploration at [EXPLORE_FACTOR]× the sample count off the PR path.
+ */
+internal object PropSeeds {
+
+    /** `-D` flag that swaps pinned determinism for unseeded exploration. */
+    const val EXPLORE_PROPERTY = "dashbuddy.propExplore"
+
+    /** Sample-count multiplier applied in exploration mode. */
+    private const val EXPLORE_FACTOR = 10
+
+    /** True when [EXPLORE_PROPERTY] is set to anything other than `false`/`0`/empty. */
+    val exploring: Boolean = System.getProperty(EXPLORE_PROPERTY)
+        ?.lowercase()
+        ?.let { it.isNotEmpty() && it != "false" && it != "0" } ?: false
+
+    /** Pinned sample count on PR CI; [EXPLORE_FACTOR]× that under exploration. */
+    fun samples(pinned: Int): Int = if (exploring) pinned * EXPLORE_FACTOR else pinned
+
+    /** Pinned [seed] on PR CI (deterministic); unseeded under exploration. */
+    // PropTestConfig's `constraints`/`maxDiscardPercentage` defaults are @ExperimentalKotest
+    // in 5.9.1; we touch neither, but constructing the class needs the opt-in.
+    @OptIn(ExperimentalKotest::class)
+    fun config(seed: Long): PropTestConfig =
+        if (exploring) PropTestConfig(seed = null) else PropTestConfig(seed = seed)
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScannerParityTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScannerParityTest.kt
@@ -42,8 +42,17 @@ import org.junit.Test
  * `SensitiveTextMarkers.findMarker` (not by duplicating its list), keeping the
  * scanner-specific EXTRA pin/gate corpus-gate shapes on top. Delegation is what makes
  * a future marker addition impossible to diverge.
+ *
+ * **Determinism (#878).** The seed below pins PR CI, so a failure is a reproducible
+ * finding rather than a dice roll; bump it **deliberately** to explore new samples.
+ * Unseeded breadth lives on the `-Ddashbuddy.propExplore=true` path ([PropSeeds]).
  */
 class SnapshotSecurityScannerParityTest {
+
+    private companion object {
+        /** #878 pinned seed — pins PR CI. Bump deliberately to explore new samples. */
+        const val SEED = 0x0590_000AL
+    }
 
     // Representative spread of production markers + the two shapes findMarker owns.
     private val toxicTokens: List<String> = listOf(
@@ -108,7 +117,7 @@ class SnapshotSecurityScannerParityTest {
 
     @Test
     fun `property - scanner catches everything the production backstop catches`() = runTest {
-        checkAll(600, treeArb) { tree ->
+        checkAll(PropSeeds.samples(600), PropSeeds.config(SEED), treeArb) { tree ->
             val markerHit = SensitiveTextMarkers.findMarker(tree)
             if (markerHit != null) {
                 assertTrue(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,5 +40,15 @@ subprojects {
         // "Sharing is only supported for boot loader classes" notice — turn CDS off
         // for test workers rather than ship a permanent noise line.
         jvmArgs("-Xshare:off")
+
+        // #878 — the #590 property/fuzz suite pins a seed per property so PR CI is
+        // deterministic (a failure is a reproducible finding, not a dice roll).
+        // `-Ddashbuddy.propExplore=true` flips every property back to unseeded
+        // generation at 10x the sample count — the exploration path that keeps breadth
+        // OFF the PR path. Gradle passes -D to the daemon, not to the forked test
+        // worker, so forward it explicitly. Opt-in only: absent the flag, nothing
+        // changes. See `PropSeeds` in :core:pipeline's test source set.
+        providers.systemProperty("dashbuddy.propExplore").orNull
+            ?.let { systemProperty("dashbuddy.propExplore", it) }
     }
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/PropSeeds.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/PropSeeds.kt
@@ -1,0 +1,76 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import io.kotest.common.ExperimentalKotest
+import io.kotest.property.PropTestConfig
+
+/**
+ * #878 — determinism control for the #590 security property/fuzz suite.
+ *
+ * **Why.** `TransformFuzzFailClosedTest` failed ONCE on CI (PR #869's first run) on a
+ * diff that does not touch `:core:pipeline`, and 25 consecutive local runs (10 000
+ * samples) could not reproduce it. Because the property was unseeded and the failure
+ * output was not retained, the counterexample is **gone** — the fuzzer found something
+ * and we cannot see it. An un-diagnosable flake in a *security* property suite is the
+ * worst outcome available: it trains everyone to re-run past real findings.
+ *
+ * **The fix.** Every property in the suite pins an explicit seed, so PR CI draws the
+ * same samples on every run — a failure is a real, reproducible finding, never a dice
+ * roll. Bump a site's seed **deliberately** (a one-line, reviewable diff) when you want
+ * that property to explore a new region; do not bump it to make a red test go green.
+ *
+ * **Breadth is not lost.** Seeding narrows PR CI to one fixed sample set, so the
+ * exploration that found the #869 counterexample has to live somewhere. It lives here:
+ * running with `-Ddashbuddy.propExplore=true` flips EVERY property back to unseeded
+ * generation at [EXPLORE_FACTOR]× the pinned sample count.
+ *
+ * ```
+ * # PR-CI shape (default): pinned seeds, pinned sample counts, fully deterministic
+ * ./gradlew :core:pipeline:testDebugUnitTest
+ *
+ * # Exploration shape (nightly / manual): unseeded, EXPLORE_FACTOR x the samples
+ * ./gradlew :core:pipeline:testDebugUnitTest :app:testDebugUnitTest \
+ *     -Ddashbuddy.propExplore=true
+ * ```
+ *
+ * A failure in EITHER shape prints the shrunken counterexample and the line
+ * `Repeat this test by using seed <N>` — in exploration mode that seed is the thing to
+ * paste into the failing site's [config] call, which converts a one-off finding into a
+ * permanent regression pin.
+ *
+ * Gradle passes `-D` to the daemon, not to the forked test worker; the root
+ * `build.gradle.kts` forwards [EXPLORE_PROPERTY] explicitly.
+ *
+ * **Duplication, by choice.** An identical copy lives in `:app`'s test source set
+ * (`cloud.trotter.dashbuddy.test.util.PropSeeds`) because there is no test-source
+ * dependency edge between the two modules and wiring `testFixtures` for one 20-line
+ * object is not worth the build-graph surface. THIS copy is authoritative — change it
+ * first, then mirror.
+ */
+internal object PropSeeds {
+
+    /** `-D` flag that swaps pinned determinism for unseeded exploration. */
+    const val EXPLORE_PROPERTY = "dashbuddy.propExplore"
+
+    /** Sample-count multiplier applied in exploration mode. */
+    private const val EXPLORE_FACTOR = 10
+
+    /** True when [EXPLORE_PROPERTY] is set to anything other than `false`/`0`/empty. */
+    val exploring: Boolean = System.getProperty(EXPLORE_PROPERTY)
+        ?.lowercase()
+        ?.let { it.isNotEmpty() && it != "false" && it != "0" } ?: false
+
+    /** Pinned sample count on PR CI; [EXPLORE_FACTOR]× that under exploration. */
+    fun samples(pinned: Int): Int = if (exploring) pinned * EXPLORE_FACTOR else pinned
+
+    /**
+     * Pinned [seed] on PR CI (deterministic); unseeded under exploration.
+     *
+     * Seeds are literal and per-site so a failure names exactly one property, and so
+     * re-seeding one property never silently re-rolls the others.
+     */
+    // PropTestConfig's `constraints`/`maxDiscardPercentage` defaults are @ExperimentalKotest
+    // in 5.9.1; we touch neither, but constructing the class needs the opt-in.
+    @OptIn(ExperimentalKotest::class)
+    fun config(seed: Long): PropTestConfig =
+        if (exploring) PropTestConfig(seed = null) else PropTestConfig(seed = seed)
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveMarkerEvasionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveMarkerEvasionTest.kt
@@ -37,8 +37,17 @@ import org.junit.Test
  * Documented out-of-scope residuals (see the bottom of this file) are asserted as
  * residuals, not detections, so a future hardening that closes them is a visible
  * behaviour change.
+ *
+ * **Determinism (#878).** The seed below pins PR CI, so a failure is a reproducible
+ * finding rather than a dice roll; bump it **deliberately** to explore new samples.
+ * Unseeded breadth lives on the `-Ddashbuddy.propExplore=true` path ([PropSeeds]).
  */
 class SensitiveMarkerEvasionTest {
+
+    private companion object {
+        /** #878 pinned seed — pins PR CI. Bump deliberately to explore new samples. */
+        const val SEED = 0x0590_0008L
+    }
 
     // ---- Seed toxic markers to mutate (a representative spread) -----------------
     // Multi-word (space-bearing) keywords, a single-word keyword, and the two shapes.
@@ -176,11 +185,12 @@ class SensitiveMarkerEvasionTest {
 
     @Test
     fun `property - any composition of homoglyph-whitespace mutations still detects a keyword`() = runTest {
-        val seed = Arb.element(keywordSeeds)
+        // Named `keywordArb`, not `seed` — the pinned PRNG seed is [SEED] (#878).
+        val keywordArb = Arb.element(keywordSeeds)
         val mut = Arb.element<(String) -> String>(
             ::nbsp, ::narrowNbsp, ::zeroWidth, ::fullwidth, ::altCase,
         )
-        checkAll(200, seed, mut, mut) { s, m1, m2 ->
+        checkAll(PropSeeds.samples(200), PropSeeds.config(SEED), keywordArb, mut, mut) { s, m1, m2 ->
             val mutated = m2(m1(s))
             assertDetected("composed", s, tree(mutated))
         }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapperPropertyTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapperPropertyTest.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.core.pipeline.accessibility.mapper
 
 import android.view.accessibility.AccessibilityNodeInfo
+import cloud.trotter.dashbuddy.core.pipeline.PropSeeds
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import io.kotest.property.Arb
 import io.kotest.property.RandomSource
@@ -44,10 +45,23 @@ import java.util.concurrent.atomic.AtomicInteger
  *
  * Pinned to SDK 36: the mapper reads the tri-state `getChecked():int` (API 36) and
  * `getStateDescription()` (API 30), so the Robolectric shadow must supply both.
+ *
+ * **Determinism (#878).** The seed below pins PR CI, so a failure is a reproducible
+ * finding rather than a dice roll; bump it **deliberately** to explore new samples.
+ * Unseeded breadth lives on the `-Ddashbuddy.propExplore=true` path ([PropSeeds]).
+ * The generated case is a graph of Mockito mocks, whose `toString` is opaque
+ * (`Mock for AccessibilityNodeInfo, hashCode: …`), so [TreeCase] carries a structural
+ * label (materialized node count / deepest level / oversized-text count) — that label
+ * plus the reported seed is what makes a CI failure actionable.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [36])
 class AccessibilityNodeMapperPropertyTest {
+
+    private companion object {
+        /** #878 pinned seed — pins PR CI. Bump deliberately to explore new samples. */
+        const val SEED = 0x0590_0006L
+    }
 
     // ---- Mock AccessibilityNodeInfo factory (counts getChild IPC) ---------------
 
@@ -175,32 +189,69 @@ class AccessibilityNodeMapperPropertyTest {
         else -> "node-${rs.random.nextInt(1000)}"
     }
 
+    /**
+     * Structural label for a generated case, accumulated at BUILD time (#878).
+     *
+     * A Mockito mock renders as `Mock for AccessibilityNodeInfo, hashCode: 1234`, so a
+     * failing sample would otherwise print nothing a human can act on — and re-walking
+     * the tree to describe it would issue `getChild` IPC and corrupt the very counter
+     * the property asserts on. So the shape is recorded as it is generated.
+     */
+    private class Shape {
+        var nodes = 0
+        var deepestLevel = 0
+        var oversizedTexts = 0
+        override fun toString(): String =
+            "nodes=$nodes, deepestLevel=$deepestLevel, oversizedTexts=$oversizedTexts"
+    }
+
     /** Eager bounded mock tree: depth ≤ [maxDepth], total nodes ≤ [budget]. */
-    private fun buildTree(rs: RandomSource, maxDepth: Int, budget: IntArray, ipc: AtomicInteger): AccessibilityNodeInfo {
+    private fun buildTree(
+        rs: RandomSource,
+        maxDepth: Int,
+        budget: IntArray,
+        ipc: AtomicInteger,
+        shape: Shape,
+        level: Int = 0,
+    ): AccessibilityNodeInfo {
         budget[0]--
+        shape.nodes++
+        if (level > shape.deepestLevel) shape.deepestLevel = level
         val childCount = if (maxDepth <= 0 || budget[0] <= 0) 0 else rs.random.nextInt(4)
         val children = (0 until childCount).mapNotNull {
-            if (budget[0] <= 0) null else buildTree(rs, maxDepth - 1, budget, ipc)
+            if (budget[0] <= 0) null else buildTree(rs, maxDepth - 1, budget, ipc, shape, level + 1)
         }
-        return node(ipc, children = children, text = textArb(rs), desc = textArb(rs))
+        val text = textArb(rs)
+        val desc = textArb(rs)
+        if ((text?.length ?: 0) > TreeBudget.MAX_TEXT_LENGTH) shape.oversizedTexts++
+        if ((desc?.length ?: 0) > TreeBudget.MAX_TEXT_LENGTH) shape.oversizedTexts++
+        return node(ipc, children = children, text = text, desc = desc)
     }
 
     /** One generated case: the mock root + the IPC counter it increments. */
-    private class TreeCase(val root: AccessibilityNodeInfo, val ipc: AtomicInteger)
+    private class TreeCase(
+        val root: AccessibilityNodeInfo,
+        val ipc: AtomicInteger,
+        private val shape: Shape,
+    ) {
+        /** #878 — what a CI failure prints instead of a mock's opaque identity hash. */
+        override fun toString(): String = "TreeCase($shape)"
+    }
 
     private val treeArb: Arb<TreeCase> = arbitrary { rs ->
         // depth up to 75 (exceeds MAX_TREE_DEPTH=60), materialization budget 120 —
         // kept lean so the Mockito-inline mock graph doesn't pressure the shared worker.
         val ipc = AtomicInteger(0)
-        val root = buildTree(rs, maxDepth = 75, budget = intArrayOf(120), ipc = ipc)
-        TreeCase(root, ipc)
+        val shape = Shape()
+        val root = buildTree(rs, maxDepth = 75, budget = intArrayOf(120), ipc = ipc, shape = shape)
+        TreeCase(root, ipc, shape)
     }
 
     // ---- Property: any generated tree stays within every cap, never throws ------
 
     @Test
     fun `property - generated trees stay within depth-node-text caps, bound IPC, never throw`() = runTest {
-        checkAll(200, treeArb) { case ->
+        checkAll(PropSeeds.samples(200), PropSeeds.config(SEED), treeArb) { case ->
             val mapped = case.root.toUiNode()   // must not throw
             assertWithinCaps(mapped)
             assertTrue(

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationMapperTotalityTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationMapperTotalityTest.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.core.pipeline.notification
 import android.app.Notification
 import android.os.Bundle
 import android.service.notification.StatusBarNotification
+import cloud.trotter.dashbuddy.core.pipeline.PropSeeds
 import cloud.trotter.dashbuddy.core.pipeline.notification.mapper.toDomain
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.element
@@ -36,8 +37,17 @@ import org.mockito.kotlin.mock
  * the catch was added). Fix: the mapping is wrapped to return null on any
  * exception (the pipeline's `mapNotNull` drops it) + one PII-free WARN — so one
  * bad notification is dropped and the flow keeps emitting.
+ *
+ * **Determinism (#878).** The seed below pins PR CI, so a failure is a reproducible
+ * finding rather than a dice roll; bump it **deliberately** to explore new samples.
+ * Unseeded breadth lives on the `-Ddashbuddy.propExplore=true` path ([PropSeeds]).
  */
 class NotificationMapperTotalityTest {
+
+    private companion object {
+        /** #878 pinned seed — pins PR CI. Bump deliberately to explore new samples. */
+        const val SEED = 0x0590_0007L
+    }
 
     /** A [StatusBarNotification] whose `notification` and `packageName` are stubbed. */
     private fun sbn(notification: Notification, pkg: String = "com.doordash.driverapp"): StatusBarNotification =
@@ -87,7 +97,11 @@ class NotificationMapperTotalityTest {
 
     @Test
     fun `property - a throw on any single extras key never escapes`() = runTest {
-        checkAll(50, Arb.element("android.title", "android.text", "android.bigText", "android.subText")) { key ->
+        checkAll(
+            PropSeeds.samples(50),
+            PropSeeds.config(SEED),
+            Arb.element("android.title", "android.text", "android.bigText", "android.subText"),
+        ) { key ->
             val bundle: Bundle = mock {
                 on { getCharSequence(key) } doThrow RuntimeException("boom on $key")
             }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/EachAmplificationBoundedTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/EachAmplificationBoundedTest.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.pipeline.rules
 
+import cloud.trotter.dashbuddy.core.pipeline.PropSeeds
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
@@ -25,9 +26,18 @@ import org.junit.Test
  * bounded tree, by the tree itself) — never `tree_width ^ depth` — and completes
  * well within a wall-clock budget.
  *
- * A failing property prints its seed; pin it with `PropTestConfig(seed = ...)`.
+ * **Determinism (#878).** The seed below pins the generated `width`/`depth` samples on
+ * PR CI; bump it **deliberately** to explore new samples, and use
+ * `-Ddashbuddy.propExplore=true` ([PropSeeds]) for unseeded breadth. NOTE the wall-clock
+ * assertion in this property is machine-dependent by nature — the seed pins the INPUTS,
+ * not the timing.
  */
 class EachAmplificationBoundedTest {
+
+    private companion object {
+        /** #878 pinned seed — pins PR CI. Bump deliberately to explore new samples. */
+        const val SEED = 0x0590_0005L
+    }
 
     /** Mirror of the private RuleCompiler.MAX_EACH_SIZE, referenced in the bound. */
     private val maxEach = 50
@@ -89,7 +99,7 @@ class EachAmplificationBoundedTest {
     fun `property - nested each on a wide tree stays within the MAX_EACH_SIZE-derived bound and time budget`() = runTest {
         // width up to 40 → up to ~1600 id-less nodes; depth 1..3. Naive tree_width^depth
         // would be up to 40^3 = 64 000 *per outer node*; the cap must hold it far below.
-        checkAll(120, Arb.int(2, 40), Arb.int(1, 3)) { width, depth ->
+        checkAll(PropSeeds.samples(120), PropSeeds.config(SEED), Arb.int(2, 40), Arb.int(1, 3)) { width, depth ->
             val ruleset = Ruleset(RuleCompiler.compileRules<UiNode>(nestedEachRule(depth), RuleContext.SCREEN))
             val tree = bushyTree(width)
 

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RegexBudgetPropertyTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RegexBudgetPropertyTest.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.pipeline.rules
 
+import cloud.trotter.dashbuddy.core.pipeline.PropSeeds
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.element
 import io.kotest.property.arbitrary.list
@@ -29,9 +30,16 @@ import java.util.concurrent.TimeoutException
  * StackOverflowError catch, fail-closed no-match); the same patterns then return
  * in single-digit ms.
  *
- * A failing property prints its seed; pin it with `PropTestConfig(seed = ...)`.
+ * **Determinism (#878).** The seed below pins PR CI, so a failure is a reproducible
+ * finding rather than a dice roll; bump it **deliberately** to explore new samples.
+ * Unseeded breadth lives on the `-Ddashbuddy.propExplore=true` path ([PropSeeds]).
  */
 class RegexBudgetPropertyTest {
+
+    private companion object {
+        /** #878 pinned seed — pins PR CI. Bump deliberately to explore new samples. */
+        const val SEED = 0x0590_0002L
+    }
 
     private val catalog = listOf("(a|aa)+$", "(\\w+)\\1+", "(a?)*b", "(.*a){20}")
 
@@ -90,7 +98,8 @@ class RegexBudgetPropertyTest {
     fun `property - every accepted generated pattern bounds its match`() = runTest {
         val piece = Arb.element(0, 1) // 0 = unit, 1 = group
         checkAll(
-            200,
+            PropSeeds.samples(200),
+            PropSeeds.config(SEED),
             Arb.list(piece, 1..3),
             unit, group, Arb.element("", "$"),
         ) { shape, u, g, anchor ->

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompileRecursionPropertyTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompileRecursionPropertyTest.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.pipeline.rules
 
+import cloud.trotter.dashbuddy.core.pipeline.PropSeeds
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.element
 import io.kotest.property.arbitrary.int
@@ -31,10 +32,19 @@ import org.junit.Test
  * [RuleCompiler.parseBoundedJson]/[RuleCompiler.MAX_JSON_DEPTH] (raw-JSON depth
  * pre-scan before the recursive parser).
  *
- * A failing property prints its seed; pin it with `PropTestConfig(seed = ...)`
- * to reproduce.
+ * **Determinism (#878).** The seeds below pin PR CI, so a failure is a reproducible
+ * finding rather than a dice roll; bump one **deliberately** to explore new samples.
+ * Unseeded breadth lives on the `-Ddashbuddy.propExplore=true` path ([PropSeeds]).
  */
 class RuleCompileRecursionPropertyTest {
+
+    private companion object {
+        /** #878 pinned seed (parse-expression depth). Bump deliberately to explore. */
+        const val SEED_PARSE_DEPTH = 0x0590_0003L
+
+        /** #878 pinned seed (raw-JSON depth). Bump deliberately to explore. */
+        const val SEED_JSON_DEPTH = 0x0590_0004L
+    }
 
     /** parse.fields.x = <verb> -> <verb> -> ... -> "lit", [depth] levels deep. */
     private fun nestedParseRule(depth: Int, verb: String): JsonArray {
@@ -106,14 +116,14 @@ class RuleCompileRecursionPropertyTest {
         val verbs = Arb.element("coalesce", "join", "each")
         // Straddle MAX_PARSE_DEPTH (64) and go far past it into stack-overflow
         // territory pre-fix.
-        checkAll(200, Arb.int(1, 5_000), verbs) { depth, verb ->
+        checkAll(PropSeeds.samples(200), PropSeeds.config(SEED_PARSE_DEPTH), Arb.int(1, 5_000), verbs) { depth, verb ->
             assertTrue(compileIsFailClosed(nestedParseRule(depth, verb)))
         }
     }
 
     @Test
     fun `property - arbitrary raw-JSON depth is always fail-closed`() = runTest {
-        checkAll(200, Arb.int(1, 5_000)) { depth ->
+        checkAll(PropSeeds.samples(200), PropSeeds.config(SEED_JSON_DEPTH), Arb.int(1, 5_000)) { depth ->
             val json = "[".repeat(depth) + "]".repeat(depth)
             assertTrue(parseIsFailClosed(json))
         }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformFuzzFailClosedTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformFuzzFailClosedTest.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.pipeline.rules
 
+import cloud.trotter.dashbuddy.core.pipeline.PropSeeds
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.element
@@ -35,9 +36,20 @@ import org.junit.Test
  *     replacement between every char — bounded by the rule-authored, compile-bounded
  *     replacement length).
  *
- * A failing property prints its seed; pin it with `PropTestConfig(seed = ...)`.
+ * **Determinism (#878).** This is THE property that failed once on CI (PR #869's first
+ * run) and could not be reproduced in 10 000 local samples — unseeded, so the
+ * counterexample was lost. The seed below pins PR CI to one fixed sample set: a failure
+ * here is now a reproducible finding, not a dice roll. Bump the seed **deliberately** to
+ * explore new samples (a reviewable one-line diff) — never to turn a red run green. The
+ * unseeded breadth lives on the `-Ddashbuddy.propExplore=true` path ([PropSeeds]); that
+ * is where the lost #869 counterexample would resurface. It is NOT recovered by seeding.
  */
 class TransformFuzzFailClosedTest {
+
+    private companion object {
+        /** #878 pinned seed — pins PR CI. Bump deliberately to explore new samples. */
+        const val SEED = 0x0590_0001L
+    }
 
     private val input = "Deliver to 123-45-6789 at 4111 1111 1111 1111 by 8:52 PM"
 
@@ -104,7 +116,7 @@ class TransformFuzzFailClosedTest {
 
     @Test
     fun `property - validate is typed-reject-or-ok and a validated spec never raw-throws at apply`() = runTest {
-        checkAll(400, specArb) { spec ->
+        checkAll(PropSeeds.samples(400), PropSeeds.config(SEED), specArb) { spec ->
             val validated = try {
                 TransformRegistry.validateTransformSpec(spec)
                 true


### PR DESCRIPTION
Closes #878.

`TransformFuzzFailClosedTest > property - validate is typed-reject-or-ok…` (`:core:pipeline`, the #590 phase-1 suite) failed **once** on CI — PR #869's first run, on a diff that does not touch `:core:pipeline` — and 25 consecutive local runs (10 000 samples) could not reproduce it. The property was **unseeded** and its failure output was not retained, so the counterexample is **gone**. An un-diagnosable flake in a *security* property suite is the worst outcome available: it trains everyone to re-run past real findings.

This PR makes the whole suite deterministic on the PR path and keeps the exploration that found the counterexample alive off it.

---

## 1. Census — every unseeded property test in the repo

Grepped `checkAll` / `forAll` / `PropTestConfig` across all modules. **10 `checkAll` sites in 9 files. All were unseeded. All are now pinned.** There are no `forAll` sites and no other kotest property entry points; `kotest-property` is declared only in `:app` and `:core:pipeline`.

| # | Module | File | Property | Samples | Pinned seed |
|---|---|---|---|---|---|
| 1 | `:core:pipeline` | `rules/TransformFuzzFailClosedTest.kt` | validate is typed-reject-or-ok; validated spec never raw-throws at apply | 400 | `0x0590_0001` |
| 2 | `:core:pipeline` | `rules/RegexBudgetPropertyTest.kt` | every accepted generated pattern bounds its match | 200 | `0x0590_0002` |
| 3 | `:core:pipeline` | `rules/RuleCompileRecursionPropertyTest.kt` | arbitrary parse-expression depth is always fail-closed | 200 | `0x0590_0003` |
| 4 | `:core:pipeline` | `rules/RuleCompileRecursionPropertyTest.kt` | arbitrary raw-JSON depth is always fail-closed | 200 | `0x0590_0004` |
| 5 | `:core:pipeline` | `rules/EachAmplificationBoundedTest.kt` | nested `each` on a wide tree stays within the MAX_EACH_SIZE bound | 120 | `0x0590_0005` |
| 6 | `:core:pipeline` | `accessibility/mapper/AccessibilityNodeMapperPropertyTest.kt` | generated trees stay within depth/node/text caps, bound IPC, never throw | 200 | `0x0590_0006` |
| 7 | `:core:pipeline` | `notification/NotificationMapperTotalityTest.kt` | a throw on any single extras key never escapes | 50 | `0x0590_0007` |
| 8 | `:core:pipeline` | `SensitiveMarkerEvasionTest.kt` | any composition of homoglyph/whitespace mutations still detects a keyword | 200 | `0x0590_0008` |
| 9 | `:app` | `replay/ClassifyGateCaptureFuzzTest.kt` | adversarial trees never crash classify/capture, stay time-bounded, never leak an UNKNOWN sensitive frame | 200 | `0x0590_0009` |
| 10 | `:app` | `test/util/SnapshotSecurityScannerParityTest.kt` | scanner catches everything the production backstop catches | 600 | `0x0590_000A` |

Seeds are `0x0590_00NN` — self-describing (`590` = the suite that owns them), per-site so a failure names exactly one property and re-seeding one never silently re-rolls the others. **Every seed was chosen by running it: all 10 pass today.**

## 2. How determinism is pinned

Each site now reads:

```kotlin
checkAll(PropSeeds.samples(400), PropSeeds.config(SEED), specArb) { spec -> … }
```

with a class-local `private companion object { const val SEED = 0x0590_0001L }` and a KDoc line on every affected class:

> **Determinism (#878).** The seed below pins PR CI, so a failure is a reproducible finding rather than a dice roll; bump it **deliberately** to explore new samples. Unseeded breadth lives on the `-Ddashbuddy.propExplore=true` path.

`PropSeeds` is a ~20-line test-only object. **Bump a seed deliberately** (a reviewable one-line diff) to move a property onto new samples — **never** to turn a red run green.

Kotest 5.9.1 note: constructing `PropTestConfig` trips `@ExperimentalKotest` (its `constraints`/`maxDiscardPercentage` defaults). We touch neither; the opt-in is site-local on `PropSeeds.config`, with a comment saying why — not a module-wide opt-out.

## 3. Diagnosability proof (deliberate break, then reverted)

Broke two properties on purpose, ran them, captured the real output, reverted both. **What a future CI failure now prints, verbatim from `TEST-*.xml`:**

```
java.lang.AssertionError: Property failed after 9 attempts

	Arg 0: "sha256"

Repeat this test by using seed 93323265

Caused by: validated transform output length 64 exceeded documented bound 1 for spec="sha256"
	at …TransformFuzzFailClosedTest.kt:119
```

`93323265` == `0x0590_0001` — kotest echoes back the **pinned** seed, so the report is self-identifying: paste it, re-run, get the identical sample.

Opaque-generator fix. `AccessibilityNodeMapperPropertyTest`'s sample is a graph of **Mockito mocks**, whose `toString` is `Mock for AccessibilityNodeInfo, hashCode: 1234` — a failure printed nothing a human could act on. `TreeCase` now carries a structural label **accumulated at build time** (re-walking the tree to describe it on failure would issue `getChild` IPC and corrupt the very counter the property asserts on):

```
java.lang.AssertionError: Property failed after 1 attempts

	Arg 0: TreeCase(nodes=120, deepestLevel=74, oversizedTexts=42)

Repeat this test by using seed 93323270

Caused by: getChild IPC 106 exceeds bound 0
```

All other generators already render readably and were left alone: `JsonElement` and `UiNode` are data-class/serializer-backed; the remaining args are `Int`/`String`/`List<Int>`; `SensitiveMarkerEvasionTest`'s mutation args are `KFunction` references that print their own names.

Two honest limits: (a) generators built with `arbitrary { rs -> … }` carry no shrinker, so the reported `Arg 0` is the **raw failing sample**, not a minimized one — still a full reproduction, just not the smallest one; (b) two properties (`EachAmplificationBoundedTest`, `ClassifyGateCaptureFuzzTest`) assert a wall-clock budget, which is machine-dependent by nature — the seed pins the **inputs**, not the timing. Both limits are noted in the affected KDocs.

## 4. Exploration path (built — it was cheap)

`-Ddashbuddy.propExplore=true` flips **every** property back to unseeded generation at **10× the pinned sample count**:

```bash
./gradlew :core:pipeline:testDebugUnitTest :app:testDebugUnitTest -Ddashbuddy.propExplore=true
```

Gradle passes `-D` to the daemon, not to the forked test worker, so the root `build.gradle.kts` forwards it explicitly inside the existing `subprojects { tasks.withType<Test> }` block. **Strictly opt-in** — absent the flag the provider is null and nothing is set, so PR CI is byte-identical to before this line existed. **No CI workflow changes.** A future nightly/scheduled job only has to add that one flag; the command is documented in CLAUDE.md § Build Commands.

Verified working (see §5): with the flag set, the reported seed is random per run instead of the pinned literal.

## 5. Determinism runs

**Whole `:core:pipeline` suite, 3× consecutive forced re-runs** (`--rerun-tasks`), identical every time:

```
run1 exit=0 classes=51 tests=443 failures=0 errors=0 skipped=0
run2 exit=0 classes=51 tests=443 failures=0 errors=0 skipped=0
run3 exit=0 classes=51 tests=443 failures=0 errors=0 skipped=0
```

A green run alone proves nothing about *sample identity*, so the sharper receipt — the deliberately-broken `TransformFuzzFailClosedTest`, 3× pinned then 3× explore:

```
PINNED  run1 :: Property failed after 9 attempts :: seed 93323265
PINNED  run2 :: Property failed after 9 attempts :: seed 93323265
PINNED  run3 :: Property failed after 9 attempts :: seed 93323265
EXPLORE run1 :: Property failed after 4 attempts :: seed <random>
EXPLORE run2 :: Property failed after 3 attempts :: seed 2133637750804754125
EXPLORE run3 :: Property failed after 4 attempts :: seed <random>
```

Pinned mode: identical seed, identical attempt count, identical counterexample. Explore mode: different seed and different attempt count each run — the flag genuinely reaches the worker and genuinely un-pins. (The break was reverted; the diff contains no `TEMP BREAK`.)

Full CI-shaped run green: `./gradlew testDebugUnitTest :domain:test` → BUILD SUCCESSFUL.

## 6. What this does NOT do

**The original #869 counterexample is not recovered.** It is gone — no seed, no retained output. The property may still have a real hole: some input on which `validateTransformSpec`/`applyAny` violates fail-closed, which the pinned 400-sample set does not happen to draw.

What changes is that the **next** failure is a reproducible finding rather than something a re-run makes disappear, and the `-Ddashbuddy.propExplore=true` path is where the original class of finding would resurface — at which point the printed seed goes straight into that property's `SEED` const and the one-off becomes a permanent regression pin.

Follow-up worth considering (not in scope here): a scheduled workflow running the exploration flag nightly. Deliberately left out — the instruction was no CI workflow changes beyond the opt-in flag read.

---

### Design-goal review

- **3. Clean code / single responsibility.** One ~20-line `PropSeeds` object with exactly two functions; no test file grew a second concern. The only structural edit is `AccessibilityNodeMapperPropertyTest`'s `Shape`, which exists solely to make a failure legible.
- **4. Kotlin/Android best practices.** Idiomatic: named constants over magic numbers, site-local `@OptIn` with a justifying comment rather than a module-wide experimental opt-out, `providers.systemProperty(...)` (configuration-cache-friendly) rather than a raw `System.getProperty` at configuration time. Survives the repo's `allWarningsAsErrors` gate.
- **5. SSOT.** ⚠️ **Declared duplication.** `PropSeeds` exists twice — `:core:pipeline`'s test source set (authoritative) and `:app`'s (mirror) — because there is **no test-source dependency edge** between the two module test compilations. The alternative was standing up `testFixtures` on an AGP library module with Hilt/KSP for one 20-line object; that build-graph surface costs more than the copy. Both copies say so in their KDoc and name the authoritative one, matching the repo's existing "duplicated by choice, one copy authoritative" pattern (#99 `common_content_desc_back`, #854 `@color/white`). Divergence risk is low and non-behavioural (the seeds themselves are per-site and unique).
- **6. Security & privacy first.** This is the #590 security suite's own infrastructure, and it strengthens it: an un-diagnosable flake in a fail-closed property suite is a *privacy/security* defect in the process, because the observed behaviour is "re-run and move on". No production code, no recognition, no capture, no network, no effects touched — the diff is test source + one opt-in Gradle line + docs. No PII enters the new label: `TreeCase`'s label is counts only (`nodes` / `deepestLevel` / `oversizedTexts`), never node text; the generated trees are synthetic in the first place. Nothing weakens or narrows an existing fail-closed assertion — every property still asserts exactly what it asserted before, over a fixed rather than a random sample set. The *narrowing* that seeding does cause (one fixed sample set per PR) is explicitly compensated by the exploration path rather than silently accepted.
- **7. Semantic, PII-safe logging.** No log sites added or moved.
- **8. Platform-agnostic core.** The diff touches `:core:pipeline` test sources, so the check applies: **no** platform literals introduced in logic. `ClassifyGateCaptureFuzzTest`'s pre-existing `pkg = "com.doordash.driverapp"` fixture constant is untouched (it is generator fixture data, not gating logic).
- Principles 1 (UDF) and 2 (MAD) are not touched by a test-determinism diff. No UI, so the Reactive UI rules do not apply.
- **Context updates.** CLAUDE.md updated in-PR (§ Build Commands gains the exploration command; the adversarial-review § records that the #590 suite is seeded and that a `SEED` bump is deliberate, never a red-to-green move).
