### PR TITLE
feat(bubble): #867 display-side — platform labels + manual dash switcher + session-presentation modes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,13 +139,21 @@ and `DashboardView` carved out of `BubbleScreen.kt` into `BubbleDashboardView.kt
 data-in/lambdas-out renderers of `:domain` types + the bubble-only `ui/formatters/*` — no Hilt,
 no `:core:data`/`:core:state`. The `BubbleActivity` (manifest host), `BubbleScreen` (nav host —
 `MainActivity`/`Screen` route table), `BubbleManager` (`OfferActionReceiver` + notification
-plumbing), and `BubbleViewModel` (injects `BubbleManager` → moving it needs an inversion, declined
-per the honest-smaller-module doctrine, same as `DashboardViewModel`) all stay in `:app`, which
+plumbing), and `BubbleViewModel` (injects the `:core:data`/`:core:state` repositories +
+`StateManagerV2`, which `:feature:bubble` does not and should not depend on — moving it would need
+an inversion the honest-smaller-module doctrine declines, same as `DashboardViewModel`; #867 dropped
+its former `BubbleManager` injection when session identity moved to a single `AppState`-derived
+resolution, but the `:core:*` deps keep it in `:app` regardless) all stay in `:app`, which
 consumes the moved formatters/gauge/renderers as a legal `:app → :feature` dependency. The bubble
-`flow_card_*`/`bubble_mode_idle_*`/`bubble_status_*`/`bubble_chat_*` strings + the `ic_badge_*`/
+`flow_card_*`/`bubble_mode_idle_*`/`bubble_status_*`/`bubble_chat_*`/`bubble_switcher_*` strings +
+the `ic_badge_*`/
 `ic_chat_*` badge/chat drawables moved clean (disjoint from every stayed consumer); `@color/white`
 is duplicated by choice into the module — multi-consumer with :app-remaining drawables, `:app` copy
-authoritative — the #854 pattern.) **Remaining Phase-6 extractions: none — Phase 6 complete.**
+authoritative — the #854 pattern. #867 added the module's `session/*` — the pure
+`BubbleSessionResolver` (which dash the HUD shows: follow-active + a manual switcher / pinned /
+merged, a Dev-settings experiment switch) and the stateless `PlatformSwitcherRow` — plus
+`cards/CardStackAssembler` (the merged interleave + the per-card platform-chip map); still no
+Hilt/`:core:data`/`:core:state`.) **Remaining Phase-6 extractions: none — Phase 6 complete.**
 
 - **`:domain`** — Pure Kotlin library. Domain models, state regions, evaluation logic,
   pipeline/provider contracts, the capture contracts (`CaptureBus`, `EnvelopeBuilder`,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.feature.bubble.ChatHeaderTitle
 import cloud.trotter.dashbuddy.feature.bubble.DashboardView
 import cloud.trotter.dashbuddy.feature.bubble.FullChatView
 import cloud.trotter.dashbuddy.feature.bubble.SessionMetricsActions
@@ -50,7 +51,10 @@ fun BubbleScreen(
     val gasPrice by viewModel.gasPrice.collectAsStateWithLifecycle()
     val isGasPriceAuto by viewModel.isGasPriceAuto.collectAsStateWithLifecycle()
     val isGasPriceRefreshing by viewModel.isGasPriceRefreshing.collectAsStateWithLifecycle()
-    val cardStack by viewModel.cardStack.collectAsStateWithLifecycle()
+    val cards by viewModel.cards.collectAsStateWithLifecycle()
+    // #867 multi-app: which dash the surface is scoped to, and the switcher that re-scopes it.
+    val switchablePlatforms by viewModel.switchablePlatforms.collectAsStateWithLifecycle()
+    val displayedPlatformLabel by viewModel.displayedPlatformLabel.collectAsStateWithLifecycle()
     var showFullChat by remember { mutableStateOf(false) }
 
     // Collapse the bubble to its head after the user acts on an offer.
@@ -84,7 +88,12 @@ fun BubbleScreen(
             TopAppBar(
                 title = {
                     if (showFullChat) {
-                        Text(stringResource(R.string.bubble_screen_chat_history_title))
+                        // #867: the chat is per-session, so while two dashes are live the header
+                        // names whose chat this is (null label ⇒ nothing to disambiguate).
+                        ChatHeaderTitle(
+                            title = stringResource(R.string.bubble_screen_chat_history_title),
+                            platformLabel = displayedPlatformLabel,
+                        )
                     } else {
                         StatusBadgeTitle(
                             region = focusedRegion,
@@ -123,11 +132,14 @@ fun BubbleScreen(
                 FullChatView(messages)
             } else {
                 DashboardView(
-                    cardStack = cardStack,
+                    cardStack = cards.stack,
                     region = focusedRegion,
                     messages = messages,
                     lastSession = lastSession,
                     focusedPlatform = focusedPlatform,
+                    cardPlatformLabels = cards.platformLabels,
+                    switchablePlatforms = switchablePlatforms,
+                    onSelectPlatform = viewModel::selectPlatform,
                     gasPrice = gasPrice,
                     isGasPriceAuto = isGasPriceAuto,
                     isGasPriceRefreshing = isGasPriceRefreshing,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
@@ -8,18 +8,23 @@ import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
 import cloud.trotter.dashbuddy.core.data.fuel.FuelPriceRepository
 import cloud.trotter.dashbuddy.core.data.location.OdometerRepository
 import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
+import cloud.trotter.dashbuddy.core.data.settings.DevSettingsRepository
 import cloud.trotter.dashbuddy.core.designsystem.theme.DRIVING_GLANCE_MULTIPLIER
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
-import cloud.trotter.dashbuddy.domain.model.cards.CardStack
+import cloud.trotter.dashbuddy.domain.model.bubble.BubbleSessionMode
 import cloud.trotter.dashbuddy.domain.model.vehicle.FuelType
 import cloud.trotter.dashbuddy.domain.state.AppState
-import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.feature.bubble.cards.BubbleCards
+import cloud.trotter.dashbuddy.feature.bubble.cards.CardStackAssembler
 import cloud.trotter.dashbuddy.feature.bubble.cards.FlowCardMapper
 import cloud.trotter.dashbuddy.feature.bubble.cards.LiveCardBuilder
+import cloud.trotter.dashbuddy.feature.bubble.session.BubbleSessionPresentation
+import cloud.trotter.dashbuddy.feature.bubble.session.BubbleSessionResolver
+import cloud.trotter.dashbuddy.feature.bubble.session.LiveSession
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -40,7 +45,6 @@ import javax.inject.Inject
 
 @HiltViewModel
 class BubbleViewModel @Inject constructor(
-    private val bubbleManager: BubbleManager,
     private val chatRepository: ChatRepository,
     odometerRepository: OdometerRepository,
     private val stateManager: StateManagerV2,
@@ -48,6 +52,7 @@ class BubbleViewModel @Inject constructor(
     private val appPreferencesRepository: AppPreferencesRepository,
     private val fuelPriceRepository: FuelPriceRepository,
     analyticsRepository: AnalyticsRepository,
+    devSettingsRepository: DevSettingsRepository,
 ) : ViewModel() {
 
     // Current app state — drives the mode card in the HUD
@@ -61,13 +66,124 @@ class BubbleViewModel @Inject constructor(
         .map { enabled -> if (enabled) DRIVING_GLANCE_MULTIPLIER else 1f }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 1f)
 
-    // Which platform the bubble is currently showing
-    val focusedPlatform = stateManager.state
+    // ---------------------------------------------------------------------------------------
+    // #867 — WHICH dash the bubble is showing (multi-app session presentation)
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * The dev-settings experiment switch, read reactively so flipping it re-scopes the live HUD
+     * with no restart. Fail-closed decode lives in the repository
+     * ([cloud.trotter.dashbuddy.core.data.settings.DevSettingsRepository.bubbleSessionMode]).
+     */
+    private val sessionMode = devSettingsRepository.bubbleSessionMode
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), BubbleSessionMode.Default)
+
+    /**
+     * The manual switcher's pick — pure UI state, deliberately **in-memory / session-lifetime**
+     * (not persisted, even in `PINNED` mode). It is a live-testing control over a surface that only
+     * exists while dashing; persisting it would let a forgotten pin silently re-scope a later dash,
+     * which is the exact class of defect #867 is about. Cleared to null when the picked platform's
+     * dash ends in `FOLLOW_ACTIVE` (the temporary pin); kept in `PINNED` so it re-takes effect on
+     * that platform's next dash. See [BubbleSessionMode] for the full semantics.
+     */
+    private val _selectedPlatform = MutableStateFlow<Platform?>(null)
+
+    /** The platform whose frame we last recognized — the base the presentation follows. */
+    private val followPlatform = stateManager.state
         .map { state ->
             state.regions.flow.activePlatform
                 ?: state.regions.crossPlatform.mostRecentActivityPlatform
         }
+        .distinctUntilChanged()
+
+    /** Every platform currently dashing (`PlatformRegion.session != null`), oldest dash first. */
+    private val liveSessions = stateManager.state
+        .map { state ->
+            state.regions.platforms
+                .mapNotNull { (platform, region) ->
+                    region.session?.let { LiveSession(platform, it.sessionId, it.startedAt) }
+                }
+                // Deterministic order: the switcher chip row and the merged interleave must not
+                // reshuffle on an unrelated state emission (Map iteration order is not a contract).
+                .sortedWith(compareBy({ it.startedAt }, { it.platform.name }))
+        }
+        .distinctUntilChanged()
+
+    /**
+     * The resolved presentation — the single owner of "what is the bubble showing" (#867).
+     *
+     * The durable most-recent session from the event log (#459) is the fallback when nothing is
+     * live: the old in-memory latch was wiped by process death AND by a post-dash bubble
+     * re-subscribe, emptying the chat/cards.
+     */
+    private val presentation = combine(
+        sessionMode,
+        _selectedPlatform,
+        followPlatform,
+        liveSessions,
+        appEventRepo.getMostRecentSessionId(),
+    ) { mode, selection, follow, live, mostRecent ->
+        BubbleSessionResolver.resolve(
+            mode = mode,
+            selection = selection,
+            followPlatform = follow,
+            liveSessions = live,
+            fallbackSessionId = mostRecent,
+        )
+    }
+        .distinctUntilChanged()
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5000),
+            BubbleSessionPresentation.Empty,
+        )
+
+    // Which platform the bubble is currently showing — the switcher's pick when one is in effect,
+    // otherwise the last-active platform (the pre-#867 behavior). Everything platform-scoped
+    // (status badge, mode cards, session earnings, chat, cards) hangs off this ONE value.
+    val focusedPlatform = presentation
+        .map { it.displayedPlatform }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    /** The switcher chip row's options; fewer than two ⇒ the row hides itself. */
+    val switchablePlatforms = presentation
+        .map { it.switchablePlatforms }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /**
+     * The displayed platform's badge for the chat header — non-null only while ≥2 dashes are live,
+     * which is when the identity is ambiguous. Same gate as the per-card chips.
+     */
+    val displayedPlatformLabel = presentation
+        .map { pres ->
+            pres.displayedPlatform?.shortName?.takeIf { pres.labelsVisible && it.isNotBlank() }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    /**
+     * The switcher intent (UDF: the UI dispatches, the ViewModel owns the state). Re-picking the
+     * platform already displayed clears the pin — a toggle back to plain follow-active.
+     */
+    fun selectPlatform(platform: Platform) {
+        _selectedPlatform.value = if (_selectedPlatform.value == platform) null else platform
+    }
+
+    init {
+        // The temporary-pin release (#867): in FOLLOW_ACTIVE a pick lasts only as long as the dash
+        // it points at, so when that platform goes offline the pin is DROPPED and the HUD follows
+        // again. PINNED keeps it (durable until the user switches); MERGED ignores it entirely.
+        viewModelScope.launch {
+            combine(sessionMode, liveSessions) { mode, live -> mode to live.map { it.platform } }
+                .collect { (mode, livePlatforms) ->
+                    val pinned = _selectedPlatform.value
+                    if (mode == BubbleSessionMode.FOLLOW_ACTIVE &&
+                        pinned != null && pinned !in livePlatforms
+                    ) {
+                        _selectedPlatform.value = null
+                    }
+                }
+        }
+    }
 
     // The focused platform's region — drives all mode composables
     val focusedRegion = combine(stateManager.state, focusedPlatform) { state, platform ->
@@ -96,55 +212,73 @@ class BubbleViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0.0)
 
 
-    // Messages scoped to the active dash session.
-    //
-    // Chat and cards key off the SAME displayed dash id (#367). The fallback
-    // when no dash is live is now the DURABLE most-recent dash from the event
-    // log (#459), not an in-memory scan latch: the old latch was wiped by
-    // process death AND by a post-dash bubble re-subscribe (>5s collapsed),
-    // emptying the chat/cards. The active dash wins while one is running; the
-    // DB fallback survives both restarts, so the bubble reviews the last dash
-    // until the next one starts (when activeSessionId takes over again).
-    private val displayedSessionId = combine(
-        bubbleManager.activeSessionId,
-        appEventRepo.getMostRecentSessionId(),
-    ) { active, mostRecent -> active ?: mostRecent }
-        .distinctUntilChanged()
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    val messages = displayedSessionId.flatMapLatest { dashId ->
-        if (dashId != null) {
-            chatRepository.getMessages(dashId)
-        } else {
-            flowOf(emptyList())
-        }
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
-
-    // Dash whose event log feeds the card stack — the current active dash
-    // when one is running, otherwise the most-recently-completed one so the
-
     /**
-     * Bubble HUD flow-card stack (#257). Completed cards are folded from
-     * the AppEvent log scoped to [displayedSessionId]; the live card is built
-     * from current [appState]. A new dash clears the stack via DASH_START's
-     * fold logic, so the user can review the previous dash's cards until
-     * they go Online again.
+     * Messages scoped to the DISPLAYED dash session (#867 — it was the *active* one).
+     *
+     * Chat and cards key off the SAME displayed dash id (#367): [presentation] resolves it once
+     * from the mode + the switcher pick + liveness, so a pin re-scopes both together. Chat never
+     * merges — even in `MERGED` mode it stays on one session (see [BubbleSessionResolver]) and the
+     * header badge names it.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    val cardStack = combine(
+    val messages = presentation
+        .map { it.chatSessionId }
+        .distinctUntilChanged()
+        .flatMapLatest { dashId ->
+            if (dashId != null) {
+                chatRepository.getMessages(dashId)
+            } else {
+                flowOf(emptyList())
+            }
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /**
+     * The folded completed cards for every displayed session — one list in the normal modes, N in
+     * `MERGED`. Each fold stays per-session because [FlowCardMapper.fold] is a per-session fold by
+     * construction (DASH_START clears the stack); the interleave happens after, in
+     * [CardStackAssembler].
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val foldedCards = presentation
+        .map { it.cardSources }
+        .distinctUntilChanged()
+        .flatMapLatest { sources ->
+            if (sources.isEmpty()) {
+                flowOf(emptyList())
+            } else {
+                combine(
+                    sources.map { source ->
+                        appEventRepo.getEventsForSession(source.sessionId)
+                            .map { events -> source to FlowCardMapper.fold(events) }
+                    }
+                ) { folds -> folds.toList() }
+            }
+        }
+
+    /**
+     * Bubble HUD flow-card stack (#257) + its per-card platform badges (#867). Completed cards are
+     * folded from the AppEvent log scoped to the displayed session(s); the live card is built from
+     * current [appState]. A new dash clears the stack via DASH_START's fold logic, so the user can
+     * review the previous dash's cards until they go Online again.
+     *
+     * The live card is dropped when the display is pinned away from the platform whose frame we
+     * last saw — the live card is derived from the global `FlowRegion`, which only ever describes
+     * that platform (see [BubbleSessionPresentation.showLiveCard]).
+     */
+    val cards = combine(
         stateManager.state,
-        displayedSessionId.flatMapLatest { dashId ->
-            if (dashId != null) appEventRepo.getEventsForSession(dashId)
-            else flowOf(emptyList())
-        },
-    ) { state, events ->
+        foldedCards,
+        presentation,
+    ) { state, folded, pres ->
         // CardStack.of drops a frozen completed card that duplicates the active
         // card's id — the at-door frozen+live overlap (#458).
-        CardStack.of(
-            completed = FlowCardMapper.fold(events),
-            active = LiveCardBuilder.build(state),
+        CardStackAssembler.assemble(
+            folded = folded,
+            activeCard = if (pres.showLiveCard) LiveCardBuilder.build(state) else null,
+            activePlatform = pres.followPlatform,
+            labelsVisible = pres.labelsVisible,
         )
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), CardStack.Empty)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), BubbleCards.Empty)
 
     // Real-time session miles from GPS odometer
     val sessionMiles = odometerRepository.sessionMilesFlow

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
@@ -6,24 +6,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.flow.MutableStateFlow
 import androidx.navigation.NavType
@@ -41,6 +30,7 @@ import cloud.trotter.dashbuddy.ui.main.settings.AboutScreen
 import cloud.trotter.dashbuddy.ui.main.settings.EconomySettingsScreen
 import cloud.trotter.dashbuddy.feature.settings.CapabilityConsentScreen
 import cloud.trotter.dashbuddy.feature.settings.DataExportScreen
+import cloud.trotter.dashbuddy.feature.settings.DeveloperSettingsScreen
 import cloud.trotter.dashbuddy.feature.settings.EvidenceSettingsScreen
 import cloud.trotter.dashbuddy.feature.settings.GeneralSettingsScreen
 import cloud.trotter.dashbuddy.feature.settings.PlatformSettingsScreen
@@ -48,7 +38,6 @@ import cloud.trotter.dashbuddy.ui.main.settings.SettingsHomeScreen
 import cloud.trotter.dashbuddy.feature.settings.StrategySettingsScreen
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.WizardScreen
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
-import cloud.trotter.dashbuddy.R
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -208,10 +197,9 @@ class MainActivity : ComponentActivity() {
                             )
                         }
 
-                        // 5. Developer Options
+                        // 5. Developer Options — the field-experiment switches (#867).
                         composable(Screen.DeveloperSettings.route) {
-                            PlaceholderScreen(
-                                title = stringResource(R.string.main_activity_developer_options_title),
+                            DeveloperSettingsScreen(
                                 onBack = { navController.popBackStack() }
                             )
                         }
@@ -256,42 +244,5 @@ class MainActivity : ComponentActivity() {
                 )
                 putExtra(EXTRA_ROUTE, route)
             }
-    }
-}
-
-/**
- * A temporary placeholder to prevent compile errors for screens
- * you haven't built yet (General & Developer).
- */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun PlaceholderScreen(title: String, onBack: () -> Unit) {
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text(title) },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.common_content_desc_back),
-                        )
-                    }
-                }
-            )
-        }
-    ) { padding ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                text = stringResource(R.string.main_activity_placeholder_construction),
-                style = MaterialTheme.typography.headlineSmall,
-                color = MaterialTheme.colorScheme.secondary
-            )
-        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,7 +210,6 @@
 
     <!-- main/MainActivity.kt -->
     <string name="main_activity_developer_options_title">Developer Options</string>
-    <string name="main_activity_placeholder_construction">Construction Area 🚧\nComing Soon</string>
 
     <!-- setup/wizard/cards/VehicleCard.kt -->
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModelTest.kt
@@ -6,11 +6,18 @@ import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
 import cloud.trotter.dashbuddy.core.data.fuel.FuelPriceRepository
 import cloud.trotter.dashbuddy.core.data.location.OdometerRepository
 import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
+import cloud.trotter.dashbuddy.core.data.settings.DevSettingsRepository
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
+import cloud.trotter.dashbuddy.domain.model.bubble.BubbleSessionMode
 import cloud.trotter.dashbuddy.domain.model.vehicle.FuelType
 import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Regions
+import cloud.trotter.dashbuddy.domain.state.Session
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,6 +25,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -45,7 +53,6 @@ import org.mockito.kotlin.whenever
 @OptIn(ExperimentalCoroutinesApi::class)
 class BubbleViewModelTest {
 
-    private val bubbleManager: BubbleManager = mock()
     private val chatRepository: ChatRepository = mock()
     private val odometerRepository: OdometerRepository = mock()
     private val stateManager: StateManagerV2 = mock()
@@ -53,16 +60,24 @@ class BubbleViewModelTest {
     private val appPreferencesRepository: AppPreferencesRepository = mock()
     private val fuelPriceRepository: FuelPriceRepository = mock()
     private val analyticsRepository: AnalyticsRepository = mock()
+    private val devSettingsRepository: DevSettingsRepository = mock()
 
     private val dispatcher = StandardTestDispatcher()
+
+    /** The state the VM reads; tests mutate it to drive multi-app scenarios (#867). */
+    private val state = MutableStateFlow(AppState())
+
+    /** The dev-settings session-presentation switch (#867). */
+    private val modeFlow = MutableStateFlow(BubbleSessionMode.FOLLOW_ACTIVE)
 
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
         // Init-time flow accessors — the VM builds several stateIn() flows in its property initializers.
-        whenever(stateManager.state).thenReturn(MutableStateFlow(AppState()))
-        whenever(bubbleManager.activeSessionId).thenReturn(MutableStateFlow(null))
+        whenever(stateManager.state).thenReturn(state)
+        whenever(devSettingsRepository.bubbleSessionMode).thenReturn(modeFlow)
         whenever(appEventRepo.getMostRecentSessionId()).thenReturn(flowOf(null))
+        whenever(appEventRepo.getEventsForSession(any())).thenReturn(flowOf(emptyList()))
         whenever(odometerRepository.sessionMilesFlow).thenReturn(flowOf(0.0))
         whenever(appPreferencesRepository.glanceMode).thenReturn(flowOf(false))
         whenever(appPreferencesRepository.gasPrice).thenReturn(flowOf(3.50f))
@@ -74,7 +89,6 @@ class BubbleViewModelTest {
     fun tearDown() = Dispatchers.resetMain()
 
     private fun viewModel() = BubbleViewModel(
-        bubbleManager = bubbleManager,
         chatRepository = chatRepository,
         odometerRepository = odometerRepository,
         stateManager = stateManager,
@@ -82,6 +96,7 @@ class BubbleViewModelTest {
         appPreferencesRepository = appPreferencesRepository,
         fuelPriceRepository = fuelPriceRepository,
         analyticsRepository = analyticsRepository,
+        devSettingsRepository = devSettingsRepository,
     )
 
     private fun session(
@@ -199,5 +214,214 @@ class BubbleViewModelTest {
         verify(fuelPriceRepository).fetchAndResumeAutoGasPrice(eq(FuelType.REGULAR))
         // Resume-auto never routes through the manual (stepper) write path.
         verify(appPreferencesRepository, never()).updateGasPriceManual(any())
+    }
+
+    // ===========================================================================================
+    // #867 — multi-app session presentation (follow / pin / merge + the labeling pledge)
+    // ===========================================================================================
+
+    private fun appState(active: Platform?, vararg live: Pair<Platform, String>) = AppState(
+        regions = Regions(
+            flow = FlowRegion(activePlatform = active),
+            platforms = live.mapIndexed { index, (platform, sessionId) ->
+                platform to PlatformRegion(
+                    platform = platform,
+                    mode = Mode.Online,
+                    session = Session(sessionId = sessionId, startedAt = 1_000L * (index + 1)),
+                )
+            }.toMap(),
+        ),
+    )
+
+    private val dualOnline = arrayOf(
+        Platform.DoorDash to "session-dd",
+        Platform.Uber to "session-uber",
+    )
+
+    /** Keeps every WhileSubscribed flow hot for the duration of a test. */
+    private fun TestScope.subscribe(vm: BubbleViewModel) = launch {
+        launch { vm.focusedPlatform.collect {} }
+        launch { vm.switchablePlatforms.collect {} }
+        launch { vm.displayedPlatformLabel.collect {} }
+        launch { vm.messages.collect {} }
+        launch { vm.cards.collect {} }
+    }
+
+    private fun stubNoDashes() {
+        whenever(analyticsRepository.recentSessions(any())).thenReturn(flowOf(emptyList()))
+        whenever(chatRepository.getMessages(any())).thenReturn(flowOf(emptyList()))
+    }
+
+    @Test
+    fun `follow-active tracks the platform that produced the last frame`() = runTest {
+        stubNoDashes()
+        state.value = appState(Platform.DoorDash, *dualOnline)
+        val vm = viewModel()
+        val job = subscribe(vm)
+        advanceUntilIdle()
+        assertEquals(Platform.DoorDash, vm.focusedPlatform.value)
+
+        // The multi-app flip the issue documented: a DoorDash frame, then an Uber frame.
+        state.value = appState(Platform.Uber, *dualOnline)
+        advanceUntilIdle()
+
+        assertEquals(Platform.Uber, vm.focusedPlatform.value)
+        verify(chatRepository).getMessages(eq("session-uber"))
+        job.cancel()
+    }
+
+    @Test
+    fun `a switcher pick holds the surface against an active-platform flip`() = runTest {
+        stubNoDashes()
+        state.value = appState(Platform.DoorDash, *dualOnline)
+        val vm = viewModel()
+        val job = subscribe(vm)
+        advanceUntilIdle()
+
+        vm.selectPlatform(Platform.Uber)
+        advanceUntilIdle()
+        assertEquals(Platform.Uber, vm.focusedPlatform.value)
+
+        // A DoorDash frame arrives — the pin must NOT be dragged away by it.
+        state.value = appState(Platform.DoorDash, *dualOnline)
+        advanceUntilIdle()
+
+        assertEquals(Platform.Uber, vm.focusedPlatform.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `the live card is dropped while pinned away from the active platform`() = runTest {
+        stubNoDashes()
+        state.value = appState(Platform.DoorDash, *dualOnline)
+        val vm = viewModel()
+        val job = subscribe(vm)
+        advanceUntilIdle()
+
+        vm.selectPlatform(Platform.Uber)
+        advanceUntilIdle()
+
+        // The live card is built from the GLOBAL FlowRegion, which describes DoorDash's screen —
+        // rendering it under an Uber pin is exactly the mislabeling #867 is about (and it is what
+        // carries the offer Accept/Decline row).
+        assertNull(vm.cards.value.stack.active)
+        job.cancel()
+    }
+
+    @Test
+    fun `re-picking the displayed platform releases the pin`() = runTest {
+        stubNoDashes()
+        state.value = appState(Platform.DoorDash, *dualOnline)
+        val vm = viewModel()
+        val job = subscribe(vm)
+        advanceUntilIdle()
+
+        vm.selectPlatform(Platform.Uber)
+        advanceUntilIdle()
+        vm.selectPlatform(Platform.Uber)
+        advanceUntilIdle()
+
+        assertEquals(Platform.DoorDash, vm.focusedPlatform.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `follow-active releases the pin when the picked dash ends`() = runTest {
+        stubNoDashes()
+        state.value = appState(Platform.DoorDash, *dualOnline)
+        val vm = viewModel()
+        val job = subscribe(vm)
+        advanceUntilIdle()
+
+        vm.selectPlatform(Platform.Uber)
+        advanceUntilIdle()
+        assertEquals(Platform.Uber, vm.focusedPlatform.value)
+
+        // Uber goes offline (its region's session clears) → the temporary pin lapses.
+        state.value = appState(Platform.DoorDash, Platform.DoorDash to "session-dd")
+        advanceUntilIdle()
+        assertEquals(Platform.DoorDash, vm.focusedPlatform.value)
+
+        // …and it stays released when Uber dashes again — the difference from PINNED.
+        state.value = appState(Platform.DoorDash, *dualOnline)
+        advanceUntilIdle()
+        assertEquals(Platform.DoorDash, vm.focusedPlatform.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `pinned survives the picked dash ending and re-takes effect on the next one`() = runTest {
+        stubNoDashes()
+        modeFlow.value = BubbleSessionMode.PINNED
+        state.value = appState(Platform.DoorDash, *dualOnline)
+        val vm = viewModel()
+        val job = subscribe(vm)
+        advanceUntilIdle()
+
+        vm.selectPlatform(Platform.Uber)
+        advanceUntilIdle()
+        assertEquals(Platform.Uber, vm.focusedPlatform.value)
+
+        // Uber stops dashing: nothing live to show for the pin, so the display follows…
+        state.value = appState(Platform.DoorDash, Platform.DoorDash to "session-dd")
+        advanceUntilIdle()
+        assertEquals(Platform.DoorDash, vm.focusedPlatform.value)
+
+        // …but the pin was never dropped, so Uber's next dash re-takes the surface.
+        state.value = appState(Platform.DoorDash, *dualOnline)
+        advanceUntilIdle()
+        assertEquals(Platform.Uber, vm.focusedPlatform.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `merged folds every live dash into one stack`() = runTest {
+        stubNoDashes()
+        modeFlow.value = BubbleSessionMode.MERGED
+        state.value = appState(Platform.DoorDash, *dualOnline)
+        val vm = viewModel()
+        val job = subscribe(vm)
+        advanceUntilIdle()
+
+        verify(appEventRepo).getEventsForSession(eq("session-dd"))
+        verify(appEventRepo).getEventsForSession(eq("session-uber"))
+        // The switcher would be inert in this mode, so it is hidden…
+        assertEquals(emptyList<Platform>(), vm.switchablePlatforms.value)
+        // …and the chat stays on ONE session (the followed one), badged in the header.
+        verify(chatRepository).getMessages(eq("session-dd"))
+        job.cancel()
+    }
+
+    @Test
+    fun `labels and the switcher appear only once two dashes are live`() = runTest {
+        stubNoDashes()
+        state.value = appState(Platform.DoorDash, Platform.DoorDash to "session-dd")
+        val vm = viewModel()
+        val job = subscribe(vm)
+        advanceUntilIdle()
+
+        assertNull(vm.displayedPlatformLabel.value)
+        assertEquals(emptyList<Platform>(), vm.switchablePlatforms.value)
+
+        state.value = appState(Platform.DoorDash, *dualOnline)
+        advanceUntilIdle()
+
+        assertEquals(Platform.DoorDash.shortName, vm.displayedPlatformLabel.value)
+        assertEquals(listOf(Platform.DoorDash, Platform.Uber), vm.switchablePlatforms.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `an unknown stored mode is decoded by the repository, so the VM just follows`() = runTest {
+        // Fail-closed decode lives in DevSettingsRepository (BubbleSessionModeTest covers it); the
+        // VM's contract is that it renders whatever mode it is handed, starting at the default.
+        stubNoDashes()
+        state.value = appState(Platform.DoorDash, *dualOnline)
+        val vm = viewModel()
+        val job = subscribe(vm)
+        advanceUntilIdle()
+
+        assertEquals(Platform.DoorDash, vm.focusedPlatform.value)
+        job.cancel()
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/DevSettingsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/DevSettingsRepository.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.core.data.settings
 
 import android.util.Log
 import cloud.trotter.dashbuddy.core.datastore.settings.DevSettingsDataSource
+import cloud.trotter.dashbuddy.domain.model.bubble.BubbleSessionMode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
@@ -53,12 +54,25 @@ class DevSettingsRepository @Inject constructor(
     val isDevModeUnlocked: Flow<Boolean> =
         dataSource.isDevModeUnlocked.map { it ?: isDebug }
 
+    /**
+     * The bubble's session-presentation experiment switch (#867). Decode is **fail-closed**: an
+     * absent or unrecognized stored value resolves to [BubbleSessionMode.Default] — the shipped
+     * follow-last-active presentation — so a corrupt/stale preference can never leave the HUD in an
+     * undefined presentation.
+     */
+    val bubbleSessionMode: Flow<BubbleSessionMode> =
+        dataSource.bubbleSessionMode.map { BubbleSessionMode.fromWire(it) }
+
     // ============================================================================================
     // WRITE ACTIONS
     // ============================================================================================
     suspend fun setDevModeUnlocked(unlocked: Boolean) = dataSource.setDevModeUnlocked(unlocked)
 
     suspend fun setLogLevel(priority: Int) = dataSource.setLogLevel(priority)
+
+    /** #867 — persist the bubble session-presentation mode as its wire value. */
+    suspend fun setBubbleSessionMode(mode: BubbleSessionMode) =
+        dataSource.setBubbleSessionMode(mode.wire)
 
     suspend fun clearPreferences() {
         Timber.tag(TAG).w("Clearing Developer Preferences")

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/DevSettingsDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/DevSettingsDataSource.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import cloud.trotter.dashbuddy.core.datastore.di.DevSettingsPreferences
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -18,10 +19,17 @@ class DevSettingsDataSource @Inject constructor(
     private object Keys {
         val IS_DEV_MODE_UNLOCKED = booleanPreferencesKey("is_dev_mode_unlocked")
         val LOG_LEVEL = intPreferencesKey("log_level")
+        val BUBBLE_SESSION_MODE = stringPreferencesKey("bubble_session_mode")
     }
 
     val isDevModeUnlocked: Flow<Boolean?> = ds.data.map { it[Keys.IS_DEV_MODE_UNLOCKED] }
     val logLevel: Flow<Int?> = ds.data.map { it[Keys.LOG_LEVEL] }
+
+    /**
+     * The bubble's session-presentation experiment switch (#867), stored as the enum's wire string.
+     * Raw here — the repository owns the fail-closed decode so the datastore stays type-free.
+     */
+    val bubbleSessionMode: Flow<String?> = ds.data.map { it[Keys.BUBBLE_SESSION_MODE] }
 
     suspend fun setDevModeUnlocked(unlocked: Boolean) {
         ds.edit { it[Keys.IS_DEV_MODE_UNLOCKED] = unlocked }
@@ -29,6 +37,10 @@ class DevSettingsDataSource @Inject constructor(
 
     suspend fun setLogLevel(priority: Int) {
         ds.edit { it[Keys.LOG_LEVEL] = priority }
+    }
+
+    suspend fun setBubbleSessionMode(wire: String) {
+        ds.edit { it[Keys.BUBBLE_SESSION_MODE] = wire }
     }
 
     suspend fun clear() {

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,30 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — #867 (display side) — the bubble says WHICH dash it is showing, and you can switch it.**
+  With two platforms online the HUD used to follow whichever app produced the last frame, unlabeled
+  — a DoorDash "Declined" chip read as the Uber offer you had just acted on. Now: platform chips on
+  every card + the chat header whenever ≥2 dashes are live, a manual **Showing DD | UBER** chip row
+  above the stack, and a Dev-settings switch (Settings → Developer Options → **Session
+  presentation**) picking between **Follow** (default), **Pin**, and **Merge**.
+  **What to watch (needs a genuine multi-app dash — both apps online at once):**
+  1. **Chips appear** the moment the second dash starts (cards + chat header), and DISAPPEAR when
+     you drop back to one platform. A chip must never name the wrong app.
+  2. **Follow (default):** the stack tracks whichever app you last touched. Tap the other chip in
+     the switcher — the stack + chat swap to that dash and STAY there while you use the other app.
+     The live (bottom, expanded) card disappears while you're looking at the non-active platform —
+     that's intentional (there is no live screen for it), and the Accept/Decline buttons go with it.
+     End the dash you pinned → the HUD goes back to following on its own.
+  3. **Pin:** same, except the pick survives that dash ending and re-takes the surface when that
+     platform dashes again. Nothing is persisted across an app restart — a pin is per-session.
+  4. **Merge:** one stack with both dashes' cards interleaved chronologically, each chipped; the
+     switcher row is hidden and chat stays on the followed dash. This is the mode to judge — it's
+     the one the dev was unsure about.
+  **Which mode felt right while driving** is the actual deliverable — the winner becomes the
+  shipped default and the other two get deleted.
+  **Desk:** the two dashes' chat histories should now be cleanly separated per session (the #873
+  write-side fix); confirm no line from one platform sits in the other's `chat_messages` rows.
+  - Confirmed: 0/2
 - **🆕 NEW — #884 — the amount-bearing transfer button no longer evades the marker backstop.**
   `SensitiveTextMarkers` gained `Transfer in` plus a `transfer $<digit>` amount-adjacency shape.
   The leak channel was the CLICK envelope (the tapped button is serialized in isolation, so the

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/bubble/BubbleSessionMode.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/bubble/BubbleSessionMode.kt
@@ -1,0 +1,50 @@
+package cloud.trotter.dashbuddy.domain.model.bubble
+
+import java.util.Locale
+
+/**
+ * How the bubble HUD picks WHICH dash session it renders when more than one is live (#867).
+ *
+ * Multi-apping means two platforms can be Online at once. The HUD is a single-session surface, so
+ * something has to decide whose cards/chat it shows — and the field defect this enum exists for was
+ * that the decision was implicit (whichever platform produced the last recognized frame) and
+ * *unlabeled*, so the stack silently swapped platforms mid-glance.
+ *
+ * This is a **dev-settings experiment switch**, not a user-facing preference: the developer
+ * live-tests the three presentations and whichever wins becomes the shipped default (the others can
+ * then be deleted). Regardless of mode, platform chips render on the cards + the header whenever
+ * ≥2 sessions are live — the silent-swap class is impossible in every mode.
+ *
+ * Semantics (the manual platform switcher is the chip row above the stack):
+ *
+ * - [FOLLOW_ACTIVE] — today's behavior: the HUD follows the platform that produced the last
+ *   recognized frame. A switcher pick acts as a **temporary pin**: it holds while that platform's
+ *   session is live and RELEASES automatically when that session ends (back to following).
+ * - [PINNED] — the switcher pick is **durable**: it survives its session ending and re-takes effect
+ *   when that platform dashes again; only another pick changes it. While the pinned platform has no
+ *   live session the display falls back to follow-active (there is no per-platform session history
+ *   to show, and the header chip always names what is actually on screen — a fallback is never a
+ *   lie). The pin is in-memory / session-lifetime only — it is deliberately NOT persisted.
+ * - [MERGED] — test-only: the card stack folds EVERY live session into one timeline with per-card
+ *   platform chips. The switcher is hidden (it would do nothing) and the chat stays on the
+ *   follow-active session — see `BubbleSessionResolver` for why the merge is card-stack-only.
+ *
+ * Stored as [wire]; an unknown/absent value fails closed to [FOLLOW_ACTIVE] (the shipped behavior).
+ */
+enum class BubbleSessionMode(val wire: String) {
+    FOLLOW_ACTIVE("follow_active"),
+    PINNED("pinned"),
+    MERGED("merged"),
+    ;
+
+    companion object {
+        /** The fail-closed default: the shipped follow-last-active presentation. */
+        val Default = FOLLOW_ACTIVE
+
+        private val byWire = entries.associateBy { it.wire }
+
+        /** Decode a stored [wire] value; anything unrecognized (or null) falls back to [Default]. */
+        fun fromWire(wire: String?): BubbleSessionMode =
+            wire?.lowercase(Locale.ROOT)?.let { byWire[it] } ?: Default
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/bubble/BubbleSessionModeTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/bubble/BubbleSessionModeTest.kt
@@ -1,0 +1,34 @@
+package cloud.trotter.dashbuddy.domain.model.bubble
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** #867 — the stored mode decodes fail-closed to the shipped presentation. */
+class BubbleSessionModeTest {
+
+    @Test
+    fun `every mode round-trips through its wire value`() {
+        BubbleSessionMode.entries.forEach { mode ->
+            assertEquals(mode, BubbleSessionMode.fromWire(mode.wire))
+        }
+    }
+
+    @Test
+    fun `an absent value falls back to follow-active`() {
+        assertEquals(BubbleSessionMode.FOLLOW_ACTIVE, BubbleSessionMode.fromWire(null))
+        assertEquals(BubbleSessionMode.Default, BubbleSessionMode.fromWire(null))
+    }
+
+    @Test
+    fun `an unknown or garbage value falls back to follow-active`() {
+        listOf("", "  ", "MERGED_STACK", "follow", "pinned-to-uber", "42").forEach { wire ->
+            assertEquals(wire, BubbleSessionMode.Default, BubbleSessionMode.fromWire(wire))
+        }
+    }
+
+    @Test
+    fun `decode is case-insensitive so a hand-edited preference still resolves`() {
+        assertEquals(BubbleSessionMode.MERGED, BubbleSessionMode.fromWire("MERGED"))
+        assertEquals(BubbleSessionMode.PINNED, BubbleSessionMode.fromWire("Pinned"))
+    }
+}

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/BubbleDashboardView.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/BubbleDashboardView.kt
@@ -29,6 +29,7 @@ import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.feature.bubble.cards.FlowCardItem
+import cloud.trotter.dashbuddy.feature.bubble.session.PlatformSwitcherRow
 
 // ---------------------------------------------------------------------------
 // Dashboard layout
@@ -41,6 +42,14 @@ fun DashboardView(
     messages: List<ChatMessage>,
     lastSession: SessionRecord?,
     focusedPlatform: Platform?,
+    /**
+     * Per-card platform badges keyed by card id (#867) — empty unless ≥2 dashes are live.
+     * Resolved upstream so the label gate has exactly one owner.
+     */
+    cardPlatformLabels: Map<String, String> = emptyMap(),
+    /** Live platforms offered by the manual switcher; fewer than two ⇒ the row hides itself. */
+    switchablePlatforms: List<Platform> = emptyList(),
+    onSelectPlatform: (Platform) -> Unit = {},
     gasPrice: Float?,
     isGasPriceAuto: Boolean,
     isGasPriceRefreshing: Boolean = false,
@@ -68,6 +77,13 @@ fun DashboardView(
             .padding(horizontal = 12.dp, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
+        // #867: the manual dash switcher sits above everything it re-scopes, so the surface says
+        // WHICH dash it is showing before the dasher reads any number off it.
+        PlatformSwitcherRow(
+            platforms = switchablePlatforms,
+            selected = focusedPlatform,
+            onSelect = onSelectPlatform,
+        )
         when {
             // Idle/offline with no ACTIVE dash → the idle dashboard card (gas/vehicle
             // just-in-time actions + last-session summary). Keyed on `active == null`, NOT
@@ -130,6 +146,7 @@ fun DashboardView(
                                 isActive = true,
                                 expanded = true,
                                 onToggleExpand = { /* active always expanded */ },
+                                platformLabel = cardPlatformLabels[live.id],
                                 onAccept = onAccept,
                                 onDecline = onDecline,
                             )
@@ -150,6 +167,7 @@ fun DashboardView(
                             isActive = false,
                             expanded = expanded,
                             onToggleExpand = { expandedIds[snap.id] = !expanded },
+                            platformLabel = cardPlatformLabels[snap.id],
                         )
                     }
                 }

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/ChatViews.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/ChatViews.kt
@@ -48,6 +48,36 @@ import cloud.trotter.dashbuddy.feature.bubble.formatters.getIconResId
 import java.util.Date
 
 // ---------------------------------------------------------------------------
+// Chat header title
+// ---------------------------------------------------------------------------
+
+/**
+ * The full-chat TopAppBar title, with the displayed dash's platform badge (#867).
+ *
+ * The chat is per-session, and while two dashes are live it silently swapped platforms with the
+ * card stack — this makes the attribution explicit. [platformLabel] is null when fewer than two
+ * sessions are live (nothing to disambiguate), so the single-platform title is unchanged. [title]
+ * is passed in rather than read here because the copy belongs to the hosting app shell.
+ */
+@Composable
+fun ChatHeaderTitle(title: String, platformLabel: String?) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        platformLabel?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                fontWeight = FontWeight.Medium,
+            )
+        }
+        Text(text = title)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Latest message ticker
 // ---------------------------------------------------------------------------
 

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/CardStackAssembler.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/CardStackAssembler.kt
@@ -1,0 +1,90 @@
+package cloud.trotter.dashbuddy.feature.bubble.cards
+
+import cloud.trotter.dashbuddy.domain.model.cards.CardStack
+import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.feature.bubble.session.CardSource
+
+/**
+ * The bubble HUD's card stack plus the per-card platform chips it renders (#867).
+ *
+ * [platformLabels] is keyed by [FlowCardSnapshot.id] and is EMPTY whenever fewer than two sessions
+ * are live — a single-session HUD renders no chips at all. It is a sidecar map rather than a field
+ * on [FlowCardSnapshot] on purpose: the snapshot is the frozen *content* of a phase (folded from
+ * the event log and shared with the analytics drill-down), while "which platform's surface am I
+ * looking at right now" is a property of the current presentation, not of the historical fact.
+ */
+data class BubbleCards(
+    val stack: CardStack = CardStack.Empty,
+    val platformLabels: Map<String, String> = emptyMap(),
+) {
+    companion object {
+        val Empty = BubbleCards()
+    }
+}
+
+/**
+ * Assembles the rendered stack from one folded card list per displayed session.
+ *
+ * Single-source (every non-merged mode) is a pass-through: the fold's own order is preserved
+ * byte-for-byte, so the shipped presentation is unchanged. Multi-source ([BubbleSessionMode.MERGED]
+ * (`cloud.trotter.dashbuddy.domain.model.bubble.BubbleSessionMode.MERGED`)) is a **k-way merge on
+ * `phaseStartedAt` that preserves each session's internal order** — deliberately not a global
+ * `sortedBy`, which would re-order cards *within* a session (the fold emits cards in close order,
+ * not start order, so sorting a single session's list is not a no-op).
+ */
+object CardStackAssembler {
+
+    fun assemble(
+        folded: List<Pair<CardSource, List<FlowCardSnapshot>>>,
+        activeCard: FlowCardSnapshot?,
+        activePlatform: Platform?,
+        labelsVisible: Boolean,
+    ): BubbleCards {
+        val completed = interleaveByStart(folded.map { it.second })
+        val stack = CardStack.of(completed = completed, active = activeCard)
+
+        if (!labelsVisible) return BubbleCards(stack = stack)
+
+        val labels = buildMap {
+            folded.forEach { (source, cards) ->
+                val label = source.platform?.shortName?.takeIf { it.isNotBlank() } ?: return@forEach
+                cards.forEach { put(it.id, label) }
+            }
+            activeCard?.let { live ->
+                activePlatform?.shortName?.takeIf { it.isNotBlank() }?.let { put(live.id, it) }
+            }
+        }
+        return BubbleCards(stack = stack, platformLabels = labels)
+    }
+
+    /**
+     * Merge already-ordered per-session lists into one chronological list, always taking the head
+     * with the earliest `phaseStartedAt` and breaking ties by list order (stable). Each input
+     * list's relative order is preserved exactly.
+     */
+    private fun interleaveByStart(lists: List<List<FlowCardSnapshot>>): List<FlowCardSnapshot> {
+        val nonEmpty = lists.filter { it.isNotEmpty() }
+        if (nonEmpty.size <= 1) return nonEmpty.firstOrNull() ?: emptyList()
+
+        val cursors = IntArray(nonEmpty.size)
+        val total = nonEmpty.sumOf { it.size }
+        val merged = ArrayList<FlowCardSnapshot>(total)
+        repeat(total) {
+            var pick = -1
+            for (i in nonEmpty.indices) {
+                val idx = cursors[i]
+                if (idx >= nonEmpty[i].size) continue
+                if (pick < 0 ||
+                    nonEmpty[i][idx].phaseStartedAt < nonEmpty[pick][cursors[pick]].phaseStartedAt
+                ) {
+                    pick = i
+                }
+            }
+            if (pick < 0) return@repeat
+            merged.add(nonEmpty[pick][cursors[pick]])
+            cursors[pick]++
+        }
+        return merged
+    }
+}

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/FlowCardItem.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/FlowCardItem.kt
@@ -84,6 +84,12 @@ fun FlowCardItem(
     expanded: Boolean,
     onToggleExpand: () -> Unit,
     modifier: Modifier = Modifier,
+    /**
+     * The owning platform's short name (#867), rendered as a leading chip. Null ⇒ no chip: the
+     * caller passes a label only while ≥2 dashes are live, so a single-platform HUD is unchanged
+     * and a two-platform HUD can never show an unattributed card.
+     */
+    platformLabel: String? = null,
     onAccept: () -> Unit = {},
     onDecline: () -> Unit = {},
 ) {
@@ -105,7 +111,12 @@ fun FlowCardItem(
                 .padding(horizontal = 14.dp, vertical = 10.dp),
             verticalArrangement = Arrangement.spacedBy(if (effectiveExpanded) 10.dp else 4.dp),
         ) {
-            CardHeader(snapshot = snapshot, isActive = isActive, expanded = effectiveExpanded)
+            CardHeader(
+                snapshot = snapshot,
+                isActive = isActive,
+                expanded = effectiveExpanded,
+                platformLabel = platformLabel,
+            )
             if (effectiveExpanded) {
                 CardBody(snapshot = snapshot, isActive = isActive)
                 if (snapshot is FlowCardSnapshot.Offer && isActive && snapshot.outcome == null) {
@@ -125,12 +136,16 @@ private fun CardHeader(
     snapshot: FlowCardSnapshot,
     isActive: Boolean,
     expanded: Boolean,
+    platformLabel: String? = null,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        // #867: multi-app attribution leads the row — whose dash is this card? Shown only when the
+        // caller resolved a label (≥2 live sessions).
+        platformLabel?.let { PlatformChip(it) }
         PhaseChip(snapshot, isActive)
         Text(
             text = cardSummary(snapshot, isActive),
@@ -162,6 +177,27 @@ private fun CardHeader(
                 modifier = Modifier.size(18.dp),
             )
         }
+    }
+}
+
+/**
+ * The owning platform's badge (#867). Deliberately quiet — it's an attribution marker, not a
+ * status: the phase chip beside it keeps the loud color.
+ */
+@Composable
+private fun PlatformChip(label: String) {
+    val c = AppTheme.colors
+    Surface(
+        shape = RoundedCornerShape(4.dp),
+        color = c.neutralBg,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = c.neutral,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 5.dp, vertical = 2.dp),
+        )
     }
 }
 

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/session/BubbleSessionResolver.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/session/BubbleSessionResolver.kt
@@ -1,0 +1,145 @@
+package cloud.trotter.dashbuddy.feature.bubble.session
+
+import cloud.trotter.dashbuddy.domain.model.bubble.BubbleSessionMode
+import cloud.trotter.dashbuddy.domain.state.Platform
+
+/** A dash that is live right now (its `PlatformRegion.session` is non-null) on one platform. */
+data class LiveSession(
+    val platform: Platform,
+    val sessionId: String,
+    val startedAt: Long,
+)
+
+/** One session feeding the card stack, tagged with the platform that owns it (null ⇒ unknown). */
+data class CardSource(
+    val sessionId: String,
+    val platform: Platform?,
+)
+
+/**
+ * The resolved answer to "what is the bubble showing right now" (#867) — pure data derived from
+ * the mode, the switcher pick, and live state. Everything the HUD renders keys off exactly one of
+ * these, so there is a single owner for the displayed identity (principle 5).
+ *
+ * @param displayedPlatform the platform the surface is attributed to (status badge, mode cards,
+ *   session earnings). Null before anything has been recognized.
+ * @param followPlatform the platform whose frame we last recognized — the one the LIVE card and
+ *   the global `FlowRegion` describe. Equal to [displayedPlatform] unless a pin is in effect.
+ * @param chatSessionId the session whose chat + live surfaces are shown. Null when nothing has
+ *   ever dashed.
+ * @param cardSources the sessions whose event logs fold into the card stack — one normally, N in
+ *   [BubbleSessionMode.MERGED].
+ * @param switchablePlatforms the manual switcher's chip row; EMPTY means "don't render it"
+ *   (fewer than two live sessions, or merged mode where a pick would do nothing).
+ * @param labelsVisible true when ≥2 sessions are live: platform chips MUST render on the cards and
+ *   the header in EVERY mode, so a swap of identity can never be silent.
+ * @param showLiveCard whether the live (active) card belongs to what we're displaying. The live
+ *   card is built from the global `FlowRegion`, which only ever describes [followPlatform]; when a
+ *   pin points somewhere else there is no live screen for that platform, so we render its completed
+ *   timeline with NO live card rather than dressing another platform's frame in its name. This is
+ *   also what keeps the offer Accept/Decline row (live-card-only) from ever aiming at the wrong
+ *   platform while pinned.
+ */
+data class BubbleSessionPresentation(
+    val displayedPlatform: Platform? = null,
+    val followPlatform: Platform? = null,
+    val chatSessionId: String? = null,
+    val cardSources: List<CardSource> = emptyList(),
+    val switchablePlatforms: List<Platform> = emptyList(),
+    val labelsVisible: Boolean = false,
+    val showLiveCard: Boolean = true,
+) {
+    companion object {
+        val Empty = BubbleSessionPresentation()
+    }
+}
+
+/**
+ * Decides which dash session(s) the bubble HUD renders (#867).
+ *
+ * Pure, Android-free and clock-free — the same shape as [cloud.trotter.dashbuddy.feature.bubble
+ * .cards.FlowCardMapper]: state in, presentation out. The mode semantics are documented on
+ * [BubbleSessionMode]; the load-bearing details:
+ *
+ * - **The temporary pin.** In [BubbleSessionMode.FOLLOW_ACTIVE] a switcher pick is honored only
+ *   while that platform's session is live; the moment it ends the pick stops applying and the HUD
+ *   follows again. In [BubbleSessionMode.PINNED] the pick is *not* forgotten (the caller keeps it),
+ *   but display still falls back to follow while the pinned platform is dark — so it re-takes
+ *   effect on that platform's next dash.
+ * - **Merged is card-stack-only.** Chat stays on the follow-active session. Merging the chat would
+ *   interleave two dispatcher narratives whose per-line provenance the chat model doesn't carry
+ *   (the #873 write-side fix files each line to its OWN session; nothing on `ChatMessage` says
+ *   which). Rather than invent a per-line platform tag for a test-only mode, the merge covers the
+ *   surface the issue is actually about — the card stack — and the header chip keeps the chat's
+ *   identity explicit. If merged wins the field test, per-line chat labels are the follow-up.
+ * - **Fail-toward-labels.** [BubbleSessionPresentation.labelsVisible] keys off liveness alone, not
+ *   the mode, so no mode can turn labeling off.
+ */
+object BubbleSessionResolver {
+
+    /**
+     * @param mode the dev-settings experiment switch.
+     * @param selection the switcher's current pick (null ⇒ never picked / released by the caller).
+     * @param followPlatform `flow.activePlatform ?: crossPlatform.mostRecentActivityPlatform` —
+     *   the platform of the last recognized frame.
+     * @param liveSessions every platform with a live session, caller-ordered (oldest dash first).
+     * @param fallbackSessionId the durable most-recent session from the event log (#459) — what to
+     *   show when nothing is live.
+     */
+    fun resolve(
+        mode: BubbleSessionMode,
+        selection: Platform?,
+        followPlatform: Platform?,
+        liveSessions: List<LiveSession>,
+        fallbackSessionId: String?,
+    ): BubbleSessionPresentation {
+        // A pick only applies while its platform is actually dashing. FOLLOW_ACTIVE and PINNED
+        // differ in whether the caller KEEPS the pick after that (see BubbleSessionMode), not in
+        // what a dark platform displays. MERGED ignores the pick outright.
+        val effectiveSelection = when (mode) {
+            BubbleSessionMode.MERGED -> null
+            else -> selection?.takeIf { picked -> liveSessions.any { it.platform == picked } }
+        }
+
+        val displayedPlatform = effectiveSelection ?: followPlatform
+
+        // Preserves the pre-#867 resolution exactly when nothing is pinned: the displayed
+        // platform's live session, else ANY live session, else the durable event-log fallback
+        // (AppState.activeSessionId() ?: getMostRecentSessionId(), #437/#459).
+        val chatSessionId = liveSessions.firstOrNull { it.platform == displayedPlatform }?.sessionId
+            ?: liveSessions.firstOrNull()?.sessionId
+            ?: fallbackSessionId
+
+        val cardSources = when {
+            mode == BubbleSessionMode.MERGED && liveSessions.isNotEmpty() ->
+                liveSessions.map { CardSource(it.sessionId, it.platform) }
+
+            chatSessionId != null -> listOf(
+                CardSource(
+                    sessionId = chatSessionId,
+                    // Only claim a platform for the session we can actually attribute: a
+                    // fallback (post-dash) session's platform is not knowable from live state.
+                    platform = liveSessions.firstOrNull { it.sessionId == chatSessionId }?.platform,
+                )
+            )
+
+            else -> emptyList()
+        }
+
+        val multiLive = liveSessions.size >= 2
+
+        return BubbleSessionPresentation(
+            displayedPlatform = displayedPlatform,
+            followPlatform = followPlatform,
+            chatSessionId = chatSessionId,
+            cardSources = cardSources,
+            switchablePlatforms = if (multiLive && mode != BubbleSessionMode.MERGED) {
+                liveSessions.map { it.platform }
+            } else {
+                emptyList()
+            },
+            labelsVisible = multiLive,
+            showLiveCard = mode == BubbleSessionMode.MERGED || displayedPlatform == followPlatform,
+        )
+    }
+}

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/session/PlatformSwitcher.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/session/PlatformSwitcher.kt
@@ -1,0 +1,61 @@
+package cloud.trotter.dashbuddy.feature.bubble.session
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.feature.bubble.R
+
+/**
+ * The manual platform switcher (#867) — one chip per live dash, the displayed one highlighted.
+ *
+ * Stateless and data-in/lambdas-out: the caller decides WHEN it renders (it passes an empty list
+ * to hide it — fewer than two live sessions, or merged mode) and what a tap means. Tapping a chip
+ * only ever dispatches [onSelect]; the ViewModel owns the resulting selection state.
+ */
+@Composable
+fun PlatformSwitcherRow(
+    platforms: List<Platform>,
+    selected: Platform?,
+    onSelect: (Platform) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (platforms.size < 2) return
+    val c = AppTheme.colors
+    val description = stringResource(R.string.bubble_switcher_content_desc)
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = description },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.bubble_switcher_label),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+        )
+        platforms.forEach { platform ->
+            val isSelected = platform == selected
+            AppChip(
+                text = platform.shortName,
+                color = if (isSelected) c.accent else c.neutral,
+                container = if (isSelected) c.accent.copy(alpha = 0.15f) else c.neutralBg,
+                modifier = Modifier.clickable { onSelect(platform) },
+            )
+        }
+    }
+}

--- a/feature/bubble/src/main/res/values/strings.xml
+++ b/feature/bubble/src/main/res/values/strings.xml
@@ -91,4 +91,8 @@
     <string name="flow_card_outcome_declined">Declined</string>
     <string name="flow_card_outcome_timed_out">Timed out</string>
 
+    <!-- #867 manual dash switcher (multi-app) -->
+    <string name="bubble_switcher_label">Showing</string>
+    <string name="bubble_switcher_content_desc">Switch which dash the bubble shows</string>
+
 </resources>

--- a/feature/bubble/src/test/java/cloud/trotter/dashbuddy/feature/bubble/cards/CardStackAssemblerTest.kt
+++ b/feature/bubble/src/test/java/cloud/trotter/dashbuddy/feature/bubble/cards/CardStackAssemblerTest.kt
@@ -1,0 +1,130 @@
+package cloud.trotter.dashbuddy.feature.bubble.cards
+
+import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.feature.bubble.session.CardSource
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** #867 — merged-stack interleave + the ≥2-live platform-chip gate. */
+class CardStackAssemblerTest {
+
+    private fun awaiting(id: String, startedAt: Long) = FlowCardSnapshot.Awaiting(
+        id = id,
+        phaseStartedAt = startedAt,
+        phaseEndedAt = startedAt + 1,
+    )
+
+    private val ddSource = CardSource("session-dd", Platform.DoorDash)
+    private val uberSource = CardSource("session-uber", Platform.Uber)
+
+    @Test
+    fun `a single session passes its fold through untouched`() {
+        // The fold emits in CLOSE order, which is not start order — a global sort would silently
+        // reorder the shipped single-session stack, so the single-source path must not sort.
+        val cards = listOf(awaiting("a", 300), awaiting("b", 100), awaiting("c", 200))
+
+        val out = CardStackAssembler.assemble(
+            folded = listOf(ddSource to cards),
+            activeCard = null,
+            activePlatform = Platform.DoorDash,
+            labelsVisible = false,
+        )
+
+        assertEquals(cards, out.stack.completed)
+        assertTrue(out.platformLabels.isEmpty())
+    }
+
+    @Test
+    fun `two sessions interleave by phase start while keeping each session's order`() {
+        val dd = listOf(awaiting("dd1", 100), awaiting("dd2", 400))
+        val uber = listOf(awaiting("ub1", 200), awaiting("ub2", 300))
+
+        val out = CardStackAssembler.assemble(
+            folded = listOf(ddSource to dd, uberSource to uber),
+            activeCard = null,
+            activePlatform = Platform.DoorDash,
+            labelsVisible = true,
+        )
+
+        assertEquals(
+            listOf("dd1", "ub1", "ub2", "dd2"),
+            out.stack.completed.map { it.id },
+        )
+    }
+
+    @Test
+    fun `a tie keeps the earlier source's card first, deterministically`() {
+        val dd = listOf(awaiting("dd1", 100))
+        val uber = listOf(awaiting("ub1", 100))
+
+        val out = CardStackAssembler.assemble(
+            folded = listOf(ddSource to dd, uberSource to uber),
+            activeCard = null,
+            activePlatform = null,
+            labelsVisible = true,
+        )
+
+        assertEquals(listOf("dd1", "ub1"), out.stack.completed.map { it.id })
+    }
+
+    @Test
+    fun `every merged card is chipped with its own platform`() {
+        val out = CardStackAssembler.assemble(
+            folded = listOf(
+                ddSource to listOf(awaiting("dd1", 100)),
+                uberSource to listOf(awaiting("ub1", 200)),
+            ),
+            activeCard = awaiting("live", 300).copy(phaseEndedAt = null),
+            activePlatform = Platform.Uber,
+            labelsVisible = true,
+        )
+
+        assertEquals(Platform.DoorDash.shortName, out.platformLabels["dd1"])
+        assertEquals(Platform.Uber.shortName, out.platformLabels["ub1"])
+        // The live card belongs to whichever platform's frame we last saw.
+        assertEquals(Platform.Uber.shortName, out.platformLabels["live"])
+    }
+
+    @Test
+    fun `no chips at all when only one dash is live`() {
+        val out = CardStackAssembler.assemble(
+            folded = listOf(ddSource to listOf(awaiting("dd1", 100))),
+            activeCard = awaiting("live", 300).copy(phaseEndedAt = null),
+            activePlatform = Platform.DoorDash,
+            labelsVisible = false,
+        )
+
+        assertTrue(out.platformLabels.isEmpty())
+    }
+
+    @Test
+    fun `an unattributable session contributes no chips`() {
+        // The post-dash log fallback has no live platform to name.
+        val out = CardStackAssembler.assemble(
+            folded = listOf(CardSource("session-old", null) to listOf(awaiting("old", 100))),
+            activeCard = null,
+            activePlatform = null,
+            labelsVisible = true,
+        )
+
+        assertTrue(out.platformLabels.isEmpty())
+    }
+
+    @Test
+    fun `the live card still suppresses its frozen twin`() {
+        // CardStack.of's #458 at-door de-dup must survive the merge.
+        val live = awaiting("dup", 100).copy(phaseEndedAt = null)
+
+        val out = CardStackAssembler.assemble(
+            folded = listOf(ddSource to listOf(awaiting("dup", 100), awaiting("other", 50))),
+            activeCard = live,
+            activePlatform = Platform.DoorDash,
+            labelsVisible = false,
+        )
+
+        assertEquals(listOf("other"), out.stack.completed.map { it.id })
+        assertEquals(live, out.stack.active)
+    }
+}

--- a/feature/bubble/src/test/java/cloud/trotter/dashbuddy/feature/bubble/session/BubbleSessionResolverTest.kt
+++ b/feature/bubble/src/test/java/cloud/trotter/dashbuddy/feature/bubble/session/BubbleSessionResolverTest.kt
@@ -1,0 +1,179 @@
+package cloud.trotter.dashbuddy.feature.bubble.session
+
+import cloud.trotter.dashbuddy.domain.model.bubble.BubbleSessionMode
+import cloud.trotter.dashbuddy.domain.state.Platform
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #867 — the bubble's session-presentation semantics. The field defect: with two dashes live, the
+ * card stack and chat silently swapped platforms mid-glance (a DoorDash "Declined" chip read as the
+ * Uber offer the dasher had just acted on).
+ */
+class BubbleSessionResolverTest {
+
+    private val dd = LiveSession(Platform.DoorDash, "session-dd", startedAt = 1_000L)
+    private val uber = LiveSession(Platform.Uber, "session-uber", startedAt = 2_000L)
+
+    private fun resolve(
+        mode: BubbleSessionMode = BubbleSessionMode.FOLLOW_ACTIVE,
+        selection: Platform? = null,
+        follow: Platform? = Platform.DoorDash,
+        live: List<LiveSession> = listOf(dd, uber),
+        fallback: String? = "session-old",
+    ) = BubbleSessionResolver.resolve(mode, selection, follow, live, fallback)
+
+    // --- follow-active (the shipped default) ---
+
+    @Test
+    fun `follow-active with no pick shows the last-active platform's dash`() {
+        val p = resolve(follow = Platform.Uber)
+
+        assertEquals(Platform.Uber, p.displayedPlatform)
+        assertEquals("session-uber", p.chatSessionId)
+        assertEquals(listOf(CardSource("session-uber", Platform.Uber)), p.cardSources)
+        assertTrue(p.showLiveCard)
+    }
+
+    @Test
+    fun `follow-active flips with the active platform`() {
+        assertEquals("session-dd", resolve(follow = Platform.DoorDash).chatSessionId)
+        assertEquals("session-uber", resolve(follow = Platform.Uber).chatSessionId)
+    }
+
+    @Test
+    fun `a pick overrides the active platform — the surface stops swapping`() {
+        val p = resolve(follow = Platform.DoorDash, selection = Platform.Uber)
+
+        assertEquals(Platform.Uber, p.displayedPlatform)
+        assertEquals("session-uber", p.chatSessionId)
+        // The live card describes the ACTIVE platform's screen — never dress DoorDash's frame up
+        // as Uber's live card.
+        assertFalse(p.showLiveCard)
+    }
+
+    @Test
+    fun `a pick for a platform that is not dashing does not apply`() {
+        val p = resolve(follow = Platform.DoorDash, selection = Platform.Uber, live = listOf(dd))
+
+        assertEquals(Platform.DoorDash, p.displayedPlatform)
+        assertEquals("session-dd", p.chatSessionId)
+        assertTrue(p.showLiveCard)
+    }
+
+    // --- pinned ---
+
+    @Test
+    fun `pinned honors the pick exactly like a temporary pin while both dash`() {
+        val p = resolve(
+            mode = BubbleSessionMode.PINNED,
+            follow = Platform.DoorDash,
+            selection = Platform.Uber,
+        )
+
+        assertEquals(Platform.Uber, p.displayedPlatform)
+        assertEquals("session-uber", p.chatSessionId)
+    }
+
+    @Test
+    fun `pinned falls back to follow while the pinned platform is dark`() {
+        // The caller KEEPS the pin in this mode (that's the durability); the resolver simply has
+        // nothing live to show for it, so the display follows rather than blanking.
+        val p = resolve(
+            mode = BubbleSessionMode.PINNED,
+            follow = Platform.DoorDash,
+            selection = Platform.Uber,
+            live = listOf(dd),
+        )
+
+        assertEquals(Platform.DoorDash, p.displayedPlatform)
+        assertEquals("session-dd", p.chatSessionId)
+    }
+
+    // --- merged ---
+
+    @Test
+    fun `merged folds every live session and ignores the pick`() {
+        val p = resolve(
+            mode = BubbleSessionMode.MERGED,
+            follow = Platform.DoorDash,
+            selection = Platform.Uber,
+        )
+
+        assertEquals(
+            listOf(
+                CardSource("session-dd", Platform.DoorDash),
+                CardSource("session-uber", Platform.Uber),
+            ),
+            p.cardSources,
+        )
+        // Chat is NOT merged — it stays on the follow-active session, badged in the header.
+        assertEquals("session-dd", p.chatSessionId)
+        assertEquals(Platform.DoorDash, p.displayedPlatform)
+        assertTrue(p.showLiveCard)
+        // A switcher pick would do nothing in this mode, so the row is hidden.
+        assertTrue(p.switchablePlatforms.isEmpty())
+    }
+
+    @Test
+    fun `merged with nothing live still shows the fallback dash`() {
+        val p = resolve(mode = BubbleSessionMode.MERGED, follow = null, live = emptyList())
+
+        assertEquals(listOf(CardSource("session-old", null)), p.cardSources)
+        assertEquals("session-old", p.chatSessionId)
+    }
+
+    // --- the labeling pledge + the switcher gate ---
+
+    @Test
+    fun `labels are on in every mode once two dashes are live`() {
+        BubbleSessionMode.entries.forEach { mode ->
+            assertTrue(mode.name, resolve(mode = mode).labelsVisible)
+        }
+    }
+
+    @Test
+    fun `labels and the switcher are off with a single live dash`() {
+        val p = resolve(live = listOf(dd))
+
+        assertFalse(p.labelsVisible)
+        assertTrue(p.switchablePlatforms.isEmpty())
+    }
+
+    @Test
+    fun `the switcher offers every live platform in the caller's order`() {
+        assertEquals(listOf(Platform.DoorDash, Platform.Uber), resolve().switchablePlatforms)
+    }
+
+    // --- the pre-#867 fallbacks are preserved ---
+
+    @Test
+    fun `nothing live falls back to the durable most-recent dash`() {
+        val p = resolve(follow = Platform.DoorDash, live = emptyList())
+
+        assertEquals("session-old", p.chatSessionId)
+        // No live session ⇒ no platform to attribute the fallback dash to.
+        assertEquals(listOf(CardSource("session-old", null)), p.cardSources)
+    }
+
+    @Test
+    fun `a live dash on another platform beats the log fallback`() {
+        // AppState.activeSessionId()'s second arm: the active platform has no session, but some
+        // platform is dashing — show that one, not the finished dash from the log.
+        val p = resolve(follow = Platform.Instacart, live = listOf(uber))
+
+        assertEquals("session-uber", p.chatSessionId)
+    }
+
+    @Test
+    fun `no dash and no history shows nothing at all`() {
+        val p = resolve(follow = null, live = emptyList(), fallback = null)
+
+        assertNull(p.chatSessionId)
+        assertTrue(p.cardSources.isEmpty())
+        assertFalse(p.labelsVisible)
+    }
+}

--- a/feature/settings/src/main/java/cloud/trotter/dashbuddy/feature/settings/DeveloperSettingsScreen.kt
+++ b/feature/settings/src/main/java/cloud/trotter/dashbuddy/feature/settings/DeveloperSettingsScreen.kt
@@ -1,0 +1,117 @@
+package cloud.trotter.dashbuddy.feature.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented
+import cloud.trotter.dashbuddy.domain.model.bubble.BubbleSessionMode
+import cloud.trotter.dashbuddy.feature.settings.R
+
+/**
+ * The label + one-line explainer for each bubble session-presentation mode (#867). The enum is the
+ * SSOT for the modes themselves; only the copy mapping lives here (a UI concern), mirroring the
+ * `TtsLangOption` pattern on General settings.
+ */
+private val BubbleSessionMode.labelRes: Int
+    get() = when (this) {
+        BubbleSessionMode.FOLLOW_ACTIVE -> R.string.developer_settings_bubble_session_follow_label
+        BubbleSessionMode.PINNED -> R.string.developer_settings_bubble_session_pinned_label
+        BubbleSessionMode.MERGED -> R.string.developer_settings_bubble_session_merged_label
+    }
+
+private val BubbleSessionMode.explainerRes: Int
+    get() = when (this) {
+        BubbleSessionMode.FOLLOW_ACTIVE -> R.string.developer_settings_bubble_session_follow_explainer
+        BubbleSessionMode.PINNED -> R.string.developer_settings_bubble_session_pinned_explainer
+        BubbleSessionMode.MERGED -> R.string.developer_settings_bubble_session_merged_explainer
+    }
+
+/**
+ * Developer Options — the field-experiment switches. Today: the bubble's session-presentation mode
+ * (#867), which the developer live-tests across a multi-app dash; whichever presentation wins
+ * becomes the shipped default and the others get deleted.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DeveloperSettingsScreen(
+    onBack: () -> Unit,
+    viewModel: SettingsMenuViewModel = hiltViewModel(),
+) {
+    val sessionMode by viewModel.bubbleSessionMode
+        .collectAsStateWithLifecycle(initialValue = BubbleSessionMode.Default)
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.developer_settings_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_content_desc_back),
+                        )
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            Modifier
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp),
+        ) {
+            Text(
+                stringResource(R.string.developer_settings_section_bubble),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(top = 16.dp, bottom = 4.dp),
+            )
+            Text(
+                stringResource(R.string.developer_settings_bubble_session_label),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                stringResource(R.string.developer_settings_bubble_session_subtitle),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 8.dp),
+            )
+            // Pair each mode with its resolved label so selection maps back to the enum without
+            // re-matching localized text through a Context (the #428 General-settings pattern).
+            val labeled = BubbleSessionMode.entries.map { it to stringResource(it.labelRes) }
+            AppSegmented(
+                options = labeled.map { it.second },
+                selected = labeled.first { it.first == sessionMode }.second,
+                onSelect = { label ->
+                    viewModel.setBubbleSessionMode(labeled.first { it.second == label }.first)
+                },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Text(
+                stringResource(sessionMode.explainerRes),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 8.dp, bottom = 24.dp),
+            )
+        }
+    }
+}

--- a/feature/settings/src/main/java/cloud/trotter/dashbuddy/feature/settings/SettingsMenuViewModel.kt
+++ b/feature/settings/src/main/java/cloud/trotter/dashbuddy/feature/settings/SettingsMenuViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
 import cloud.trotter.dashbuddy.core.data.settings.DevSettingsRepository
 import cloud.trotter.dashbuddy.core.data.strategy.StrategyRepository
+import cloud.trotter.dashbuddy.domain.model.bubble.BubbleSessionMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -32,6 +33,9 @@ class SettingsMenuViewModel @Inject constructor(
     // Re-using the debug flag from repo as the "Unlock" state
     val isDevModeUnlocked = devSettingsRepository.isDevModeUnlocked
 
+    /** #867 — the bubble's session-presentation experiment switch (Developer Options). */
+    val bubbleSessionMode = devSettingsRepository.bubbleSessionMode
+
     private val _versionClickCount = MutableStateFlow(0)
     val versionClickCount = _versionClickCount.asStateFlow()
 
@@ -44,6 +48,11 @@ class SettingsMenuViewModel @Inject constructor(
 
     fun unlockDeveloperMode() = viewModelScope.launch {
         devSettingsRepository.setDevModeUnlocked(true)
+    }
+
+    /** #867 — persist the bubble session-presentation mode; the HUD reads it reactively. */
+    fun setBubbleSessionMode(mode: BubbleSessionMode) = viewModelScope.launch {
+        devSettingsRepository.setBubbleSessionMode(mode)
     }
 
     // --- Actions ---

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -87,4 +87,16 @@
     <string name="evidence_settings_deliveries_subtitle">Track completion stats</string>
     <string name="evidence_settings_session_label">Save Session Summary</string>
     <string name="evidence_settings_session_subtitle">End of session earnings report</string>
+
+    <!-- #867 Developer Options: bubble session-presentation experiment -->
+    <string name="developer_settings_title">Developer Options</string>
+    <string name="developer_settings_section_bubble">Bubble HUD</string>
+    <string name="developer_settings_bubble_session_label">Session presentation</string>
+    <string name="developer_settings_bubble_session_subtitle">Which dash the bubble shows while two platforms are online. Platform chips appear on cards and the chat header in every mode.</string>
+    <string name="developer_settings_bubble_session_follow_label">Follow</string>
+    <string name="developer_settings_bubble_session_pinned_label">Pin</string>
+    <string name="developer_settings_bubble_session_merged_label">Merge</string>
+    <string name="developer_settings_bubble_session_follow_explainer">Follows whichever platform you last touched. Picking a platform in the bubble\'s switcher holds until that dash ends, then it goes back to following.</string>
+    <string name="developer_settings_bubble_session_pinned_explainer">Your switcher pick sticks until you change it — including across that platform\'s next dash. While the pinned platform is offline the bubble falls back to following.</string>
+    <string name="developer_settings_bubble_session_merged_explainer">Test mode: one card stack folding every live dash, each card chipped with its platform. The switcher is hidden and chat stays on the followed dash.</string>
 </resources>


### PR DESCRIPTION
Display-side of #867, per the dev decision in the 2026-07-27 issue comment. The write-side
(per-effect session threading) shipped in #873; this makes the *presentation* honest and
gives the developer three modes to live-test.

## What ships

**One Dev-settings switch** (Settings → Developer Options → **Session presentation**) picking
between three presentations. The Developer Options route was a `PlaceholderScreen` — it is now
a real screen (`:feature:settings/DeveloperSettingsScreen`), and the dead placeholder + its
string were deleted.

**Platform chips whenever ≥2 dashes are live, in EVERY mode** — on every card and on the chat
header. The gate keys off liveness alone, never the mode, so no mode can turn attribution off.
With a single dash live the HUD is byte-identical to today (no chips, no switcher row).

## Mode semantics (the decisions this PR makes, all KDoc'd on `BubbleSessionMode`)

| Mode | Switcher pick | When that dash ends | Chat |
|---|---|---|---|
| `FOLLOW_ACTIVE` (default) | **temporary pin** — holds against active-platform flips | **releases**, back to following; does NOT return on that platform's next dash | followed/pinned session |
| `PINNED` | **durable** — only another pick changes it | pin is kept; display falls back to follow while that platform is dark, and **re-takes** the surface on its next dash | followed/pinned session |
| `MERGED` (test-only) | **ignored**, row hidden | n/a | follow-active session |

Three decisions worth calling out explicitly:

1. **Merged is card-stack-only; chat is never merged.** `ChatMessage` carries no per-line
   platform (the #873 fix files each line to its own *session*, which is the right write-side
   shape, but nothing on the message says which platform). Merging chat would mean inventing a
   per-line tag for a mode that exists to be judged and possibly deleted. Instead the merge
   covers the surface the issue is actually about — the card stack — and the header chip keeps
   the chat's identity explicit. If merged wins the field test, per-line chat labels are the
   follow-up.
2. **The pinned choice is NOT persisted** (in-memory, ViewModel-lifetime). It's a live-testing
   control over a surface that only exists while dashing; a forgotten pin silently re-scoping a
   later dash is the exact defect class #867 is about. `PINNED` durability means "across that
   platform's next dash within this app session", not across process death.
3. **The live card is dropped while pinned away from the active platform.** The live card is
   built from the *global* `FlowRegion`, which only ever describes the last-recognized platform
   — rendering it under another platform's pin would be a new instance of the same mislabeling.
   Bonus safety: the offer Accept/Decline row lives on the live card, so a pin can never leave a
   button on screen that would aim at the other app.

## Files touched, per module

| Module | Files |
|---|---|
| `:domain` | **new** `model/bubble/BubbleSessionMode.kt` (wire enum, fail-closed decode) + its test |
| `:core:datastore` | `DevSettingsDataSource` — `bubble_session_mode` string key (raw; no decode here) |
| `:core:data` | `DevSettingsRepository` — `bubbleSessionMode: Flow<BubbleSessionMode>` (fail-closed) + setter |
| `:feature:bubble` | **new** `session/BubbleSessionResolver.kt` (pure resolver + `LiveSession`/`CardSource`/`BubbleSessionPresentation`), **new** `session/PlatformSwitcher.kt` (stateless chip row), **new** `cards/CardStackAssembler.kt` (order-preserving k-way merge + the chip map); `cards/FlowCardItem.kt` (+`platformLabel`), `BubbleDashboardView.kt` (switcher row + per-card labels), `ChatViews.kt` (+`ChatHeaderTitle`), `strings.xml` (2 strings) |
| `:feature:settings` | **new** `DeveloperSettingsScreen.kt`; `SettingsMenuViewModel` (+read/+write); `strings.xml` (10 strings) |
| `:app` | `BubbleViewModel` (the resolution rework), `BubbleScreen` (wiring), `MainActivity` (real Developer route; `PlaceholderScreen` deleted), `strings.xml` (−1 dead), `BubbleViewModelTest` |
| docs | `CLAUDE.md` (`:feature:bubble` contents + the `BubbleViewModel`-stays-in-`:app` rationale), `docs/field-testing/README.md` (new checklist item, `Confirmed: 0/2`) |

`:feature:bubble` gained **no new dependencies** — the new files use only `:domain`
(`Platform`, `BubbleSessionMode`, `FlowCardSnapshot`/`CardStack`) and `:core:designsystem`
(`AppChip`, `AppTheme`), exactly what the module already declares. No Hilt, no `:core:data`,
no `:core:state`.

**One boundary change to flag:** `BubbleViewModel` no longer injects `BubbleManager` — session
identity now derives from `AppState` in one place inside the VM instead of via
`BubbleManager.activeSessionId` (which was itself derived from the same `AppState`). That
removes a redundant derivation (P5) but makes CLAUDE.md's stated reason for the VM living in
`:app` stale, so the sentence was rewritten in the same PR: it stays in `:app` because it
injects `:core:data`/`:core:state` (`ChatRepository`, `AppEventRepo`, `AnalyticsRepository`,
`StateManagerV2`, `DevSettingsRepository`), which `:feature:bubble` neither has nor should have.

## Tests

`./gradlew testDebugUnitTest :domain:test` — **BUILD SUCCESSFUL**, whole repo.

- `BubbleSessionResolverTest` (14, `:feature:bubble`) — follow flips with the active platform;
  a pick overrides it; a pick for a non-dashing platform is inert; pinned falls back while dark;
  merged folds all live sessions and ignores the pick; labels on in **all three** modes at ≥2
  live and off at 1; both pre-#867 fallbacks preserved (durable log fallback, and
  `activeSessionId()`'s "any live session" arm).
- `CardStackAssemblerTest` (7) — single-source is a byte-for-byte pass-through (a global
  `sortedBy` would re-order the shipped stack, since the fold emits in *close* order); two
  sources interleave by `phaseStartedAt` while preserving each session's internal order; ties
  are deterministic; per-card + live-card chips; no chips at 1 live; the #458 at-door frozen-twin
  suppression still holds through the merge.
- `BubbleViewModelTest` (+9, 16 total) — follow tracks the active flip (and re-scopes chat);
  a pick holds against a flip; the live card is dropped while pinned away; re-picking the
  displayed platform releases the pin; **FOLLOW_ACTIVE releases the pin when that dash ends and
  stays released on its next dash**; **PINNED keeps it and re-takes the next dash**; merged
  requests both sessions' events and keeps chat single; the ≥2-live label/switcher gate.
- `BubbleSessionModeTest` (`:domain`) — wire round-trip, absent/garbage/case → `FOLLOW_ACTIVE`.

Mutation-checked the subtlest bit: flipping the pin-release mode guard from `FOLLOW_ACTIVE` to
`PINNED` reds exactly the two mode-difference tests and nothing else.

### Design-goal review

- **P1 UDF** — the mode is read reactively from the preference; the switcher dispatches an
  intent (`selectPlatform`) and the ViewModel owns the selection state; the UI writes no
  repository. Every new composable is stateless with hoisted state. State flows down as one
  immutable `BubbleSessionPresentation`/`BubbleCards`.
- **P2 MAD** — Compose-first, Flow-based (`combine`/`flatMapLatest` + `WhileSubscribed(5000)`),
  DataStore for the preference, Hilt for the new repository injection, Package-by-Feature
  (`feature/bubble/session/*`).
- **P3 single responsibility** — the decision logic is a pure object (`BubbleSessionResolver`),
  the merge is another (`CardStackAssembler`); the ViewModel only wires flows. No file grew
  near the ~900-line line: `BubbleViewModel` 258 → ~380, `FlowCardItem` +22.
- **P4 Kotlin/Android** — a sealed-free enum with a `wire` value rather than stringly-typed
  modes (#283); `Locale.ROOT` in the decode; immutable data classes throughout.
- **P5 SSOT** — one resolved presentation owns "what is the bubble showing"; chat, cards,
  `focusedPlatform`, `focusedRegion` and `sessionEarnings` all derive from it (previously
  `displayedSessionId` and `focusedPlatform` were two independent derivations that could
  disagree). The label gate has exactly one owner. `Platform.shortName` stays the badge SSOT.
  The removed `BubbleManager.activeSessionId` read was a second derivation of the same
  `AppState` fact.
- **P6 security/privacy** — no recognition, capture, network or effect surface is touched; no
  new data is persisted beyond one enum wire string in the dev preferences store; the chips
  render `Platform.shortName` ("DD"/"Uber"), never store/customer text.
- **P7 logging** — no log sites added.
- **P8 platform-agnostic** — no `Platform` literal in any new logic: the resolver takes
  `List<LiveSession>` and compares platforms by identity, the switcher renders whatever list it
  is handed, and the label is `Platform.shortName` off the registry. Adding a platform needs
  zero edits here. (Diff touches `:domain` only to ADD an enum with no per-platform branching.)
- **Reactive UI** — no derived-value caching added; the 1-Hz ticker and every countdown are
  untouched. A mode flip, a dash starting/ending, and a switcher tap all re-render without a
  state-machine transition. Rule 5 is the point of the whole PR: the surface can no longer show
  a value the dasher would believe that isn't theirs.

### Field validation

Added to `docs/field-testing/README.md` → *Next field test* (`Confirmed: 0/2`). Needs a genuine
multi-app dash. The deliverable is **which mode feels right while driving** — the winner becomes
the shipped default and the other two get deleted.

Refs #867
