### PR TITLE
fix(analytics): #887 sweep the stores identity row a monotonic key upgrade superseded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -450,7 +450,21 @@ pure-ASCII street-number token (1–6 digits, fail-null on ranges/suffixes/non-n
 (`@12125`) so provenance is self-describing; the resolution ladder is receipt key > address(`@`) key >
 chain-only with tier-aware monotonic upgrades (an address key never downgrades a receipt key), and
 `normalizeRunningKey` strips a leading `@` from receipt-path keys so a payout parenthetical can't
-masquerade as address-tier. `NetProfit`
+masquerade as address-tier. **#887 (supersession sweep, `PROJECTOR_VERSION` 8→9):** a monotonic key
+UPGRADE (address-tier `doordash|cvs|@23530` → receipt-tier `doordash|cvs|3551`, or chain-only → keyed)
+re-keys the visit rows but used to LEAVE the superseded `stores` identity row behind as a zero-visit
+phantom (2 of 28 rows in the 07-27 pull). `StoreResolutionRunner` now collects each row's PRIOR key
+wherever a re-stamp actually lands (a downgrade-blocked or H1-pinned row keeps its key, so it
+contributes nothing) and, STRICTLY LAST in the job — after every pickup/delivery/offer stamp is
+committed — deletes each superseded row that `AnalyticsDao.storeKeyReferenceCount` proves is
+referenced by ZERO pickup/delivery/offer rows. The guard **fails toward KEEPING** (a row the re-key
+didn't reach — another job's pre-receipt visits, an H1-pinned row — keeps the entity alive; deleting
+it would orphan a *referencing* row, strictly worse than a phantom) and counts a merchant-free WARN
+(P7; keys stay at DEBUG). The sweep also **converges incremental ≡ refold on the raw `stores` table**:
+a from-zero refold that sees the receipt evidence in the same batch never mints the intermediate row,
+while an incremental fold split across a page boundary mints then deletes it — the F1 test's former
+"accepted read-invisible residual" is no longer accepted. The read-side M4 `EXISTS` filter on
+`storeReportRows` still masks any survivor. `NetProfit`
 (`:domain`) is the one shared cost-math SSOT for both the offer estimate and the frozen realized net.
 `AnalyticsRepository` (`:core:data`, **DAO-only — no economy dependency**, so historical net is structurally
 immutable) serves period economics (`SUM(netProfit)` frozen + `unattributedPay`; all-pay gross =

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -916,7 +916,18 @@ class AnalyticsProjector @Inject constructor(
          * of the new nullable column: `app_events`, every frozen economy column, and pay/net/miles are
          * untouched. Precedented side effect (as v2/v3/v4/v6/v7): the refold also re-stamps
          * `CURRENT_FALLBACK` rows against today's economy.
+         * v9 (#887): store resolution now DELETES the `stores` identity row a monotonic key upgrade
+         * superseded (address-tier `doordash|cvs|@23530` → receipt-tier `doordash|cvs|3551`) once nothing
+         * references it — the fielded 07-27 pull carried 2 such zero-visit phantoms out of 28 rows. The
+         * bump exists to HEAL the on-device rows: the orphans are already committed, and the fold is the
+         * one mechanism that owns what a `stores` row means, so the established wipe+refold
+         * (rebuild ≡ backfill) heals them without adding a second, marker-gated cleanup path. The F8 wipe
+         * clears `stores`/`pickup_records`; the refold repopulates them from the immutable log, minus the
+         * superseded rows. **Scope: the `stores` table ONLY** — the code change adds nothing but a guarded
+         * `DELETE FROM stores`, so every delivery/session/offer/pickup column folds byte-identically.
+         * Precedented side effect (as v2/v3/v4/v6/v7/v8): the refold re-stamps `CURRENT_FALLBACK` rows
+         * against today's economy.
          */
-        private const val PROJECTOR_VERSION = 8
+        private const val PROJECTOR_VERSION = 9
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionRunner.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionRunner.kt
@@ -21,9 +21,10 @@ import timber.log.Timber
  * adapter). Runs INSIDE the projector's batch transaction (resolve-from-rows, F1): for each triggered
  * job it reads the job's committed `pickup_records` (anchors + address) and `delivery_records`
  * (dropoff names + the row-persisted `payoutStoreForms` receipt evidence), resolves every anchor,
- * upserts the `stores` identity rows, and stamps the deterministic `storeKey` back onto the visit rows
- * (+ the offer↔job link). Because it reads committed rows only and the key is row-sourced + monotonic,
- * incremental fold ≡ from-zero refold (B1) and a re-run is a byte-identical no-op (L1).
+ * upserts the `stores` identity rows, stamps the deterministic `storeKey` back onto the visit rows
+ * (+ the offer↔job link), and — since #887 — deletes the identity row a monotonic key UPGRADE superseded
+ * once nothing references it any more. Because it reads committed rows only and the key is row-sourced +
+ * monotonic, incremental fold ≡ from-zero refold (B1) and a re-run is a byte-identical no-op (L1).
  *
  * **Privacy:** store names/addresses are MERCHANT data — fine at rest, never logged at INFO+ (P7). No
  * network, no new capture. Customer hashes are never read here.
@@ -100,11 +101,17 @@ internal class StoreResolutionRunner(private val dao: AnalyticsDao) {
             upsertStore(key, platform, normChain, runKey, r, anchorAddresses[r.canonical])
         }
 
+        // #887: every row whose PRIOR key this re-key replaces contributes that prior key as a
+        // SUPERSESSION candidate. Collected only where the stamp actually lands (a downgrade-blocked or
+        // pinned row keeps its key, so its key is not superseded), and swept at the end of the job.
+        val superseded = LinkedHashSet<String>()
+
         // Stamp pickup rows by their own anchor (storeName == the anchor). FIX 6 monotonic backstop:
         // never re-stamp a keyed row down to a chain-only key of the same platform+chain.
         for (pu in pickups) {
             val key = anchorKey[pu.storeName] ?: continue
             if (isMonotonicDowngrade(pu.storeKey, key)) continue
+            pu.storeKey?.takeIf { it != key }?.let { superseded += it }
             dao.stampPickupStoreKey(pu.eventSequenceId, key)
         }
         // Stamp delivery rows by best-matching their dropoff form to an anchor (the dropoff form differs
@@ -114,6 +121,8 @@ internal class StoreResolutionRunner(private val dao: AnalyticsDao) {
             val anchor = StoreNameMatch.bestMatch(anchors, store) ?: continue
             val key = anchorKey[anchor] ?: continue
             if (isMonotonicDowngrade(d.storeKey, key)) continue
+            // A PINNED row (H1 driver correction) is not re-keyed by the SQL, so its key is not superseded.
+            if (d.storeKeyPinned == 0) d.storeKey?.takeIf { it != key }?.let { superseded += it }
             dao.stampDeliveryStoreKey(d.eventSequenceId, key)
         }
 
@@ -124,7 +133,49 @@ internal class StoreResolutionRunner(private val dao: AnalyticsDao) {
         for (offer in offerRows) {
             val anchor = offer.merchantName?.let { StoreNameMatch.bestMatch(anchors, it) }
             if (!exact && anchor == null) continue
-            dao.stampOfferLink(offer.eventSequenceId, anchor?.let { anchorKey[it] }, jobId)
+            val key = anchor?.let { anchorKey[it] }
+            offer.storeKey?.takeIf { it != key }?.let { superseded += it }
+            dao.stampOfferLink(offer.eventSequenceId, key, jobId)
+        }
+
+        // #887: drop each superseded identity row — STRICTLY LAST, so every re-stamp above (incl. the
+        // offer links) is already committed and the reference count sees the post-re-key world.
+        sweepSuperseded(superseded - anchorKey.values.toSet())
+    }
+
+    /**
+     * #887 — delete the `stores` rows a monotonic key upgrade left behind. When one physical store mints
+     * an address-tier key at pickup-close (`doordash|cvs|@23530`) and a later payout upgrades it to the
+     * receipt-tier key (`doordash|cvs|3551`), the visit rows are re-keyed but the superseded identity row
+     * used to survive as a zero-visit phantom (2 of 28 `stores` rows in the 07-27 pull). Same mechanism,
+     * same fix, for the chain-only → keyed upgrade.
+     *
+     * **The guard fails toward KEEPING.** A superseded key is deleted ONLY when
+     * [AnalyticsDao.storeKeyReferenceCount] proves that zero pickup / delivery / offer rows still point at
+     * it. A row this re-key did not reach — ANOTHER job's visits to the same physical store that resolved
+     * before the receipt existed, or an H1-pinned delivery row — keeps the entity alive; deleting it would
+     * orphan a *referencing* row and blank its report card, which is strictly worse than a phantom.
+     *
+     * **Refold determinism.** The delete is a pure function of the committed rows at this point in the
+     * seq-ordered resolution stream, so it replays identically. It also *converges* the two paths: an
+     * incremental fold that split the job across a page boundary minted the intermediate row and now
+     * deletes it; a from-zero refold that saw the receipt evidence in the same batch never minted it at
+     * all. Terminal `stores` set: identical. (Before this, the raw table genuinely differed — the F1 test
+     * documented it as an accepted read-invisible residual; it is no longer accepted.)
+     *
+     * **P7:** storeKeys are merchant-derived, so the kept-row observability is a DEBUG line (keys) plus a
+     * merchant-free WARN — the same split as [isMonotonicDowngrade].
+     */
+    private suspend fun sweepSuperseded(candidates: Set<String>) {
+        for (old in candidates) {
+            val refs = dao.storeKeyReferenceCount(old)
+            if (refs > 0) {
+                Timber.tag(TAG).d("store-key supersession: keeping %s — %d row(s) still reference it", old, refs)
+                Timber.tag(TAG).w("superseded store entity kept: %d row(s) the re-key did not reach still reference it", refs)
+                continue
+            }
+            Timber.tag(TAG).d("store-key supersession: deleting unreferenced %s", old)
+            dao.deleteStore(old)
         }
     }
 

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionProjectorTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionProjectorTest.kt
@@ -232,6 +232,7 @@ class StoreResolutionProjectorTest {
         val p = projector()
         while (p.processBatch(limit = 2) != null) { /* drain */ }
         val incrementalVisible = dao.storeReportRows().first().map { it.storeKey }.toSet()
+        val incrementalStores = dao.allStores()
         val incrementalDeliveryKeys = listOf("dT", "dM").associateWith { dao.deliveryRecordByTask(it)?.storeKey }
         val incrementalPickupKeys = dao.pickupRecordsForJob("J1").associate { it.taskId to it.storeKey }
 
@@ -239,13 +240,19 @@ class StoreResolutionProjectorTest {
         wipeAndResetWatermark()
         projector().catchUp()
         val refoldVisible = dao.storeReportRows().first().map { it.storeKey }.toSet()
+        val refoldStores = dao.allStores()
         val refoldDeliveryKeys = listOf("dT", "dM").associateWith { dao.deliveryRecordByTask(it)?.storeKey }
         val refoldPickupKeys = dao.pickupRecordsForJob("J1").associate { it.taskId to it.storeKey }
 
         // The READ-VISIBLE store set (M4 EXISTS-filtered) + ALL delivery + ALL pickup stamps converge.
-        // NOTE: the raw `stores` table can differ — the incremental path leaves an unreferenced chain-only
-        // orphan row (dT's early resolution before dM's receipt landed); that orphan is an ACCEPTED,
-        // read-invisible residual (M4 filters it out of every read), not a divergence that surfaces.
+        // #887: the RAW `stores` table now converges too. It used to differ — the incremental path left an
+        // unreferenced chain-only orphan (dT's early resolution, before dM's receipt landed), documented
+        // here as an accepted read-invisible residual. It is no longer accepted: dM's upgrade sweeps the
+        // key it superseded, so incremental lands on the refold's terminal set exactly.
+        assertEquals(
+            "RAW stores table identical incremental vs refold (#887 supersession sweep)",
+            refoldStores, incrementalStores,
+        )
         assertEquals("read-visible store set identical incremental vs refold", refoldVisible, incrementalVisible)
         assertEquals("delivery storeKeys identical", refoldDeliveryKeys, incrementalDeliveryKeys)
         assertEquals("pickup storeKeys identical", refoldPickupKeys, incrementalPickupKeys)
@@ -420,6 +427,148 @@ class StoreResolutionProjectorTest {
         assertEquals(setOf("@100", "@200", "@300", "@400", null), hebRunningKeys)
         assertEquals("doordash|h-e-b|@100", dao.deliveryRecordByTask("dH0")?.storeKey)
         assertEquals("doordash|h-e-b|", dao.deliveryRecordByTask("dH4")?.storeKey)
+    }
+
+    // ── #887: a monotonic key UPGRADE sweeps the identity row it superseded ──
+
+    private val cvsAddress = "23530 Bandera Rd, San Antonio, TX 78255, USA"
+    private val cvsAddressKey = "doordash|cvs|@23530"
+    private val cvsReceiptKey = "doordash|cvs|3551"
+
+    /**
+     * The fielded shape (07-27 pull, job-217): a receipt-less first drop keys the store off its pickup
+     * ADDRESS, a later drop's receipt upgrades it to the receipt tier — and the superseded address-tier
+     * `stores` row used to survive as a zero-visit phantom. The batch boundary BETWEEN the drops is what
+     * makes the intermediate row exist at all (in one batch the receipt evidence is already committed).
+     */
+    @Test
+    fun `#887 — a receipt upgrade over an address-tier key deletes the superseded stores row`() = runBlocking {
+        insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
+        insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickup("J1", "pC", "CVS", 1100, cvsAddress))
+        insert(AppEventType.DELIVERY_COMPLETED, "S1", 1200, delivery("J1", "dC1", "CVS", 1200, dropRealizedPay = 4.5))
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 1250,
+            delivery("J1", "dC2", "CVS", 1250, receipt("CVS (3551)" to 3.0), dropRealizedPay = 4.25),
+        )
+        insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300))
+
+        val p = projector()
+        // Batch 1 = DASH_START + pickup + drop1 → the receipt-less resolution mints the ADDRESS-tier row.
+        assertNotNull(p.processBatch(limit = 3))
+        assertNotNull("the address-tier row exists before the upgrade", dao.store(cvsAddressKey))
+        assertEquals(cvsAddressKey, dao.deliveryRecordByTask("dC1")?.storeKey)
+
+        // Batch 2 = drop2 (the receipt) + DASH_STOP → upgrade to the receipt tier.
+        while (p.processBatch(limit = 3) != null) { /* drain */ }
+
+        assertNull("the superseded address-tier stores row is GONE (#887)", dao.store(cvsAddressKey))
+        assertNotNull("the receipt-tier winner exists", dao.store(cvsReceiptKey))
+        assertEquals("winner keyed off the receipt", "3551", dao.store(cvsReceiptKey)!!.runningKey)
+        // Every visit row followed the upgrade — nothing is left pointing at the deleted entity.
+        assertEquals(cvsReceiptKey, dao.deliveryRecordByTask("dC1")?.storeKey)
+        assertEquals(cvsReceiptKey, dao.deliveryRecordByTask("dC2")?.storeKey)
+        assertEquals(cvsReceiptKey, dao.pickupRecordsForJob("J1").single().storeKey)
+        assertEquals("exactly one CVS identity row survives", 1, dao.allStores().count { it.normalizedChain == "cvs" })
+        // The sweep is store-identity only: the money columns are untouched.
+        assertEquals(4.5, dao.deliveryRecordByTask("dC1")!!.realizedPay!!, 0.001)
+    }
+
+    /**
+     * The guard: a row the re-key did NOT reach still references the superseded key ⇒ the entity is
+     * KEPT (fail toward keeping — deleting it would orphan a referencing row and blank its report card).
+     * Simulated with a pickup row from a DIFFERENT session's job (so the session-level DASH_STOP
+     * re-resolution never enumerates it), the same way the F8 test seeds an unreachable row.
+     */
+    @Test
+    fun `#887 guard — a superseded key still referenced by a row the re-key missed is KEPT`() = runBlocking {
+        insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
+        insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickup("J1", "pC", "CVS", 1100, cvsAddress))
+        insert(AppEventType.DELIVERY_COMPLETED, "S1", 1200, delivery("J1", "dC1", "CVS", 1200, dropRealizedPay = 4.5))
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 1250,
+            delivery("J1", "dC2", "CVS", 1250, receipt("CVS (3551)" to 3.0), dropRealizedPay = 4.25),
+        )
+        insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300))
+
+        val p = projector()
+        assertNotNull(p.processBatch(limit = 3)) // mints the address-tier row
+        assertNotNull(dao.store(cvsAddressKey))
+        // A visit row from another session's job, already keyed to the address-tier entity, that THIS
+        // job's re-key can never reach.
+        dao.upsertPickup(
+            PickupRecordEntity(
+                eventSequenceId = 88_888, sessionId = "S9", platform = "doordash", jobId = "JOTHER",
+                taskId = "pOTHER", storeName = "CVS", storeKey = cvsAddressKey,
+                phaseStartedAt = 500, arrivedAt = 520, confirmedAt = 560, deadlineMillis = null,
+                activity = "PICKUP", storeAddress = cvsAddress,
+            ),
+        )
+
+        while (p.processBatch(limit = 3) != null) { /* drain */ }
+
+        assertNotNull("the superseded entity is KEPT — a row still references it", dao.store(cvsAddressKey))
+        assertNotNull("the winner still exists alongside it", dao.store(cvsReceiptKey))
+        assertEquals("the unreached row keeps its key", cvsAddressKey, dao.pickupRecordsForJob("JOTHER").single().storeKey)
+        // This job's own rows still completed the upgrade.
+        assertEquals(cvsReceiptKey, dao.deliveryRecordByTask("dC1")?.storeKey)
+    }
+
+    /** Incremental (page boundary between the drops) ≡ from-zero refold on the RAW `stores` table —
+     *  the property the sweep buys: the refold never mints the intermediate row, incremental deletes it. */
+    @Test
+    fun `#887 — incremental across a page boundary equals a from-zero refold on the raw stores table`() = runBlocking {
+        insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
+        insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickup("J1", "pC", "CVS", 1100, cvsAddress))
+        insert(AppEventType.DELIVERY_COMPLETED, "S1", 1200, delivery("J1", "dC1", "CVS", 1200, dropRealizedPay = 4.5))
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 1250,
+            delivery("J1", "dC2", "CVS", 1250, receipt("CVS (3551)" to 3.0), dropRealizedPay = 4.25),
+        )
+        insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300))
+
+        val p = projector()
+        while (p.processBatch(limit = 3) != null) { /* drain */ }
+        val incStores = dao.allStores()
+        val incVisible = dao.storeReportRows().first().map { it.storeKey }.toSet()
+        val incKeys = listOf("dC1", "dC2").associateWith { dao.deliveryRecordByTask(it)?.storeKey }
+
+        wipeAndResetWatermark()
+        projector().catchUp() // ONE batch — the receipt evidence is committed before any resolution runs
+        val refStores = dao.allStores()
+
+        assertEquals("raw stores table identical incremental vs from-zero refold", refStores, incStores)
+        assertEquals("the refold never minted the address-tier row either", listOf(cvsReceiptKey), refStores.map { it.storeKey })
+        assertEquals(setOf(cvsReceiptKey), incVisible)
+        assertEquals(mapOf("dC1" to cvsReceiptKey, "dC2" to cvsReceiptKey), incKeys)
+    }
+
+    /** A later correction fold must not RESURRECT a swept identity row: no correction path writes the
+     *  `stores` table or stamps a storeKey — only resolution does, and it re-derives the winner. */
+    @Test
+    fun `#887 — a later correction fold does not resurrect the swept stores row`() = runBlocking {
+        insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
+        insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickup("J1", "pC", "CVS", 1100, cvsAddress))
+        val d1 = insert(AppEventType.DELIVERY_COMPLETED, "S1", 1200, delivery("J1", "dC1", "CVS", 1200, dropRealizedPay = 4.5))
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 1250,
+            delivery("J1", "dC2", "CVS", 1250, receipt("CVS (3551)" to 3.0), dropRealizedPay = 4.25),
+        )
+        insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300))
+        val p = projector()
+        while (p.processBatch(limit = 3) != null) { /* drain */ }
+        assertNull(dao.store(cvsAddressKey))
+
+        // A driver re-price + a cash-tip edit, folded in a LATER batch.
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "S1", 1400,
+            DeliveryAdjustmentPayload(targetEventSequenceId = d1, sessionId = "S1", newPay = 9.0, newCashTip = 2.0),
+        )
+        while (p.processBatch(limit = 3) != null) { /* drain */ }
+
+        assertNull("the swept address-tier row stays gone across a correction fold", dao.store(cvsAddressKey))
+        assertEquals(listOf(cvsReceiptKey), dao.allStores().map { it.storeKey })
+        assertEquals("the correction still applied", 9.0, dao.deliveryRecord(d1)!!.realizedPay!!, 0.001)
+        assertEquals(cvsReceiptKey, dao.deliveryRecord(d1)!!.storeKey)
     }
 
     // ── FIX 12d: F4 offer-link guards ──

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -119,6 +119,25 @@ interface AnalyticsDao {
     )
     suspend fun stampOfferOutcomeResolved(eventSequenceId: Long, resolved: String?)
 
+    /**
+     * How many read-model rows still point at [storeKey] — the #887 supersession guard's evidence.
+     * Counts ALL three tables that carry a resolved key (`pickup_records`, `delivery_records`,
+     * `offer_records`), which is a strict SUPERSET of the two the M4 report-card filter checks: the
+     * guard must fail toward KEEPING a store entity, so an offer-only reference still counts as a
+     * reference even though it renders no card.
+     */
+    @Query(
+        """SELECT (SELECT COUNT(*) FROM pickup_records WHERE storeKey = :storeKey)
+                + (SELECT COUNT(*) FROM delivery_records WHERE storeKey = :storeKey)
+                + (SELECT COUNT(*) FROM offer_records WHERE storeKey = :storeKey)"""
+    )
+    suspend fun storeKeyReferenceCount(storeKey: String): Int
+
+    /** Delete ONE store identity row (#887) — the superseded-key drop, run in the resolution
+     *  transaction only after [storeKeyReferenceCount] proves nothing references it. */
+    @Query("DELETE FROM stores WHERE storeKey = :storeKey")
+    suspend fun deleteStore(storeKey: String)
+
     /** All store entities (resolution debug / rebuild-equivalence assertions). */
     @Query("SELECT * FROM stores ORDER BY storeKey ASC")
     suspend fun allStores(): List<StoreEntity>

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -87,9 +87,15 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   **Nothing to watch while driving** — this is a projection-hygiene fix; no bubble, TTS, money, or
   Patterns-tab number changes. The `PROJECTOR_VERSION` 8→9 bump means the **first app launch after
   installing rebuilds the whole analytics read-model** (a one-time refold; the Money/Patterns tabs
-  should look identical afterwards — if any dollar figure MOVED, that's a finding).
+  should look identical afterwards — if any dollar figure MOVED, that's a finding, **except**
+  `CURRENT_FALLBACK`-basis rows if economy settings changed since the last refold (the precedented
+  re-stamp side effect — see the `PROJECTOR_VERSION` KDoc)).
   **Desk (next pull):** the issue's SQL should return **zero** rows —
   `SELECT storeKey FROM stores WHERE storeKey NOT IN (SELECT storeKey FROM pickup_records WHERE storeKey IS NOT NULL) AND storeKey NOT IN (SELECT storeKey FROM delivery_records WHERE storeKey IS NOT NULL) AND storeKey NOT IN (SELECT storeKey FROM offer_records WHERE storeKey IS NOT NULL);`
+  A non-zero row is expected **ONLY** if a store-name correction was made since the last refold —
+  that's the [#906](https://github.com/sjtrotter/DashBuddy/issues/906) residual (a
+  `DELIVERY_ADJUSTMENT` `newStoreName` edit nulls that row's key and can drop the last reference to
+  a store entity), **not** a #887 regression.
   Also grep the log for `superseded store entity kept:` — a WARN there means the guard fired (a row
   the re-key didn't reach), which is correct behaviour but worth a look at which store it was.
   - Confirmed: 0/2

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,21 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — #887 — no more phantom zero-visit stores in the Patterns tab's data.**
+  When one physical store was first keyed off its pickup ADDRESS (`doordash|cvs|@23530`, because that
+  drop carried no receipt) and a later receipt upgraded it to the real store code
+  (`doordash|cvs|3551`), the visits moved to the new key but the old identity row was left behind —
+  2 of 28 `stores` rows in the 07-27 pull were these zero-visit ghosts. Resolution now deletes the
+  superseded row in the same transaction, but only when nothing still points at it.
+  **Nothing to watch while driving** — this is a projection-hygiene fix; no bubble, TTS, money, or
+  Patterns-tab number changes. The `PROJECTOR_VERSION` 8→9 bump means the **first app launch after
+  installing rebuilds the whole analytics read-model** (a one-time refold; the Money/Patterns tabs
+  should look identical afterwards — if any dollar figure MOVED, that's a finding).
+  **Desk (next pull):** the issue's SQL should return **zero** rows —
+  `SELECT storeKey FROM stores WHERE storeKey NOT IN (SELECT storeKey FROM pickup_records WHERE storeKey IS NOT NULL) AND storeKey NOT IN (SELECT storeKey FROM delivery_records WHERE storeKey IS NOT NULL) AND storeKey NOT IN (SELECT storeKey FROM offer_records WHERE storeKey IS NOT NULL);`
+  Also grep the log for `superseded store entity kept:` — a WARN there means the guard fired (a row
+  the re-key didn't reach), which is correct behaviour but worth a look at which store it was.
+  - Confirmed: 0/2
 - **🆕 NEW — #882 / #881 — Uber stacked offers speak the STORE, and a "Match" is recorded as a match.**
   Two fixes on the same card. **#882:** a multi-order Uber card ("Delivery (2)") rendered its type
   chip above the one store line it shows, and the chip won the store read — so the bubble/TTS said


### PR DESCRIPTION
Closes #887.

## The defect

One physical store can be keyed at two tiers over its lifetime. A receipt-less drop keys it off the
pickup **address** (`doordash|cvs|@23530`, #773); a later drop's receipt upgrades it to the
**receipt** key (`doordash|cvs|3551`). The monotonic upgrade itself worked — `pickup_records` /
`delivery_records` were re-keyed correctly, no downgrade — but the superseded `stores` identity row
was left behind as a zero-visit phantom. **2 of 28 `stores` rows in the 07-27 pull** (`cvs|@23530`,
`pizza hut|@26210`, both stores of the 07-26 job-217 stack) matched no pickup/delivery/offer row.

Only arises when both tiers mint for one store (receipt-bearing chains visited pre-receipt); H-E-B
(address-only) and receipt-only flows are unaffected. Same mechanism, same fix, for the chain-only →
keyed upgrade — which is what the F1 test previously documented as an *"ACCEPTED, read-invisible
residual"*.

Fix direction (a) from the issue — the honest shape. Read-side masking was rejected.

## Decision: `PROJECTOR_VERSION` 8 → 9 (version bump, not a one-shot cleanup)

**Rationale.** The fielded orphans are already committed on-device, so the fix alone does not heal
them. Two options:

- **Version bump (chosen).** The established rebuild ≡ backfill pattern. The F8 wipe already clears
  `stores`/`pickup_records`, the refold repopulates them from the immutable log, and the new sweep
  means the terminal set is orphan-free by construction. **Zero new machinery** — the fold stays the
  single owner of what a `stores` row means (P5).
- **One-shot cleanup query.** Cheaper (no refold), and the code change *is* provably a no-op on
  every other table (it adds nothing but a guarded `DELETE FROM stores`), so this path was genuinely
  available. Rejected anyway: "run once" needs its own durable marker, which is a projector version
  in disguise — and it would create a **second** mechanism, outside the fold, deciding when a
  `stores` row may be deleted. That is exactly the SSOT divergence the #356 family exists to warn
  about, bought for a one-time refold cost on a single-user alpha DB.

**Scope of the bump is stated explicitly in the `PROJECTOR_VERSION` KDoc: the `stores` table only.**
Every delivery/session/offer/pickup column folds byte-identically. The one precedented side effect
(shared by v2/v3/v4/v6/v7/v8) stands: the refold re-stamps `CURRENT_FALLBACK` rows against today's
economy. **Frozen economics are untouched** — no `netProfit`, `realizedPay`, `frozenCostPerMile`,
`frozenFuelPerMile`/`frozenNonFuelPerMile`, `cashTip`, or `originalPayBasis` value is read or
written by this diff.

## The transaction change

In `StoreResolutionRunner.resolveJob`, per triggered job, inside the projector's existing batch
transaction:

1. Each re-stamp loop (pickup / delivery / offer) now records the row's **PRIOR** key as a
   supersession candidate — but only where the stamp actually lands:
   - a row blocked by the FIX-6 `isMonotonicDowngrade` backstop keeps its key ⇒ contributes nothing;
   - an **H1-pinned** delivery row is not re-keyed by the SQL (`WHERE storeKeyPinned = 0`) ⇒
     explicitly excluded in Kotlin so the two stay in agreement;
   - a row whose prior key already equals the new key ⇒ not a supersession.
2. `sweepSuperseded(candidates - anchorKey.values)` runs **strictly last** in the job — after every
   pickup, delivery *and* offer stamp is committed — so the reference count sees the post-re-key
   world (an offer re-keyed onto the winner is not miscounted as a reference to the loser).
3. Each candidate is deleted only if the new
   `AnalyticsDao.storeKeyReferenceCount(storeKey)` returns 0.

New DAO members (no schema change — `stores.storeKey` is the PK; nothing added to any entity, so no
Room `VERSION` bump and no migration):

```sql
-- storeKeyReferenceCount
SELECT (SELECT COUNT(*) FROM pickup_records   WHERE storeKey = :storeKey)
     + (SELECT COUNT(*) FROM delivery_records WHERE storeKey = :storeKey)
     + (SELECT COUNT(*) FROM offer_records    WHERE storeKey = :storeKey)

-- deleteStore
DELETE FROM stores WHERE storeKey = :storeKey
```

## Guard semantics — fail toward KEEPING

The count spans **all three** tables that carry a resolved key, a strict superset of the two the M4
`storeReportRows` `EXISTS` filter checks: an offer-only reference renders no card but is still a
reference.

A superseded key with any surviving reference is **kept**, not deleted. The realistic shapes:

- **Another job's pre-receipt visits** to the same physical store, resolved before any receipt
  existed and never re-keyed by *this* job's resolution.
- An **H1-pinned** delivery row (though today the pin path nulls `storeKey`, so it usually
  contributes no reference).
- An offer row whose `stampOfferLink` claim guard (`linkedJobId IS NULL OR = :jobId`) blocked the
  re-stamp.

Deleting an entity that a row still points at would orphan that row and blank its report card —
strictly worse than a phantom the read side already filters out. The kept case is observable: a
**merchant-free WARN** (`superseded store entity kept: N row(s) …`) plus a DEBUG line carrying the
key. **P7:** `storeKey` embeds `normalizedChain`, i.e. merchant data, so it never reaches INFO+ —
the same DEBUG-keys / WARN-counts split `isMonotonicDowngrade` already uses.

Convergence is preserved: when the still-referencing job is itself later re-resolved onto the
winner, its own supersession candidate set contains the same key, the count drops to 0, and the row
is swept then. Cross-job order is deterministic (`jobIdsForSession` is `ORDER BY jobId ASC`).

## Refold determinism

The delete is a pure function of the rows committed at that point in the seq-ordered resolution
stream (`resolutions.sortedBy { sequenceId }`), so it replays identically on a from-zero refold.

More than that, it **repairs an existing divergence**. Transaction order is
deliveries → offers → pickups → sessions → adjustments → resolutions, so:

- **From-zero refold, one batch:** the second drop's `payoutStoreForms` is already committed when
  the *first* drop's resolution runs ⇒ the receipt key is resolved immediately ⇒ the intermediate
  address-tier row **is never minted**.
- **Incremental, page boundary between the drops:** drop 1's resolution mints the address-tier row;
  drop 2's resolution upgrades ⇒ the row is orphaned.

Terminal `stores` set therefore *differed* between incremental and refold before this change (the
F1 test conceded exactly this in a comment). With the sweep, incremental mints-then-deletes and
lands on the refold's set exactly — `allStores()` equality is now asserted in both F1 and the new
#887 test. Page-independent by construction, since each resolution reads committed rows only.

**Corrections cannot resurrect a swept row.** No correction path writes `stores` or stamps a
`storeKey` at a deleted key: `applyPayAdjustment` / `applySessionAssign` preserve `storeKey` via
`row.copy`; `applyDeliveryAdjustment` only ever *nulls* it (+ sets the pin);
`applyOfferReconcile` / `applyOfferOutcomeCorrection` touch `outcomeResolved` alone. `upsertStore`
in the resolution runner is the sole creator, and it re-derives the winner. Pinned by test.

*(Noted, out of scope: a `DELIVERY_ADJUSTMENT` `newStoreName` correction nulls that row's key and
could in principle drop the last reference to a store entity. It is a different mechanism from the
upgrade path this issue names, it is masked by the same M4 filter, and widening the sweep to a
global unreferenced-row scan would make it depend on rows outside the triggered job — a
determinism hazard. Left alone deliberately.)*

## Tests

`core/data/.../StoreResolutionProjectorTest` (Robolectric + in-memory Room, the #159/#688B pattern):

| Test | Proves |
|---|---|
| `#887 — a receipt upgrade over an address-tier key deletes the superseded stores row` | The fielded shape end-to-end: batch 1 mints `doordash|cvs|@23530` (asserted present), batch 2's receipt upgrades to `doordash|cvs|3551`, superseded row **gone**, pickup + both deliveries re-keyed, exactly one CVS row survives, money columns untouched |
| `#887 guard — a superseded key still referenced by a row the re-key missed is KEPT` | A `pickup_records` row from another session's job holding `@23530` (unreachable via `jobIdsForSession`) ⇒ the entity survives and the unreached row keeps its key, while this job still upgrades |
| `#887 — incremental across a page boundary equals a from-zero refold on the raw stores table` | `allStores()` equality; also asserts the refold never minted the intermediate row |
| `#887 — a later correction fold does not resurrect the swept stores row` | A `DELIVERY_ADJUSTMENT` folded in a later batch leaves the swept key absent while the correction itself applies |
| `F1 — …` (existing, tightened) | Raw `stores` equality added; the "accepted read-invisible residual" comment retired |

**Mutation-verified both ways:**

- Comment out `sweepSuperseded(…)` ⇒ **4 tests red** (the three #887 upgrade/refold tests + F1).
- Force the guard off (`if (false && refs > 0)`) ⇒ the guard test goes **red** while the rest stay
  green (proves the guard, not just the delete, is load-bearing).

**Runs:** `:core:data:testDebugUnitTest --tests "*StoreResolutionProjectorTest*"` green (15/15);
`:core:data:testDebugUnitTest :domain:test` green; full `./gradlew testDebugUnitTest :domain:test`
green.

## Desk note (next pull)

The issue's SQL should return **zero** rows:

```sql
SELECT storeKey FROM stores
WHERE storeKey NOT IN (SELECT storeKey FROM pickup_records   WHERE storeKey IS NOT NULL)
  AND storeKey NOT IN (SELECT storeKey FROM delivery_records WHERE storeKey IS NOT NULL)
  AND storeKey NOT IN (SELECT storeKey FROM offer_records    WHERE storeKey IS NOT NULL);
```

Also grep the log for `superseded store entity kept:` — a WARN there means the guard fired (correct
behaviour, but worth knowing which store). Checklist item added to
`docs/field-testing/README.md` at `Confirmed: 0/2`, including the note that the first launch after
install performs the one-time v8→v9 refold and that **any dollar figure moving is a finding**.

### Design-goal review

- **P1 UDF.** Read-model only. The sweep runs at the projector edge inside the existing batch
  transaction; the pure `:domain` fold (`RecordFolds`/`StoreResolver`/`StoreKeys`) is untouched, and
  nothing here re-enters the state machine.
- **P3 single responsibility.** The delete lives in one small private `sweepSuperseded` on the
  existing row adapter that already owns `stores` writes — not a new class, not a second cleanup
  service. `StoreResolutionRunner` stays well under the size line.
- **P4 Kotlin/Android.** `LinkedHashSet` for deterministic candidate order; set subtraction rather
  than an index guard; the pin/downgrade exclusions are expressed as data conditions, not control
  flow duplicated from SQL.
- **P5 SSOT — the load-bearing one.** The fold remains the **single** mechanism that decides a
  `stores` row's existence: it mints them and now retires them, in the same transaction, from the
  same evidence. The rejected one-shot cleanup would have been a second owner. The reference
  question is answered by one DAO query rather than a hand-maintained "is this key used" notion, and
  the Kotlin pin exclusion is written to mirror the `WHERE storeKeyPinned = 0` predicate it shadows.
- **P6 security/privacy.** No recognition, capture, network or effects surface touched. Store
  names/keys are **merchant** data (never customer PII); no customer hash is read. The change only
  ever *removes* merchant data from the DB. The guard is fail-toward-keeping (data preservation),
  and the DB stays intact for every referencing row.
- **P7 semantic, PII-safe logging.** Two new sites, both inside the sweep: DEBUG carries the
  `storeKey` (merchant-derived ⇒ firehose only), WARN carries a **count only** and names no store —
  the `isMonotonicDowngrade` precedent. Nothing new at INFO+. WARN is correct here: a defended
  invariant fired (a superseded entity was retained because a row the re-key missed still points at
  it), and it is rare, so it will not drown the shareable stream.
- **P8 platform-agnostic core.** No `Platform` literal, package name, or wire string anywhere in the
  diff. The candidate set and reference count are derived entirely from row values; the `platform`
  segment rides inside `storeKey` exactly as `StoreKeys.storeKey` built it.
- **Reactive UI:** no UI diff. Room invalidation on `stores` re-emits `storeReportRows` /
  `storeChainDisplays`, so the Patterns tab updates itself; the deleted rows were already
  `EXISTS`-filtered out of `storeReportRows`, so no visible card changes.
- **Context updates:** CLAUDE.md §Analytics Read-Model gains the #887 paragraph (mechanism, guard
  semantics, the refold-convergence property, the version bump); `docs/field-testing/README.md`
  gains the `Confirmed: 0/2` item.
