### PR TITLE
rules(doordash): #888 recognize eight 07-27-census UNKNOWN surfaces (recognize-only batch)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/AddonPhantomReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/AddonPhantomReplayTest.kt
@@ -16,8 +16,11 @@ import org.junit.Test
  * Defense-in-depth fix, two independent guards:
  *  - **recognition** (this test): `delivery_summary_collapsed` now rejects the offer-only markers
  *    `"High paying offer"` / `"Total will be higher"` / `"Additional"`, so an add-on offer frame can
- *    no longer masquerade as a delivery summary (it falls through to UNKNOWN — harmless, never
- *    forwarded to the state machine).
+ *    no longer masquerade as a delivery summary. (#888 update: it no longer falls through to
+ *    UNKNOWN either — this is a post-accept teardown frame, the Accept footer already gone, so
+ *    `doordash.screen.offer_accepting` now claims it. That rule is RECOGNIZE-ONLY: no `state.flow`,
+ *    no parse, so the frame still cannot drive a summary exit or any other lifecycle edge; the
+ *    assertion below is unchanged and still the guard that matters.)
  *  - **state** ([cloud.trotter.dashbuddy.core.state.EffectMapTest], #564): a PostTask exit only
  *    completes a task that actually reached `TaskPhase.DROPOFF`, so a retired PICKUP can never
  *    complete even if some other frame trips the exit.

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -1420,9 +1420,27 @@
         "shape": null,
         "fields": {}
     },
+    "dropoff_continue_to_complete/2026-07-26_14-57-28-118__doordash__accessibility.window__UNKNOWN__02dac9.json": {
+        "ruleId": "doordash.screen.dropoff_continue_to_complete",
+        "intent": "dropoff_continue_to_complete",
+        "shape": null,
+        "fields": {}
+    },
     "dropoff_geofence_warning/2026-07-17_20-46-59-561__doordash__accessibility.window__dropoff_geofence_warning__f100d7.json": {
         "ruleId": "doordash.screen.dropoff_geofence_warning",
         "intent": "dropoff_geofence_warning",
+        "shape": null,
+        "fields": {}
+    },
+    "dropoff_geofence_warning/2026-07-26_14-57-25-649__doordash__accessibility.window__UNKNOWN__c336f4.json": {
+        "ruleId": "doordash.screen.dropoff_geofence_warning",
+        "intent": "dropoff_geofence_warning",
+        "shape": null,
+        "fields": {}
+    },
+    "dropoff_handed_directly_confirm/2026-07-26_21-21-27-813__doordash__accessibility.window__UNKNOWN__d7bf38.json": {
+        "ruleId": "doordash.screen.dropoff_handed_directly_confirm",
+        "intent": "dropoff_handed_directly_confirm",
         "shape": null,
         "fields": {}
     },
@@ -1471,6 +1489,12 @@
     "dropoff_handoff/20260128_180855_435_DROPOFF_DETAILS_PRE_ARRIVAL.json": {
         "ruleId": "doordash.screen.dropoff_handoff",
         "intent": "dropoff_handoff",
+        "shape": null,
+        "fields": {}
+    },
+    "dropoff_help_menu/2026-07-26_14-57-27-333__doordash__accessibility.window__UNKNOWN__7ed79f.json": {
+        "ruleId": "doordash.screen.dropoff_help_menu",
+        "intent": "dropoff_help_menu",
         "shape": null,
         "fields": {}
     },
@@ -3108,6 +3132,18 @@
             "parsedOffer": "ParsedOffer(offerHash=2142626f9b179829832f665436b00fafae2bf21ce11b052c6707f55ca3dd318f, presentationKey=b99b2492a1b22c758035feae76f98b1eaf18771fd1daa091ac745294de70d6f6, itemCount=0, itemCountIsUnits=false, payAmount=13.04, payTextRaw=null, distanceMiles=14.0, distanceTextRaw=null, dueByTimeText=null, dueByTimeMillis=null, timeToCompleteMinutes=39, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Delivery (2), itemCount=1, isItemCountEstimated=true, badges=[], countUnit=ITEMS)], offerKind=MATCH, displayStoreName=Sonic (3035 Tpc Pkwy), rawExtractedTexts=null)"
         }
     },
+    "offer_accepting/2026-07-26_11-26-00-810__doordash__accessibility.window__UNKNOWN__c43214.json": {
+        "ruleId": "doordash.screen.offer_accepting",
+        "intent": "offer_accepting",
+        "shape": null,
+        "fields": {}
+    },
+    "offer_accepting/2026-07-26_13-27-46-799__doordash__accessibility.window__UNKNOWN__57b5b8.json": {
+        "ruleId": "doordash.screen.offer_accepting",
+        "intent": "offer_accepting",
+        "shape": null,
+        "fields": {}
+    },
     "offer_popup/20260128_163448_533_OFFER_POPUP.json": {
         "ruleId": "doordash.screen.offer_popup",
         "intent": "offer_popup",
@@ -3705,6 +3741,12 @@
         "shape": null,
         "fields": {}
     },
+    "pickup_confirm_picked_up/2026-07-26_21-10-54-490__doordash__accessibility.window__UNKNOWN__0bdb1d.json": {
+        "ruleId": "doordash.screen.pickup_confirm_picked_up",
+        "intent": "pickup_confirm_picked_up",
+        "shape": null,
+        "fields": {}
+    },
     "pickup_issue_menu/2026-07-18_17-36-04-600__doordash__accessibility.window__pickup_issue_menu__e0e12f.json": {
         "ruleId": "doordash.screen.pickup_issue_menu",
         "intent": "pickup_issue_menu",
@@ -4025,6 +4067,24 @@
             "storeName": "[redacted]",
             "subFlow": "NAVIGATION"
         }
+    },
+    "pickup_pizza_bag/2026-07-26_21-10-26-597__doordash__accessibility.window__UNKNOWN__0a4147.json": {
+        "ruleId": "doordash.screen.pickup_pizza_bag",
+        "intent": "pickup_pizza_bag",
+        "shape": null,
+        "fields": {}
+    },
+    "pickup_pizza_bag/2026-07-26_21-10-49-903__doordash__accessibility.window__UNKNOWN__71b1a1.json": {
+        "ruleId": "doordash.screen.pickup_pizza_bag",
+        "intent": "pickup_pizza_bag",
+        "shape": null,
+        "fields": {}
+    },
+    "pickup_pizza_bag/2026-07-26_21-10-51-086__doordash__accessibility.window__UNKNOWN__063e5d.json": {
+        "ruleId": "doordash.screen.pickup_pizza_bag",
+        "intent": "pickup_pizza_bag",
+        "shape": null,
+        "fields": {}
     },
     "pickup_post_arrival_multi/2026-07-17_20-31-32-611__doordash__accessibility.window__pickup_post_arrival_multi__d2fa09.json": {
         "ruleId": "doordash.screen.pickup_post_arrival_multi",
@@ -4804,6 +4864,12 @@
         }
     },
     "pickup_wait_survey/2026-06-12__doordash__pickup_wait_survey__d90d0f.json": {
+        "ruleId": "doordash.screen.pickup_wait_survey",
+        "intent": "pickup_wait_survey",
+        "shape": null,
+        "fields": {}
+    },
+    "pickup_wait_survey/2026-07-26_21-08-27-628__doordash__accessibility.window__UNKNOWN__24d30f.json": {
         "ruleId": "doordash.screen.pickup_wait_survey",
         "intent": "pickup_wait_survey",
         "shape": null,
@@ -5589,6 +5655,18 @@
     "shopping_item_status/2026-07-19_17-24-25-195__doordash__accessibility.window__shopping_item_status__21722c.json": {
         "ruleId": "doordash.screen.shopping_item_status",
         "intent": "shopping_item_status",
+        "shape": null,
+        "fields": {}
+    },
+    "shopping_pay_adjustment/2026-07-26_14-00-04-853__doordash__accessibility.window__UNKNOWN__e0f9f2.json": {
+        "ruleId": "doordash.screen.shopping_pay_adjustment",
+        "intent": "shopping_pay_adjustment",
+        "shape": null,
+        "fields": {}
+    },
+    "shopping_shelf_photo/2026-07-26_16-44-36-459__doordash__accessibility.window__UNKNOWN__aa7d10.json": {
+        "ruleId": "doordash.screen.shopping_shelf_photo",
+        "intent": "shopping_shelf_photo",
         "shape": null,
         "fields": {}
     },

--- a/app/src/test/resources/snapshots/dropoff_continue_to_complete/2026-07-26_14-57-28-118__doordash__accessibility.window__UNKNOWN__02dac9.json
+++ b/app/src/test/resources/snapshots/dropoff_continue_to_complete/2026-07-26_14-57-28-118__doordash__accessibility.window__UNKNOWN__02dac9.json
@@ -1,0 +1,334 @@
+{
+    "captureId": "1d4ca611-28cd-45ab-b4fc-2dbea6720648",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785095848108,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 2400,
+            "right": 1080,
+            "bottom": 4800
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2400,
+                    "right": 1080,
+                    "bottom": 4747
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 2536,
+                            "right": 1080,
+                            "bottom": 4747
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 2536,
+                                    "right": 1080,
+                                    "bottom": 4747
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2536,
+                                            "right": 1080,
+                                            "bottom": 4747
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/layout_bottom_sheet",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 2536,
+                                                    "right": 1080,
+                                                    "bottom": 4747
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/overlay_view",
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2536,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4252,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4252,
+                                                                    "right": 1080,
+                                                                    "bottom": 4288
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/handle_overlay",
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 4252,
+                                                                            "right": 1080,
+                                                                            "bottom": 4288
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/handle_overlay_image",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 4270,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4279
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "text": "Continue to complete delivery",
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_title",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 36,
+                                                                    "top": 4324,
+                                                                    "right": 1044,
+                                                                    "bottom": 4408
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4444,
+                                                                    "right": 1080,
+                                                                    "bottom": 4711
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 4444,
+                                                                            "right": 1080,
+                                                                            "bottom": 4711
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 4444,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4568
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Thanks for letting us know. Continue to complete the delivery as per the customer's instructions.",
+                                                                                        "id": "com.doordash.driverapp:id/prism_sheet_message",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 4444,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 4568
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 4568,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 4568
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/container",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 4568,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 4568
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_header_divider",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4444,
+                                                                    "right": 1080,
+                                                                    "bottom": 4453
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4564,
+                                                            "right": 1080,
+                                                            "bottom": 4568
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4568,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_actions_container",
+                                                                "class": "android.widget.LinearLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4568,
+                                                                    "right": 1080,
+                                                                    "bottom": 4747
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.Button",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 4604,
+                                                                            "right": 1044,
+                                                                            "bottom": 4711
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "text": "Continue to delivery steps",
+                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 272,
+                                                                                    "top": 4625,
+                                                                                    "right": 808,
+                                                                                    "bottom": 4691
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 4747,
+                    "right": 1080,
+                    "bottom": 4800
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/dropoff_geofence_warning/2026-07-26_14-57-25-649__doordash__accessibility.window__UNKNOWN__c336f4.json
+++ b/app/src/test/resources/snapshots/dropoff_geofence_warning/2026-07-26_14-57-25-649__doordash__accessibility.window__UNKNOWN__c336f4.json
@@ -1,0 +1,470 @@
+{
+    "captureId": "3b1f97b8-3059-417b-8514-21c54e1639cd",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785095845645,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 2365,
+            "right": 1080,
+            "bottom": 4765
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2365,
+                    "right": 1080,
+                    "bottom": 4712
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 2501,
+                            "right": 1080,
+                            "bottom": 4712
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 2501,
+                                    "right": 1080,
+                                    "bottom": 4712
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2501,
+                                            "right": 1080,
+                                            "bottom": 4712
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/layout_bottom_sheet",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 2501,
+                                                    "right": 1080,
+                                                    "bottom": 4712
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/overlay_view",
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2501,
+                                                            "right": 1080,
+                                                            "bottom": 4712
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 3547,
+                                                            "right": 1080,
+                                                            "bottom": 4712
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 3547,
+                                                                    "right": 1080,
+                                                                    "bottom": 3547
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 3619,
+                                                                    "right": 1080,
+                                                                    "bottom": 4676
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 3619,
+                                                                            "right": 1080,
+                                                                            "bottom": 4676
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 3619,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4676
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 3619,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 4676
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/container",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 3619,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 4676
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 3619,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 4676
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/address_instructions_view",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3619,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3865
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/address_divider",
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3655,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 3657
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/ic_address",
+                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 3693,
+                                                                                                                            "right": 89,
+                                                                                                                            "bottom": 3746
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/address_line_1",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 125,
+                                                                                                                            "top": 3693,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 3735
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/address_line_2",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 125,
+                                                                                                                            "top": 3735,
+                                                                                                                            "right": 1062,
+                                                                                                                            "bottom": 3782
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/address_subpremise_line",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 125,
+                                                                                                                            "top": 3782,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 3829
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3865,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 4399
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/geofence_warning_map",
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3865,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 4399
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 3865,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 4399
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 3865,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 4399
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 3865,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 4399
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 3865,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 4399
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 5,
+                                                                                                                                                    "top": 4347,
+                                                                                                                                                    "right": 194,
+                                                                                                                                                    "bottom": 4394
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 200,
+                                                                                                                                                    "top": 4347,
+                                                                                                                                                    "right": 247,
+                                                                                                                                                    "bottom": 4394
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "desc": "Got it",
+                                                                                                                "id": "com.doordash.driverapp:id/button_primary_action",
+                                                                                                                "class": "android.widget.Button",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 27,
+                                                                                                                    "top": 4444,
+                                                                                                                    "right": 1053,
+                                                                                                                    "bottom": 4551
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Got it",
+                                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 482,
+                                                                                                                            "top": 4465,
+                                                                                                                            "right": 599,
+                                                                                                                            "bottom": 4531
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "desc": "I need help",
+                                                                                                                "id": "com.doordash.driverapp:id/button_secondary_action",
+                                                                                                                "class": "android.widget.Button",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 27,
+                                                                                                                    "top": 4569,
+                                                                                                                    "right": 1053,
+                                                                                                                    "bottom": 4676
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "I need help",
+                                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 426,
+                                                                                                                            "top": 4590,
+                                                                                                                            "right": 654,
+                                                                                                                            "bottom": 4656
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_header_divider",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 3619,
+                                                                    "right": 1080,
+                                                                    "bottom": 3628
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4708,
+                                                            "right": 1080,
+                                                            "bottom": 4712
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4712,
+                                                            "right": 1080,
+                                                            "bottom": 4712
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 4712,
+                    "right": 1080,
+                    "bottom": 4765
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/dropoff_handed_directly_confirm/2026-07-26_21-21-27-813__doordash__accessibility.window__UNKNOWN__d7bf38.json
+++ b/app/src/test/resources/snapshots/dropoff_handed_directly_confirm/2026-07-26_21-21-27-813__doordash__accessibility.window__UNKNOWN__d7bf38.json
@@ -1,0 +1,407 @@
+{
+    "captureId": "79f9fcab-2198-479d-b36d-fb37485b780d",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785118887805,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2400,
+                    "right": 1080,
+                    "bottom": 4747
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 2536,
+                            "right": 1080,
+                            "bottom": 4747
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 2536,
+                                    "right": 1080,
+                                    "bottom": 4747
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2536,
+                                            "right": 1080,
+                                            "bottom": 4747
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/layout_bottom_sheet",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 2536,
+                                                    "right": 1080,
+                                                    "bottom": 4747
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/overlay_view",
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2536,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 3974,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 3974,
+                                                                    "right": 1080,
+                                                                    "bottom": 4010
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/handle_overlay",
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 3974,
+                                                                            "right": 1080,
+                                                                            "bottom": 4010
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/handle_overlay_image",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 3992,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4001
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4010,
+                                                                    "right": 1080,
+                                                                    "bottom": 4711
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 4010,
+                                                                            "right": 1080,
+                                                                            "bottom": 4711
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 4010,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4711
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 4010,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 4711
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/recycler",
+                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 4010,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 4711
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 4010,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 4228
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "Confirm you handed order directly to customer",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 4063,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 4210
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 4228,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 4461
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "We will verify with the customer if the order was delivered. If you haven’t directly handed them the order, go back and follow the steps.",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 4246,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 4408
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 4461,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 4711
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 4461,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 4711
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/button_group_vertical_container",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 4461,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 4711
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isClickable": true,
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 4479,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 4586
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Confirm to complete delivery",
+                                                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 241,
+                                                                                                                                            "top": 4500,
+                                                                                                                                            "right": 840,
+                                                                                                                                            "bottom": 4566
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isClickable": true,
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 4604,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 4711
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Go back",
+                                                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 456,
+                                                                                                                                            "top": 4625,
+                                                                                                                                            "right": 625,
+                                                                                                                                            "bottom": 4691
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4743,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4747,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/content",
+                                                                "class": "android.widget.LinearLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4747,
+                                                                    "right": 1080,
+                                                                    "bottom": 4747
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 4747,
+                    "right": 1080,
+                    "bottom": 4800
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/dropoff_help_menu/2026-07-26_14-57-27-333__doordash__accessibility.window__UNKNOWN__7ed79f.json
+++ b/app/src/test/resources/snapshots/dropoff_help_menu/2026-07-26_14-57-27-333__doordash__accessibility.window__UNKNOWN__7ed79f.json
@@ -1,0 +1,754 @@
+{
+    "captureId": "c3aad7fc-a09c-4359-944e-62f48eee6905",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785095847316,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 2400,
+            "right": 1080,
+            "bottom": 4800
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2400,
+                    "right": 1080,
+                    "bottom": 4747
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 2536,
+                            "right": 1080,
+                            "bottom": 4747
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 2536,
+                                    "right": 1080,
+                                    "bottom": 4747
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2536,
+                                            "right": 1080,
+                                            "bottom": 4747
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/layout_bottom_sheet",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 2536,
+                                                    "right": 1080,
+                                                    "bottom": 4747
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/overlay_view",
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2536,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2624,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 2624,
+                                                                    "right": 1080,
+                                                                    "bottom": 2624
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_navigation_button",
+                                                                "class": "android.widget.Button",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 2653,
+                                                                    "right": 107,
+                                                                    "bottom": 2760
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/imageView_prism_button_icon",
+                                                                        "class": "android.widget.ImageView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 27,
+                                                                            "top": 2680,
+                                                                            "right": 80,
+                                                                            "bottom": 2733
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "text": "Help",
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_title",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 107,
+                                                                    "top": 2660,
+                                                                    "right": 1044,
+                                                                    "bottom": 2744
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 2780,
+                                                                    "right": 1080,
+                                                                    "bottom": 4711
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2780,
+                                                                            "right": 1080,
+                                                                            "bottom": 4711
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 2780,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4711
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Tell us what happened and we’ll help you find the right resolution.",
+                                                                                        "id": "com.doordash.driverapp:id/prism_sheet_message",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 2780,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2904
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2904,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 4711
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 2904,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 4711
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/epoxy_recycler_view",
+                                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 2904,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 4043
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 2904,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3029
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "I delivered the order",
+                                                                                                                        "id": "com.doordash.driverapp:id/title_view",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 2904,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 3029
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3029,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3154
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Provided address or map pin is wrong",
+                                                                                                                        "id": "com.doordash.driverapp:id/help_menu_item",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3029,
+                                                                                                                            "right": 1008,
+                                                                                                                            "bottom": 3154
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 1008,
+                                                                                                                            "top": 3073,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 3109
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3154,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3156
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3154,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 3156
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3156,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3281
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Customer asked me to deliver here",
+                                                                                                                        "id": "com.doordash.driverapp:id/help_menu_item",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3156,
+                                                                                                                            "right": 1008,
+                                                                                                                            "bottom": 3281
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 1008,
+                                                                                                                            "top": 3200,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 3236
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3281,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3283
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3281,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 3283
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3283,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3408
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Bad GPS signal or app issue at drop-off",
+                                                                                                                        "id": "com.doordash.driverapp:id/help_menu_item",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3283,
+                                                                                                                            "right": 1008,
+                                                                                                                            "bottom": 3408
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 1008,
+                                                                                                                            "top": 3327,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 3363
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3408,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3410
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3408,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 3410
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3410,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3535
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Forgot to complete order at drop-off",
+                                                                                                                        "id": "com.doordash.driverapp:id/help_menu_item",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3410,
+                                                                                                                            "right": 1008,
+                                                                                                                            "bottom": 3535
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 1008,
+                                                                                                                            "top": 3454,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 3490
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3535,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3537
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3535,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 3537
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3537,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3662
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "I’m experiencing an issue",
+                                                                                                                        "id": "com.doordash.driverapp:id/title_view",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3537,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 3662
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3662,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3787
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Can’t find or access customer’s location",
+                                                                                                                        "id": "com.doordash.driverapp:id/help_menu_item",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3662,
+                                                                                                                            "right": 1008,
+                                                                                                                            "bottom": 3787
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 1008,
+                                                                                                                            "top": 3706,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 3742
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3787,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3789
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3787,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 3789
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3789,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3914
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "I couldn't pick up the order",
+                                                                                                                        "id": "com.doordash.driverapp:id/help_menu_item",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3789,
+                                                                                                                            "right": 1008,
+                                                                                                                            "bottom": 3914
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 1008,
+                                                                                                                            "top": 3833,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 3869
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3914,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 3916
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3914,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 3916
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 3916,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 4041
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Chat with an agent",
+                                                                                                                        "id": "com.doordash.driverapp:id/help_menu_item",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 3916,
+                                                                                                                            "right": 1008,
+                                                                                                                            "bottom": 4041
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 1008,
+                                                                                                                            "top": 3960,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 3996
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 4041,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 4043
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 4041,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 4043
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_header_divider",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 2780,
+                                                                    "right": 1080,
+                                                                    "bottom": 2789
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4743,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4747,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 4747,
+                    "right": 1080,
+                    "bottom": 4800
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/offer_accepting/2026-07-26_11-26-00-810__doordash__accessibility.window__UNKNOWN__c43214.json
+++ b/app/src/test/resources/snapshots/offer_accepting/2026-07-26_11-26-00-810__doordash__accessibility.window__UNKNOWN__c43214.json
@@ -1,0 +1,811 @@
+{
+    "captureId": "c0de1c63-35dc-4b89-91f0-2c65a933e8a4",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785083160806,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/accept_decline_fragment_container",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/bottomSheetLayout",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/accept_constraint_layout",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/map_container",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.TextureView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 5,
+                                                                                                    "top": 1479,
+                                                                                                    "right": 194,
+                                                                                                    "bottom": 1526
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 200,
+                                                                                                    "top": 1479,
+                                                                                                    "right": 247,
+                                                                                                    "bottom": 1526
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/secondary_action_button_dash_plus",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "bounds": {
+                                                                                    "left": 816,
+                                                                                    "top": 172,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 297
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Decline",
+                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "bounds": {
+                                                                                            "left": 852,
+                                                                                            "top": 202,
+                                                                                            "right": 1008,
+                                                                                            "bottom": 268
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "text": "18a0f5c2-024d-428f-b337-fca594c2d32e",
+                                                                                "id": "com.doordash.driverapp:id/assignment_id_text",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 715,
+                                                                                    "top": 1485,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1526
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/load_progress",
+                                                                        "class": "android.widget.RelativeLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "state": "in progress",
+                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                "class": "android.widget.ProgressBar",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 486,
+                                                                                    "top": 1188,
+                                                                                    "right": 593,
+                                                                                    "bottom": 1295
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/progress_message",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 540,
+                                                                                    "top": 1295,
+                                                                                    "right": 540,
+                                                                                    "bottom": 1342
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 1526,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1526,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1526
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/extra_space",
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1526,
+                                                                                    "right": 0,
+                                                                                    "bottom": 1562
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1562,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2311
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                                        "class": "android.widget.ScrollView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1562,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1562,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2151
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1562,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2151
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/accept_decline_recycler_view_container",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1562,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2151
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/items_recycler_view",
+                                                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1562,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2151
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1562,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1563
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1563,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1647
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1563,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1647
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "$14.45  Guaranteed (incl. tips)",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1563,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1647
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1647,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1712
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1647,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1712
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "3.3 mi",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1647,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1712
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1712,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1768
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1712,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1768
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Deliver by 12:11 PM",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1712,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1768
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1768,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1808
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1804,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1808
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1808,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1952
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1808,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1952
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_icon_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 45,
+                                                                                                                                                    "top": 1835,
+                                                                                                                                                    "right": 99,
+                                                                                                                                                    "bottom": 1889
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.doordash.driverapp:id/work_unit_image",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 45,
+                                                                                                                                                            "top": 1835,
+                                                                                                                                                            "right": 99,
+                                                                                                                                                            "bottom": 1889
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Shop for items",
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_type",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 1841,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1883
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/bottom_vertical_line",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 71,
+                                                                                                                                                    "top": 1889,
+                                                                                                                                                    "right": 73,
+                                                                                                                                                    "bottom": 1952
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name_container",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 1901,
+                                                                                                                                                    "right": 972,
+                                                                                                                                                    "bottom": 1952
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "text": "H-E-B",
+                                                                                                                                                        "id": "com.doordash.driverapp:id/display_name",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 126,
+                                                                                                                                                            "top": 1901,
+                                                                                                                                                            "right": 264,
+                                                                                                                                                            "bottom": 1952
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "text": "(25 units)",
+                                                                                                                                                        "id": "com.doordash.driverapp:id/display_name_secondary",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 264,
+                                                                                                                                                            "top": 1901,
+                                                                                                                                                            "right": 436,
+                                                                                                                                                            "bottom": 1952
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/chevron",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1008,
+                                                                                                                                                    "top": 1912,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1952
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1952,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2033
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1952,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2033
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/top_vertical_line",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 71,
+                                                                                                                                                    "top": 1952,
+                                                                                                                                                    "right": 73,
+                                                                                                                                                    "bottom": 1979
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_image",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 45,
+                                                                                                                                                    "top": 1979,
+                                                                                                                                                    "right": 99,
+                                                                                                                                                    "bottom": 2033
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Customer dropoff",
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 1985,
+                                                                                                                                                    "right": 424,
+                                                                                                                                                    "bottom": 2027
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name_secondary",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 433,
+                                                                                                                                                    "top": 1985,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2027
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2033,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2073
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 2069,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 2073
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2073,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2151
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 2073,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2151
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/callout_image",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 45,
+                                                                                                                                                    "top": 2091,
+                                                                                                                                                    "right": 99,
+                                                                                                                                                    "bottom": 2145
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Items can be added before checkout",
+                                                                                                                                                "id": "com.doordash.driverapp:id/callout_text",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 117,
+                                                                                                                                                    "top": 2091,
+                                                                                                                                                    "right": 1035,
+                                                                                                                                                    "bottom": 2151
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2147,
+                                                                            "right": 1080,
+                                                                            "bottom": 2151
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                                        "class": "android.widget.LinearLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2151,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/offer_accepting/2026-07-26_13-27-46-799__doordash__accessibility.window__UNKNOWN__57b5b8.json
+++ b/app/src/test/resources/snapshots/offer_accepting/2026-07-26_13-27-46-799__doordash__accessibility.window__UNKNOWN__57b5b8.json
@@ -1,0 +1,592 @@
+{
+    "captureId": "5257c53e-7f16-45b0-b630-d70f06905dc5",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785090466775,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/accept_decline_fragment_container",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/bottomSheetLayout",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/accept_constraint_layout",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/map_container",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.TextureView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 5,
+                                                                                                    "top": 1335,
+                                                                                                    "right": 194,
+                                                                                                    "bottom": 1382
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 200,
+                                                                                                    "top": 1335,
+                                                                                                    "right": 247,
+                                                                                                    "bottom": 1382
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/secondary_action_button_dash_plus",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 816,
+                                                                                    "top": 172,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 297
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Decline",
+                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 852,
+                                                                                            "top": 202,
+                                                                                            "right": 1008,
+                                                                                            "bottom": 268
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "text": "9dfcff42-c75d-4b3f-b51e-c246aeaf4348",
+                                                                                "id": "com.doordash.driverapp:id/assignment_id_text",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 725,
+                                                                                    "top": 1341,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1382
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 1382,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1382,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1382
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/extra_space",
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1382,
+                                                                                    "right": 0,
+                                                                                    "bottom": 1418
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1418,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2311
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                                        "class": "android.widget.ScrollView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1418,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1418,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2151
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1418,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2151
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/accept_decline_recycler_view_container",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1418,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2151
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/items_recycler_view",
+                                                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1418,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2151
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1418,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1419
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1419,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1503
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1419,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1503
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "$9.80  Guaranteed (incl. tips)",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1419,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1503
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1503,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1568
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1503,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1568
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "7.8 mi",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1503,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1568
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1568,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1624
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1568,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1624
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Deliver by 1:55 PM",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1568,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1624
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1624,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1664
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1660,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1664
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1664,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1808
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1664,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1808
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_icon_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 45,
+                                                                                                                                                    "top": 1691,
+                                                                                                                                                    "right": 99,
+                                                                                                                                                    "bottom": 1745
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.doordash.driverapp:id/work_unit_image",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 45,
+                                                                                                                                                            "top": 1691,
+                                                                                                                                                            "right": 99,
+                                                                                                                                                            "bottom": 1745
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Pickup",
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_type",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 1697,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1739
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/bottom_vertical_line",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 71,
+                                                                                                                                                    "top": 1745,
+                                                                                                                                                    "right": 73,
+                                                                                                                                                    "bottom": 1808
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name_container",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 1757,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1808
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "text": "Dunkin'",
+                                                                                                                                                        "id": "com.doordash.driverapp:id/display_name",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 126,
+                                                                                                                                                            "top": 1757,
+                                                                                                                                                            "right": 293,
+                                                                                                                                                            "bottom": 1808
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/pickup_confirm_picked_up/2026-07-26_21-10-54-490__doordash__accessibility.window__UNKNOWN__0bdb1d.json
+++ b/app/src/test/resources/snapshots/pickup_confirm_picked_up/2026-07-26_21-10-54-490__doordash__accessibility.window__UNKNOWN__0bdb1d.json
@@ -1,0 +1,217 @@
+{
+    "captureId": "a0cb6aad-225c-424c-92f4-8f36adde9b64",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785118254486,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 514,
+            "right": 1080,
+            "bottom": 2725
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 514,
+                    "right": 1080,
+                    "bottom": 2725
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 514,
+                            "right": 1080,
+                            "bottom": 2725
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 514,
+                                    "right": 1080,
+                                    "bottom": 2725
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 514,
+                                            "right": 1080,
+                                            "bottom": 2725
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 514,
+                                                    "right": 1080,
+                                                    "bottom": 2725
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/coordinator",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 514,
+                                                            "right": 1080,
+                                                            "bottom": 2725
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/touch_outside",
+                                                                "class": "android.view.View",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 514,
+                                                                    "right": 1080,
+                                                                    "bottom": 2725
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/design_bottom_sheet",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 2302,
+                                                                    "right": 1080,
+                                                                    "bottom": 2725
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/dialog_layout",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2302,
+                                                                            "right": 1080,
+                                                                            "bottom": 2725
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "text": "Confirm order was picked up",
+                                                                                "id": "com.doordash.driverapp:id/confirm_title_text",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 36,
+                                                                                    "top": 2338,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 2404
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "desc": "Confirm",
+                                                                                "id": "com.doordash.driverapp:id/confirm_button",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 36,
+                                                                                    "top": 2475,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 2582
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Confirm",
+                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 456,
+                                                                                            "top": 2496,
+                                                                                            "right": 624,
+                                                                                            "bottom": 2562
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "desc": "Go back",
+                                                                                "id": "com.doordash.driverapp:id/go_back_button",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 36,
+                                                                                    "top": 2600,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 2689
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Go back",
+                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 463,
+                                                                                            "top": 2615,
+                                                                                            "right": 618,
+                                                                                            "bottom": 2675
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/pickup_pizza_bag/2026-07-26_21-10-26-597__doordash__accessibility.window__UNKNOWN__0a4147.json
+++ b/app/src/test/resources/snapshots/pickup_pizza_bag/2026-07-26_21-10-26-597__doordash__accessibility.window__UNKNOWN__0a4147.json
@@ -1,0 +1,408 @@
+{
+    "captureId": "0ab880d7-c6f6-45b5-9e9f-3856759d42be",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785118226589,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "id": "android:id/content",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "class": "android.view.ViewGroup",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "com.doordash.driverapp:id/education_screen",
+                                        "class": "android.view.ViewGroup",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/btn_back",
+                                                "class": "android.widget.Button",
+                                                "isClickable": true,
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 107,
+                                                    "bottom": 243
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/imageView_prism_button_icon",
+                                                        "class": "android.widget.ImageView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 27,
+                                                            "top": 163,
+                                                            "right": 80,
+                                                            "bottom": 216
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "id": "com.doordash.driverapp:id/scroll_view",
+                                                "class": "android.widget.ScrollView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 243,
+                                                    "right": 1080,
+                                                    "bottom": 2043
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 243,
+                                                            "right": 1080,
+                                                            "bottom": 1393
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/example_images_with_good_bad_group",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 243,
+                                                                    "right": 0,
+                                                                    "bottom": 243
+                                                                }
+                                                            },
+                                                            {
+                                                                "text": "Take a photo of your pizza bag",
+                                                                "id": "com.doordash.driverapp:id/component_title",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 36,
+                                                                    "top": 296,
+                                                                    "right": 1044,
+                                                                    "bottom": 362
+                                                                }
+                                                            },
+                                                            {
+                                                                "text": "The photo should include the pizza bag and the inside of the store.",
+                                                                "id": "com.doordash.driverapp:id/component_subtitle",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 36,
+                                                                    "top": 398,
+                                                                    "right": 1044,
+                                                                    "bottom": 500
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/divider_1",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 536,
+                                                                    "right": 1080,
+                                                                    "bottom": 540
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/example_good_image",
+                                                                "class": "android.widget.ImageView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 540,
+                                                                    "right": 540,
+                                                                    "bottom": 1119
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/example_good_image_circle",
+                                                                "class": "android.widget.ImageView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 362,
+                                                                    "top": 576,
+                                                                    "right": 504,
+                                                                    "bottom": 718
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/example_bad_image_circle",
+                                                                "class": "android.widget.ImageView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 902,
+                                                                    "top": 576,
+                                                                    "right": 1044,
+                                                                    "bottom": 718
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/example_bad_image",
+                                                                "class": "android.widget.ImageView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 540,
+                                                                    "top": 540,
+                                                                    "right": 1080,
+                                                                    "bottom": 1119
+                                                                }
+                                                            },
+                                                            {
+                                                                "desc": ": When you verify your pizza bag, it will count this order towards your active challenge",
+                                                                "id": "com.doordash.driverapp:id/example_banner_view",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 36,
+                                                                    "top": 1119,
+                                                                    "right": 1044,
+                                                                    "bottom": 1357
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/actions_group",
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 1119,
+                                                                            "right": 36,
+                                                                            "bottom": 1119
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/subdued_decoration_view",
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 1121,
+                                                                            "right": 45,
+                                                                            "bottom": 1355
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/start_icon_image_view",
+                                                                        "class": "android.widget.ImageView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 63,
+                                                                            "top": 1146,
+                                                                            "right": 134,
+                                                                            "bottom": 1217
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "text": "When you verify your pizza bag, it will count this order towards your active challenge",
+                                                                        "id": "com.doordash.driverapp:id/body_text_view",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 152,
+                                                                            "top": 1154,
+                                                                            "right": 909,
+                                                                            "bottom": 1322
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/end_icon_button",
+                                                                        "class": "android.widget.Button",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 936,
+                                                                            "top": 1146,
+                                                                            "right": 1008,
+                                                                            "bottom": 1217
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/button_container",
+                                                                        "class": "android.widget.LinearLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 152,
+                                                                            "top": 1322,
+                                                                            "right": 909,
+                                                                            "bottom": 1322
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/subdued_border_view",
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 1353,
+                                                                            "right": 1044,
+                                                                            "bottom": 1357
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "id": "com.doordash.driverapp:id/btn_container",
+                                                "class": "android.widget.LinearLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 2043,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/btn_primary_action",
+                                                        "class": "android.widget.Button",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 36,
+                                                            "top": 2079,
+                                                            "right": 1044,
+                                                            "bottom": 2186
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "text": "Take photo",
+                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 427,
+                                                                    "top": 2100,
+                                                                    "right": 654,
+                                                                    "bottom": 2166
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/btn_secondary_action",
+                                                        "class": "android.widget.Button",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 36,
+                                                            "top": 2204,
+                                                            "right": 1044,
+                                                            "bottom": 2311
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "text": "I don't have one",
+                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 377,
+                                                                    "top": 2225,
+                                                                    "right": 703,
+                                                                    "bottom": 2291
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/statusBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 136
+                }
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2347,
+                    "right": 1080,
+                    "bottom": 2400
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/pickup_pizza_bag/2026-07-26_21-10-49-903__doordash__accessibility.window__UNKNOWN__71b1a1.json
+++ b/app/src/test/resources/snapshots/pickup_pizza_bag/2026-07-26_21-10-49-903__doordash__accessibility.window__UNKNOWN__71b1a1.json
@@ -1,0 +1,145 @@
+{
+    "captureId": "58932615-2568-4a8d-82c1-cc65a68c32c2",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785118249895,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": -202,
+            "top": 0,
+            "right": 877,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": -202,
+                    "top": 0,
+                    "right": 877,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "id": "android:id/content",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": -202,
+                            "top": 136,
+                            "right": 877,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "class": "android.view.ViewGroup",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": -202,
+                                    "top": 136,
+                                    "right": 877,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "com.doordash.driverapp:id/loading_screen",
+                                        "class": "android.view.ViewGroup",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": -202,
+                                            "top": 136,
+                                            "right": 877,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "text": "Uploading & evaluating your photo",
+                                                "id": "com.doordash.driverapp:id/pizza_bag_uploading_title",
+                                                "class": "android.widget.TextView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": -166,
+                                                    "top": 189,
+                                                    "right": 841,
+                                                    "bottom": 255
+                                                }
+                                            },
+                                            {
+                                                "text": "This will usually only take a few seconds.",
+                                                "id": "com.doordash.driverapp:id/pizza_bag_uploading_description",
+                                                "class": "android.widget.TextView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": -166,
+                                                    "top": 291,
+                                                    "right": 841,
+                                                    "bottom": 338
+                                                }
+                                            },
+                                            {
+                                                "desc": "Loading",
+                                                "id": "com.doordash.driverapp:id/uploading_progress_bar",
+                                                "class": "android.widget.ImageView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": -202,
+                                                    "top": 1197,
+                                                    "right": 877,
+                                                    "bottom": 1286
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/statusBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": -202,
+                    "top": 0,
+                    "right": 877,
+                    "bottom": 136
+                }
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": -202,
+                    "top": 2347,
+                    "right": 877,
+                    "bottom": 2400
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/pickup_pizza_bag/2026-07-26_21-10-51-086__doordash__accessibility.window__UNKNOWN__063e5d.json
+++ b/app/src/test/resources/snapshots/pickup_pizza_bag/2026-07-26_21-10-51-086__doordash__accessibility.window__UNKNOWN__063e5d.json
@@ -1,0 +1,194 @@
+{
+    "captureId": "30fc8313-ea9d-4371-9134-32f8f50097c7",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785118251084,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "id": "android:id/content",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "class": "android.view.ViewGroup",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "com.doordash.driverapp:id/main_instruction_group",
+                                        "class": "android.view.View",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 0,
+                                            "bottom": 136
+                                        }
+                                    },
+                                    {
+                                        "id": "com.doordash.driverapp:id/instructions_container",
+                                        "class": "android.view.ViewGroup",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 45,
+                                            "top": 932,
+                                            "right": 1035,
+                                            "bottom": 1409
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/verification_result_icon",
+                                                "class": "android.widget.ImageView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 441,
+                                                    "top": 932,
+                                                    "right": 639,
+                                                    "bottom": 1130
+                                                }
+                                            },
+                                            {
+                                                "text": "Thanks for using a pizza bag",
+                                                "id": "com.doordash.driverapp:id/verification_result_title",
+                                                "class": "android.widget.TextView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 45,
+                                                    "top": 1166,
+                                                    "right": 1035,
+                                                    "bottom": 1232
+                                                }
+                                            },
+                                            {
+                                                "text": "Pizza bags help to keep pizzas warm for customers, which can lead to greater tips and higher customer ratings.",
+                                                "id": "com.doordash.driverapp:id/verification_result_description",
+                                                "class": "android.widget.TextView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 45,
+                                                    "top": 1268,
+                                                    "right": 1035,
+                                                    "bottom": 1409
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "com.doordash.driverapp:id/footer_container",
+                                        "class": "android.widget.LinearLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2204,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/btn_primary_action",
+                                                "class": "android.widget.Button",
+                                                "isClickable": true,
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 36,
+                                                    "top": 2222,
+                                                    "right": 1044,
+                                                    "bottom": 2329
+                                                },
+                                                "children": [
+                                                    {
+                                                        "text": "Continue",
+                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                        "class": "android.widget.TextView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 445,
+                                                            "top": 2243,
+                                                            "right": 635,
+                                                            "bottom": 2309
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/statusBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 136
+                }
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2347,
+                    "right": 1080,
+                    "bottom": 2400
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/pickup_wait_survey/2026-07-26_21-08-27-628__doordash__accessibility.window__UNKNOWN__24d30f.json
+++ b/app/src/test/resources/snapshots/pickup_wait_survey/2026-07-26_21-08-27-628__doordash__accessibility.window__UNKNOWN__24d30f.json
@@ -1,0 +1,219 @@
+{
+    "captureId": "669c5772-0c6b-4d82-8fa3-9b8f0e0a0b95",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785118107627,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "id": "android:id/content",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/container",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "com.doordash.driverapp:id/survey_container",
+                                        "class": "android.widget.ScrollView",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/wait_survey_container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 731
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/close_button",
+                                                        "class": "android.widget.ImageView",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 125,
+                                                            "bottom": 261
+                                                        }
+                                                    },
+                                                    {
+                                                        "text": "What's causing your wait?",
+                                                        "id": "com.doordash.driverapp:id/wait_survey_banner_title",
+                                                        "class": "android.widget.TextView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 36,
+                                                            "top": 297,
+                                                            "right": 1044,
+                                                            "bottom": 363
+                                                        }
+                                                    },
+                                                    {
+                                                        "text": "Your feedback helps us improve our pickup time estimates.",
+                                                        "id": "com.doordash.driverapp:id/wait_survey_subtext",
+                                                        "class": "android.widget.TextView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 36,
+                                                            "top": 381,
+                                                            "right": 1080,
+                                                            "bottom": 428
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/buttonbar_placeholder",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 428,
+                                                            "right": 1080,
+                                                            "bottom": 731
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "state": "in progress",
+                                        "id": "com.doordash.driverapp:id/progress_bar",
+                                        "class": "android.widget.ProgressBar",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 486,
+                                            "top": 1188,
+                                            "right": 593,
+                                            "bottom": 1295
+                                        }
+                                    },
+                                    {
+                                        "id": "com.doordash.driverapp:id/buttons_container",
+                                        "class": "android.view.ViewGroup",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2166,
+                                            "right": 1080,
+                                            "bottom": 2311
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/divider_submit",
+                                                "class": "android.view.View",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 2166,
+                                                    "right": 1080,
+                                                    "bottom": 2168
+                                                }
+                                            },
+                                            {
+                                                "text": "Submit",
+                                                "id": "com.doordash.driverapp:id/btn_submit_survey",
+                                                "class": "android.widget.Button",
+                                                "isClickable": true,
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 36,
+                                                    "top": 2204,
+                                                    "right": 1044,
+                                                    "bottom": 2311
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/statusBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 136
+                }
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2347,
+                    "right": 1080,
+                    "bottom": 2400
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/shopping_pay_adjustment/2026-07-26_14-00-04-853__doordash__accessibility.window__UNKNOWN__e0f9f2.json
+++ b/app/src/test/resources/snapshots/shopping_pay_adjustment/2026-07-26_14-00-04-853__doordash__accessibility.window__UNKNOWN__e0f9f2.json
@@ -1,0 +1,310 @@
+{
+    "captureId": "fc5cae5e-6750-4ef3-ae9d-d6e5142a600b",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785092404845,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 2400,
+            "right": 1080,
+            "bottom": 4800
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/layout_bottom_sheet",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/overlay_view",
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 1852,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 1852,
+                                                                    "right": 1080,
+                                                                    "bottom": 1888
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/handle_overlay",
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 1852,
+                                                                            "right": 1080,
+                                                                            "bottom": 1888
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/handle_overlay_image",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1870,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1879
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "text": "12 items have been added",
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_title",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 36,
+                                                                    "top": 1924,
+                                                                    "right": 1044,
+                                                                    "bottom": 2008
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 2044,
+                                                                    "right": 1080,
+                                                                    "bottom": 2311
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2044,
+                                                                            "right": 1080,
+                                                                            "bottom": 2311
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 2044,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2168
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "We have adjusted your pay for this order.\nYou can see your pay when the order is delivered.",
+                                                                                        "id": "com.doordash.driverapp:id/prism_sheet_message",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 2044,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2168
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_header_divider",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 2044,
+                                                                    "right": 1080,
+                                                                    "bottom": 2053
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2164,
+                                                            "right": 1080,
+                                                            "bottom": 2168
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2168,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_actions_container",
+                                                                "class": "android.widget.LinearLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 2168,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.Button",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 2204,
+                                                                            "right": 1044,
+                                                                            "bottom": 2311
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "text": "Got it",
+                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 482,
+                                                                                    "top": 2225,
+                                                                                    "right": 599,
+                                                                                    "bottom": 2291
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2347,
+                    "right": 1080,
+                    "bottom": 2400
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/shopping_shelf_photo/2026-07-26_16-44-36-459__doordash__accessibility.window__UNKNOWN__aa7d10.json
+++ b/app/src/test/resources/snapshots/shopping_shelf_photo/2026-07-26_16-44-36-459__doordash__accessibility.window__UNKNOWN__aa7d10.json
@@ -1,0 +1,321 @@
+{
+    "captureId": "121039bc-8bb6-4a5a-b8b5-b540fabb6359",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785102276455,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 2400,
+            "right": 1080,
+            "bottom": 4800
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2400,
+                    "right": 1080,
+                    "bottom": 4747
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 2536,
+                            "right": 1080,
+                            "bottom": 4747
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 2536,
+                                    "right": 1080,
+                                    "bottom": 4747
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2536,
+                                            "right": 1080,
+                                            "bottom": 4747
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/layout_bottom_sheet",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 2536,
+                                                    "right": 1080,
+                                                    "bottom": 4747
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/overlay_view",
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2536,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4121,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4121,
+                                                                    "right": 1080,
+                                                                    "bottom": 4157
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/handle_overlay",
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 4121,
+                                                                            "right": 1080,
+                                                                            "bottom": 4157
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/handle_overlay_image",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 4139,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4148
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "text": "Take a photo of the shelf to provide more substitution options to the customer",
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_title",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 36,
+                                                                    "top": 4193,
+                                                                    "right": 1044,
+                                                                    "bottom": 4407
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4443,
+                                                                    "right": 1080,
+                                                                    "bottom": 4711
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 4443,
+                                                                            "right": 1080,
+                                                                            "bottom": 4711
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 4443,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4443
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_header_divider",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4443,
+                                                                    "right": 1080,
+                                                                    "bottom": 4452
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4439,
+                                                            "right": 1080,
+                                                            "bottom": 4443
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4443,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_actions_container",
+                                                                "class": "android.widget.LinearLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 4443,
+                                                                    "right": 1080,
+                                                                    "bottom": 4747
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.Button",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 4479,
+                                                                            "right": 1044,
+                                                                            "bottom": 4586
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "text": "Take shelf photo",
+                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 372,
+                                                                                    "top": 4500,
+                                                                                    "right": 708,
+                                                                                    "bottom": 4566
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "class": "android.widget.Button",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 4604,
+                                                                            "right": 1044,
+                                                                            "bottom": 4711
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "text": "No options available",
+                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 333,
+                                                                                    "top": 4625,
+                                                                                    "right": 747,
+                                                                                    "bottom": 4691
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 4747,
+                    "right": 1080,
+                    "bottom": 4800
+                }
+            }
+        ]
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,32 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — #888 — eight DoorDash screens that used to fall to UNKNOWN are now recognized.**
+  All eight are **recognize-only** (no state claim, no parse), so the only intended change is that
+  the frames stop landing in the UNKNOWN capture pile. The list: the post-accept **"accepting"
+  spinner** (every accept was losing its own follow-frame), the mid-shop **pay-adjustment sheet**
+  ("N items have been added / We have adjusted your pay"), the dropoff **geofence-warning help flow**
+  (warning card mid-inflation → Help menu → "Continue to complete delivery"), **"Confirm you handed
+  order directly to customer"**, the **pizza-bag verification** flow (instruction → uploading →
+  result), the **shelf-photo substitution** sheet, the **"Confirm order was picked up"** dialog, and
+  the **wait-survey sheet variant**.
+  **What to watch (DoorDash dash) — this is a NEGATIVE test; nothing new should appear:**
+  1. **Nothing changes visibly.** No new bubble cards, no new TTS, no "Declined/Expired" chatter
+     around an accept. If any of these screens now makes the HUD say or do something, that is the
+     bug — note which screen.
+  2. **Accepting an offer still behaves exactly as before** — the accept lands, the pickup card
+     comes up, no ghost offer, no "(offer replaced)". The accept spinner is the highest-frequency
+     of the eight, so it is the one to watch. The rule deliberately does NOT re-assert
+     `offer:presented` (that is the #595 ghost-accept class), but the field is the proof.
+  3. **A pizza order and a shop-with-substitutions order** exercise two of the eight; if you get
+     either, note whether the pickup/dropoff lineage stayed correct through them.
+  **Desk (next pull):** the UNKNOWN pile should no longer contain these eight families — check the
+  UNKNOWN census for `progress_message` offer frames, `pizza_bag_*`, `wait_survey_container`,
+  `geofence_warning_map`, "items have been added", "photo of the shelf", "handed order directly",
+  "Confirm order was picked up". Recognized captures for these intents should be PII-clean (they
+  carry no customer nodes at all; the geofence card's `address_line_*` are covered by that rule's
+  existing redact).
+  - Confirmed: 0/2
 - **🆕 NEW — #882 / #881 — Uber stacked offers speak the STORE, and a "Match" is recorded as a match.**
   Two fixes on the same card. **#882:** a multi-order Uber card ("Delivery (2)") rendered its type
   chip above the one store line it shows, and the chip won the store read — so the bubble/TTS said

--- a/matchers/rules/doordash/dropoff.json5
+++ b/matchers/rules/doordash/dropoff.json5
@@ -1190,11 +1190,24 @@
           }
         }
       ],
-      "require": {
-        "exists": {
-          "hasTextContaining": "far away from the customer"
+      "branches": [
+        {
+          "comment": "The fully-rendered card, anchored on its 'You're far away from the customer' copy.",
+          "require": {
+            "exists": {
+              "hasTextContaining": "far away from the customer"
+            }
+          }
+        },
+        {
+          "comment": "#888 — the SAME card caught mid-inflation: the sheet is only partially laid out (its title and address TextViews exist but carry no text yet — bounds are still below the viewport), so the copy anchor above misses and the frame fell to UNKNOWN (2026-07-26 14:57:25 in the pull, ~280ms before the fully-rendered frame branch 1 already recognizes). geofence_warning_map is this card's own view id and appears on no other DoorDash surface (verified across the 07-26 pull's 632 captures and the committed corpus: the only two hits are this frame and the already-recognized one), so the id alone is a sound anchor. Same rule, same intent, so the whole-rule address redact above covers this branch too — which is exactly why it must live HERE and not as a separate rule: the card's address_line_* nodes carry the CUSTOMER's address whenever they are populated.",
+          "require": {
+            "exists": {
+              "hasIdSuffix": "geofence_warning_map"
+            }
+          }
         }
-      }
+      ]
     },
     {
       "id": "doordash.screen.delivery_summary_expanded",
@@ -1594,6 +1607,77 @@
         "exists": {
           "hasTextContaining": "complete it at the drop-off location"
         }
+      }
+    },
+    {
+      "comment": "#888 — the generic drop-off HELP sheet reached from the geofence-warning card's 'I need help' ('Help' title over 'Tell us what happened and we'll help you find the right resolution.' and a help_menu_item list: 'I delivered the order' / 'Provided address or map pin is wrong' / 'Bad GPS signal or app issue at drop-off' / …). RECOGNIZE-ONLY (dev decision 2026-07-27, recognition-gap batch #888): no state.flow, no parse — a transient help overlay over an established task:dropoff flow, exactly the posture dropoff_issue_menu (#796) already sets for the sibling 'Drop-off issues' menu. This is a DIFFERENT sheet from that one (different title, different id family, different option set), hence a separate rule rather than a branch. Anchors: the generic intro copy — matched WITHOUT its typographic apostrophe ('help you find the right resolution', so the U+2019 in \"we'll\" can never break the match) — paired with a help_menu_item node naming drop-off, which keeps the rule off any pickup-side help sheet reusing the same ids. Corpus-unique (0 other snapshots or pull frames). PRIVACY: no customer PII — every node is a fixed option label; the sheet names no customer, address, or store.",
+      "id": "doordash.screen.dropoff_help_menu",
+      "priority": 133,
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasTextContaining": "help you find the right resolution"
+            }
+          },
+          {
+            "exists": {
+              "all": [
+                {
+                  "hasIdSuffix": "help_menu_item"
+                },
+                {
+                  "hasTextContaining": "drop-off"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "comment": "#888 — the acknowledgement sheet that closes the drop-off help flow ('Continue to complete delivery' title over 'Thanks for letting us know. Continue to complete the delivery as per the customer's instructions.' + a 'Continue to delivery steps' button). RECOGNIZE-ONLY (dev decision 2026-07-27, batch #888): no state.flow, no parse — it acknowledges and returns the dasher to the drop-off steps that already own the flow. Anchored on the exact prism_sheet_title copy plus the button label; both are generic DoorDash chrome and corpus-unique (0 other snapshots or pull frames). PRIVACY: no customer PII — the body says \"the customer's instructions\" generically and quotes none of them.",
+      "id": "doordash.screen.dropoff_continue_to_complete",
+      "priority": 134,
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "all": [
+                {
+                  "hasIdSuffix": "prism_sheet_title"
+                },
+                {
+                  "hasText": "Continue to complete delivery"
+                }
+              ]
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "Continue to delivery steps"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "comment": "#888 — the hand-it-to-customer attestation sheet ('Confirm you handed order directly to customer' / 'We will verify with the customer if the order was delivered. If you haven't directly handed them the order, go back and follow the steps.' over Confirm to complete delivery / Go back), the last gate on a hand-to-customer drop. RECOGNIZE-ONLY (dev decision 2026-07-27, batch #888) — task-lifecycle-ADJACENT but deliberately claiming no phase: it is a confirmation modal over an already-established task:dropoff:arrived flow, and the completion edge is owned by the frames that follow it (dropoff_completed_confirm / the delivery receipt). Claiming a phase from a modal is how a mis-anchored dialog perturbs task lineage; the repo's standing posture for this exact shape is recognize-only (dropoff_multi_order_confirm, the whole #796 batch). Anchors are the two id-LESS body/button strings — both fixed DoorDash copy, no merchant or customer literal — and are corpus-unique (0 other snapshots or pull frames). PRIVACY: no customer PII — the copy says 'customer'/'them' and names nobody; no address, gate code, or order detail is on the sheet.",
+      "id": "doordash.screen.dropoff_handed_directly_confirm",
+      "priority": 136,
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasTextContaining": "handed order directly to customer"
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "Confirm to complete delivery"
+            }
+          }
+        ]
       }
     }
   ],

--- a/matchers/rules/doordash/offer.json5
+++ b/matchers/rules/doordash/offer.json5
@@ -282,6 +282,99 @@
           "throttleMs": 60000
         }
       ]
+    },
+    {
+      "comment": "#888 — the post-accept 'accepting' TEARDOWN frame of the offer card: the dasher pressed Accept, DoorDash swaps the footer for an in-card spinner while it submits, and the card then unwinds. The offer chrome (accept_decline_fragment_container, the Decline button, the pay/distance/store rows) is still rendered but the Accept button is GONE. Every accept produced one of these and it fell straight to UNKNOWN (4 frames in the 07-26 pull: 3 spinner-shaped + 1 footer-gone), so each accept was silently dropping its own follow-frame. RECOGNIZE-ONLY (dev decision 2026-07-27, recognition-gap batch #888): no state.flow, no parse, no bind — the same posture as every other transient overlay rule (dropoff_multi_order_confirm, dropoff_issue_menu, pickup_wait_survey). This is DELIBERATELY not mirroring the sibling offer rules' `flow: offer:presented`: #595 is the standing receipt that re-asserting offer state on a post-accept TEARDOWN frame is how ghost accepts/timeouts get manufactured, and the accept was already latched by the click rule on the frame before. Recognizing it only graduates the capture out of UNKNOWN (see FlowRegionStepper: a flow-less observation advances the observed clock and nothing else). Priority 127 sits AFTER offer_popup (20) and offer_popup_confirm_decline (19), so a live, actionable offer can never be pre-empted by this rule; the rejects below make the two shapes structurally disjoint regardless of order.",
+      "id": "doordash.screen.offer_accepting",
+      "priority": 127,
+      // Any surviving accept affordance means the card is still actionable — that is a
+      // LIVE offer (offer_popup's territory), not a teardown. These four rejects are what
+      // make the two shapes structurally disjoint, independent of priority order.
+      "reject": [
+        {
+          "exists": {
+            "hasIdSuffix": "accept_button"
+          }
+        },
+        {
+          "exists": {
+            "hasIdSuffix": "accept_decline_footer_container"
+          }
+        },
+        {
+          "exists": {
+            "hasText": "Accept"
+          }
+        },
+        {
+          "exists": {
+            "hasText": "Add to route"
+          }
+        }
+      ],
+      "branches": [
+        {
+          "comment": "Shape A — the submit spinner: load_progress's progress_message is inflated over the card while the accept POST is in flight. progress_message alone is NOT sufficient (verified: live offer frames in the same pull carry load_progress/progress_message too, with the Accept button still present) — the rule-level rejects are what separate them.",
+          "require": {
+            "all": [
+              {
+                "exists": {
+                  "hasIdSuffix": "accept_decline_fragment_container"
+                }
+              },
+              {
+                "exists": {
+                  "hasIdSuffix": "progress_message"
+                }
+              },
+              {
+                "exists": {
+                  "hasText": "Decline"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "comment": "Shape B — the footer has already been torn down but the offer body is still rendered (no progress node at all; 2026-07-26 13:27:46 in the pull, and the 06-21 add-on frame in snapshots/sessions/addon_phantom_2026_06_21). Requires a REAL store leg, the same #595 predicate offer_popup uses, so the store-less degenerate frame #595 deliberately routes to UNKNOWN stays there.",
+          "require": {
+            "all": [
+              {
+                "exists": {
+                  "hasIdSuffix": "accept_decline_fragment_container"
+                }
+              },
+              {
+                "exists": {
+                  "hasIdSuffix": "secondary_action_button_dash_plus"
+                }
+              },
+              {
+                "exists": {
+                  "all": [
+                    {
+                      "hasIdSuffix": "display_name"
+                    },
+                    {
+                      "hasTextMatchesRegex": "\\S"
+                    },
+                    {
+                      "not": {
+                        "hasText": "Customer dropoff"
+                      }
+                    },
+                    {
+                      "not": {
+                        "hasText": "Business handoff"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
     }
   ],
   "clicks": [

--- a/matchers/rules/doordash/pickup.json5
+++ b/matchers/rules/doordash/pickup.json5
@@ -485,6 +485,28 @@
               }
             ]
           }
+        },
+        {
+          "comment": "#888 — the DoorDash wait survey's SHEET variant: same 'What's causing your wait?' banner + Submit, but rendered as the wait_survey_container scroll sheet whose reason list has not inflated yet, so branch 1's 'Order still being prepared when I arrived' option anchor is absent and the frame fell to UNKNOWN (2026-07-26 21:08:27 in the pull, ~300ms before the fully-inflated frame branch 1 already recognizes). Anchored on the two survey-specific container/button ids plus the same banner copy branch 1 uses; the ids keep this off any other sheet. Same rule, same intent, same recognize-only posture.",
+          "require": {
+            "all": [
+              {
+                "exists": {
+                  "hasIdSuffix": "wait_survey_container"
+                }
+              },
+              {
+                "exists": {
+                  "hasIdSuffix": "btn_submit_survey"
+                }
+              },
+              {
+                "exists": {
+                  "hasTextContaining": "What's causing your wait"
+                }
+              }
+            ]
+          }
         }
       ]
     },
@@ -1017,6 +1039,140 @@
         "exists": {
           "hasTextContaining": "Confirm barcode scanned"
         }
+      }
+    },
+    {
+      "comment": "#888 — the mid-shop PAY-ADJUSTMENT sheet: while shopping, the customer adds items and DoorDash raises the offer pay, announcing it as a prism sheet ('<N> items have been added' / 'We have adjusted your pay for this order. You can see your pay when the order is delivered.' / Got it). RECOGNIZE-ONLY (dev decision 2026-07-27, recognition-gap batch #888): no state.flow, no parse — same posture as every other transient shopping sheet here. It IS economics-bearing (a mid-job pay change the read-model cannot see today, since the offer's frozen pay was set at accept), but the sheet states no NUMBER — only that pay changed — so there is nothing to parse; capturing the realized delta is a separate follow-up on the delivery receipt, noted on #888. Anchors are generic DoorDash chrome: the item count is variable, so 'items have been added' is matched as a SUBSTRING on the prism_sheet_title node, paired with the 'adjusted your pay' body. Corpus-unique (0 other snapshots or pull frames carry either). PRIVACY: no customer PII — the sheet names no customer, address, or store.",
+      "id": "doordash.screen.shopping_pay_adjustment",
+      "priority": 128,
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "all": [
+                {
+                  "hasIdSuffix": "prism_sheet_title"
+                },
+                {
+                  "hasTextContaining": "items have been added"
+                }
+              ]
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "adjusted your pay"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "comment": "#888 — the PIZZA-BAG verification sub-flow at pickup (a DoorDash pizza-order requirement): three consecutive screens, one intent. RECOGNIZE-ONLY (dev decision 2026-07-27, batch #888): no state.flow, no parse — the task:pickup flow is already established and these are instruction/progress/result screens, not lifecycle anchors. Anchors are generic DoorDash chrome + the literal 'pizza bag' product vocabulary (NOT a merchant name — no store literal appears in any anchor here, per the standing no-store-anchor constraint). PRIVACY: no customer PII on any of the three frames (equipment-photo instructions and a generic thank-you). NOTE — this is an EQUIPMENT photo (the dasher's own insulated bag), not a document-image capture surface: it is neither an identity document nor a signature, so the sensitive block does not apply.",
+      "id": "doordash.screen.pickup_pizza_bag",
+      "priority": 129,
+      "branches": [
+        {
+          "comment": "Shape A — the education/instruction screen ('Take a photo of your pizza bag' + good/bad examples + Take photo / I don't have one).",
+          "require": {
+            "all": [
+              {
+                "exists": {
+                  "all": [
+                    {
+                      "hasIdSuffix": "component_title"
+                    },
+                    {
+                      "hasTextContaining": "photo of your pizza bag"
+                    }
+                  ]
+                }
+              },
+              {
+                "exists": {
+                  "hasIdSuffix": "btn_primary_action"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "comment": "Shape B — the upload/evaluation progress screen. Its title id is pizza-bag-specific, so the id alone is a unique anchor.",
+          "require": {
+            "exists": {
+              "hasIdSuffix": "pizza_bag_uploading_title"
+            }
+          }
+        },
+        {
+          "comment": "Shape C — the verification RESULT screen. verification_result_title is a GENERIC id (a future ID/document verification could reuse it), so the 'pizza bag' text pairing is load-bearing, not decorative: it keeps this branch off any other verification result. Both the positive ('Thanks for using a pizza bag') and any negative wording name the bag, so the substring holds across outcomes.",
+          "require": {
+            "all": [
+              {
+                "exists": {
+                  "hasIdSuffix": "verification_result_title"
+                }
+              },
+              {
+                "exists": {
+                  "hasTextContaining": "pizza bag"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "comment": "#888 — the SHELF-PHOTO substitution sheet of the shopping sub-flow ('Take a photo of the shelf to provide more substitution options to the customer' over Take shelf photo / No options available), shown when a shopped item is out of stock. RECOGNIZE-ONLY (dev decision 2026-07-27, batch #888): no state.flow, no parse. Anchors are generic DoorDash copy on the prism_sheet_title node plus the 'substitution options' body phrase; corpus-unique (0 other snapshots or pull frames). PRIVACY: no customer PII — the copy says 'the customer', names nobody, and the shelf photo itself is a store artifact, not a document image.",
+      "id": "doordash.screen.shopping_shelf_photo",
+      "priority": 131,
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "all": [
+                {
+                  "hasIdSuffix": "prism_sheet_title"
+                },
+                {
+                  "hasTextContaining": "photo of the shelf"
+                }
+              ]
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "substitution options"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "comment": "#888 — the 'Confirm order was picked up' bottom-sheet dialog (Confirm / Go back), the last gate before a pickup is committed. RECOGNIZE-ONLY (dev decision 2026-07-27, batch #888) — DELIBERATELY not mirroring the `task:pickup:arrived` flow its neighbours pickup_picked_up (98) / pickup_verify (101) declare: this is a transient CONFIRMATION modal over an already-established pickup flow, and the repo's standing posture for exactly that shape is recognize-only (dropoff_multi_order_confirm, dropoff_completed_confirm's sibling overlays, pickup_wait_survey, the whole #796 batch). Claiming a phase from a modal is how a mis-anchored dialog perturbs task lineage; recognizing it costs nothing and graduates the frame. Anchored on the confirm_title_text id + its exact copy, paired with the dialog's go_back_button id; corpus-unique (0 other snapshots). Distinct from dropoff_completed_confirm's 'Confirm order was completed'. PRIVACY: no customer PII (title + two button labels).",
+      "id": "doordash.screen.pickup_confirm_picked_up",
+      "priority": 132,
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "all": [
+                {
+                  "hasIdSuffix": "confirm_title_text"
+                },
+                {
+                  "hasTextContaining": "Confirm order was picked up"
+                }
+              ]
+            }
+          },
+          {
+            "exists": {
+              "hasIdSuffix": "go_back_button"
+            }
+          }
+        ]
       }
     }
   ],


### PR DESCRIPTION
Closes #888.

Eight DoorDash recognition-gap surfaces from the 07-26 pull's UNKNOWN census, built to the
#796/#837/#877 batch pattern: **every rule is recognize-only** — no `state.flow`, no `parse`,
no `bind`. Every one of the eight is a transient overlay / modal / progress screen sitting
inside a flow that is *already established* by the frames around it, which is exactly the shape
the repo already treats as recognize-only (`dropoff_multi_order_confirm`, `dropoff_issue_menu`,
`pickup_wait_survey`, `pickup_zone_arrival`, the whole #796 batch). See "State claims" below for
the two places I deliberately did **not** mirror a phase-claiming sibling.

## Per-surface anchors + PII verdicts

All anchors are platform chrome only — view ids and fixed DoorDash copy. **No merchant literal
appears in any anchor.**

| # | Rule (prio) | Anchors | Frames | PII verdict |
|---|---|---|---|---|
| 1 | `offer_accepting` (127, 2 branches) | **A:** `accept_decline_fragment_container` + `progress_message` + text `Decline`. **B:** `accept_decline_fragment_container` + `secondary_action_button_dash_plus` + a real store leg (the #595 `display_name` predicate `offer_popup` uses). Rule-level **reject**: `accept_button`, `accept_decline_footer_container`, text `Accept`, text `Add to route` | 4 | **Clean.** Offer economics + store names (driver-owned) + `assignment_id_text` (DoorDash's opaque offer UUID — the not-PII precedent is `AddonPhantomReplayTest`). No customer node exists on the offer card at all. |
| 2 | `shopping_pay_adjustment` (128) | `prism_sheet_title` ∧ contains `items have been added`, + `adjusted your pay` | 2 | **Clean.** Three text nodes, all fixed copy. The count is variable so it is matched as a substring. |
| 3a | `dropoff_geofence_warning` (84) — **new branch** | `geofence_warning_map` (this card's own view id) | 1 | **Clean in this frame** (partially inflated — the address TextViews exist but carry no text). Kept as a *branch on the existing rule* precisely so the rule's existing `address_line_1/_2/_subpremise_line` redact covers it — those nodes carry the **customer's** address whenever populated. |
| 3b | `dropoff_help_menu` (133) | `help you find the right resolution` (matched **without** the U+2019 apostrophe) + a `help_menu_item` naming `drop-off` | 1 | **Clean.** Fixed option labels only. |
| 3c | `dropoff_continue_to_complete` (134) | `prism_sheet_title` = `Continue to complete delivery` + `Continue to delivery steps` | 2 | **Clean.** Body says "the customer's instructions" generically and quotes none. |
| 4 | `dropoff_handed_directly_confirm` (136) | `handed order directly to customer` + `Confirm to complete delivery` (both id-less body/button copy) | 2 | **Clean.** Says "customer"/"them", names nobody; no address, gate code or order detail. |
| 5 | `pickup_pizza_bag` (129, 3 branches) | **A:** `component_title` ∧ `photo of your pizza bag` + `btn_primary_action`. **B:** `pizza_bag_uploading_title`. **C:** `verification_result_title` + text `pizza bag` | 3 | **Clean.** Equipment-photo instructions + a generic thank-you. Note: the dasher's own insulated bag is *not* a document-image capture surface, so the sensitive block correctly does not apply. |
| 6 | `shopping_shelf_photo` (131) | `prism_sheet_title` ∧ `photo of the shelf` + `substitution options` | 2 | **Clean.** Store-shelf artifact, "the customer" generic. |
| 7 | `pickup_confirm_picked_up` (132) | `confirm_title_text` ∧ `Confirm order was picked up` + `go_back_button` | 1 | **Clean.** Title + two button labels. |
| 8 | `pickup_wait_survey` (88) — **new branch** | `wait_survey_container` + `btn_submit_survey` + `What's causing your wait` | 1 | **Clean.** Three text nodes. |

**PII method.** Every one of the 13 committed fixtures went through the automated sweep
(`CLAUDE.local.md` step-6 recipe: two-capitalized-words, the `[A-Z][a-z]+ [A-Z]\.` #809 shape,
`Deliver to `/`Pickup for `/`Delivery for `/`Message from `/`For ` prefixes, `pin|code|gate` +
digits, street-address shapes, `Customer Notes:`, apt/suite/unit, bare 4–6 digit nodes) — **zero
hits** — *and* a manual eyeball of every `text`/`desc`/`stateDescription`/`hintText` value in all
13 files (they total 55 text-bearing values; all reproduced and read). Zero customer names,
addresses, gate codes, PINs, or free-text notes.

The `Delivery for <name>` going-to-store family from the same census (2 frames, sibling-split
label+name) is **out of scope** — that is #806 direction-1 work, per the issue.

## State claims — where I did NOT mirror the siblings

Three of the eight sit next to rules that *do* declare a flow. All three stay recognize-only,
deliberately:

- **`offer_accepting`** vs `offer_popup` / `offer_popup_confirm_decline` (`flow: offer:presented`).
  #595's comment in `offer.json5` is the standing receipt: re-asserting offer state on a
  **post-accept teardown frame** is exactly how ghost accepts / `OFFER_TIMEOUT`s got manufactured
  (06-28 seq 141/142, 06-30 seq 241/242). The accept was already latched by the click rule on the
  frame before; there is nothing for this frame to add. Branch B additionally requires the #595
  store-leg predicate, so the store-less degenerate frame #595 intentionally routes to UNKNOWN
  **stays** there.
- **`pickup_confirm_picked_up`** vs `pickup_picked_up` (98) / `pickup_verify` (101)
  (`task:pickup:arrived`), and **`dropoff_handed_directly_confirm`** vs `dropoff_completed_confirm`
  (65) (`task:dropoff:arrived`). Both new rules are *confirmation modals* over an already-established
  phase; the lifecycle edge is owned by the frames that follow. Claiming a phase from a modal is how
  a mis-anchored dialog perturbs task lineage, and the repo's posture for that exact shape is
  recognize-only.

`FlowRegionStepper` is the mechanical guarantee: a flow-less `FlowObservation` advances
`lastObservedAt` and returns `prev` — it cannot move R0.

## Census + steal-check (#877-style simulation)

A Python re-implementation of each rule's `require`/`reject` was run over **632 capture files**
(the whole 07-26 pull, both platforms, UNKNOWN *and* every recognized folder) and over the
**676-file committed corpus**.

**Pull (632 files) — matches, by current classification:**

| Rule | matches | UNKNOWN | already-recognized |
|---|---|---|---|
| `offer_accepting` | 4 | 4 | 0 |
| `shopping_pay_adjustment` | 2 | 2 | 0 |
| `dropoff_geofence_warning` (new branch) | 2 | 1 | 1 — `dropoff_geofence_warning` (**same rule**, self-match) |
| `dropoff_help_menu` | 1 | 1 | 0 |
| `dropoff_continue_to_complete` | 2 | 2 | 0 |
| `dropoff_handed_directly_confirm` | 2 | 2 | 0 |
| `pickup_pizza_bag` | 3 | 3 | 0 |
| `shopping_shelf_photo` | 2 | 2 | 0 |
| `pickup_confirm_picked_up` | 1 | 1 | 0 |
| `pickup_wait_survey` (new branch) | 2 | 1 | 1 — `pickup_wait_survey` (**same rule**, self-match) |

- **Cross-matches: zero.** No capture file matches more than one new rule.
- **Steals: zero.** The only two hits on already-recognized frames are self-matches of the rule
  the frame already belongs to. Structurally, every new *rule* takes priority 127–136 while every
  recognized folder present in the pull maps to a rule at priority ≤ 126, so `matchFirst` reaches
  the incumbent first regardless; and the two *branch* additions are on the very rules those
  frames already belong to.
- Corpus scan surfaced exactly one cross-folder hit — `sessions/addon_phantom_2026_06_21/01_addon_offer_de5eb2.json`
  — which is **correct**, not a steal: it *is* a post-accept teardown frame (footer gone,
  `progress_message` present). It has no folder==intent oracle (it is a session-replay fixture) and
  today classifies UNKNOWN. See the test note below.
- The simulation was then validated against the real classifier: `InboxProcessorTest` sorted all 13
  fixtures into exactly the folders the census predicted, and `GoldenSnapshotRegressionTest` is
  green across all 676 corpus files (folder == intent), i.e. no corpus frame changed rules.

**Documented residual (in-pull, deliberate):** one more offer-container UNKNOWN in the pull
(`11-25-27-947`, `18-39-52-655`) renders the **Accept** button with no `Decline` text — a live-offer
partial render that fails `offer_popup`'s `Decline` require. That is not the accepting spinner and is
correctly left to fall through; broadening `offer_popup` is a separate question.

## Golden summary

`approved-parse-output.json` regenerated with `-DupdateParseGolden=true` and diffed:

- **+78 lines, −0.** 13 new entries × 6 lines.
- **13 NEW, 0 CHANGED, 0 GONE.**
- Every new entry is `"shape": null, "fields": {}` — the recognize-only signature. No existing
  entry's `ruleId`, `intent`, `shape` or `fields` moved.
- The `screen-rule intent corpus coverage only ratchets up` pin needed no edit: the 8 new intents
  ship with corpus, so they never enter the uncovered set.

## Test results

- `./gradlew testDebugUnitTest :domain:test` — **BUILD SUCCESSFUL**, zero failures (full
  multi-module run, incl. `:core:pipeline` and `:domain`).
- `AllMatchersSuite` green (816 tests): golden guard, parse-output golden, ruleset + classifier
  regressions, `CaptureRedactionCorpusTest`, `CaptureBackstopCorpusTest`.
- `AddonPhantomReplayTest` green. Its fixture now reports `target=offer_accepting parsed=None`
  instead of UNKNOWN — its KDoc is updated in this PR to say so (a stale KDoc is a doc bug).
  The assertion it actually guards (never `delivery_summary_collapsed`) is untouched and passes,
  and because the rule is recognize-only the frame still cannot drive a PostTask exit.
- `OdometerPredicateEquivalenceTest` (replays all 8 session fixtures, pins the divergence count)
  green — the reclassified add-on frame produced no new odometer divergence.

## Field validation

Checklist item added to `docs/field-testing/README.md` (`Confirmed: 0/2`). It is framed as a
**negative** test — nothing new should appear on the HUD — with the accept spinner called out as
the one to watch, plus the desk-side UNKNOWN-census greps for the eight families.

---

### Design-goal review

- **1 (UDF).** No reducer, effect or UI change. Recognition is upstream of the state machine, and
  every new rule is flow-less, so `FlowRegionStepper` returns `prev` unchanged for these frames.
- **3 (single responsibility).** Each surface family gets one rule; multi-frame families
  (`offer_accepting`, `pickup_pizza_bag`) use `branches` rather than N near-duplicate rules, and the
  two variants of an existing surface (geofence card, wait survey) are branches on the *existing*
  rule so intent and `redact` stay singular.
- **5 (SSOT).** Branch-not-new-rule is the SSOT call for 3a and 8: a separate `dropoff_geofence_warning_partial`
  rule would have needed a second copy of the address `redact` block — the exact hand-maintained-second-copy
  class principle 5 exists to prevent. Branch B of `offer_accepting` reuses `offer_popup`'s own #595
  store-leg predicate shape rather than inventing a second definition of "has a real store".
- **6 (security & privacy).** Recognition-only widening; nothing new is parsed, hashed, persisted or
  sent. Per-surface PII verdicts above (automated sweep + manual read of all 55 text values across 13
  fixtures): **none of the eight surfaces carries customer PII**. The one surface that *can*
  (`dropoff_geofence_warning`, whose `address_line_*` hold the customer address) was extended as a
  **branch on the existing rule** specifically so its whole-rule `redact` keeps covering the new
  render — a separate rule would have silently shipped an unredacted customer-address surface. No
  sensitive-block rule is touched, so the #432/#399 block side cannot be downgraded by this diff. No
  `bind` is added, so no actuation target and no new capability key (#417/#425) enters the grant
  store. Capture posture unchanged (debug-only, `NoOpCaptureBus` in release).
- **7 (logging).** No log sites added or moved.
- **8 (platform-agnostic core).** Rule JSON only — **zero** Kotlin changes outside a test KDoc. No
  `:core:state` / `:core:pipeline` / `:domain` logic touched, no new vocabulary: every rule declares
  only `id`/`priority`/`require`/`reject`/`branches`, so nothing goes near `StateMachineContract`,
  `REQUIRED_FIELDS_BY_SHAPE`, `EFFECT_INTENTS` or `REQUIRED_FIELDS_BY_FLOW`. No platform literal
  enters any logic path — the anchors are per-platform ruleset *data*, which is the intended
  mechanism. Adding a platform still requires zero core edits.
- **Reactive UI rules.** N/A — no UI in the diff.
