### PR TITLE
test(corpus): 2026-07-30 pull slice additions

### DIFF
--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -269,6 +269,12 @@
         "shape": null,
         "fields": {}
     },
+    "customer_rating_detail/2026-07-29_15-19-01-381__doordash__accessibility.window__UNKNOWN__948ec3.json": {
+        "ruleId": "doordash.screen.customer_rating_detail",
+        "intent": "customer_rating_detail",
+        "shape": null,
+        "fields": {}
+    },
     "customer_rating_detail/customer_rating_detail.json": {
         "ruleId": "doordash.screen.customer_rating_detail",
         "intent": "customer_rating_detail",
@@ -1486,6 +1492,12 @@
         "shape": null,
         "fields": {}
     },
+    "dropoff_handoff/2026-07-29_17-55-50-627__doordash__accessibility.window__dropoff_handoff__b23b66.json": {
+        "ruleId": "doordash.screen.dropoff_handoff",
+        "intent": "dropoff_handoff",
+        "shape": null,
+        "fields": {}
+    },
     "dropoff_handoff/20260128_180855_435_DROPOFF_DETAILS_PRE_ARRIVAL.json": {
         "ruleId": "doordash.screen.dropoff_handoff",
         "intent": "dropoff_handoff",
@@ -2115,6 +2127,27 @@
             "deadline": {
                 "text": "5:02 PM",
                 "time": 1780333320000
+            },
+            "itemsRemaining": null,
+            "itemsShopped": null,
+            "phase": "DROPOFF",
+            "redCardTotal": null,
+            "storeAddress": null,
+            "storeName": null,
+            "subFlow": "NAVIGATION"
+        }
+    },
+    "dropoff_pre_arrival/2026-07-29_19-02-29-477__doordash__accessibility.window__dropoff_pre_arrival__8fe217.json": {
+        "ruleId": "doordash.screen.dropoff_pre_arrival",
+        "intent": "dropoff_pre_arrival",
+        "shape": "task",
+        "fields": {
+            "arrivalConfirmed": false,
+            "customerAddressHash": null,
+            "customerNameHash": "b68919aff001d8366249403a2544fba2d833084f1ad22839b6310aadacb6a138",
+            "deadline": {
+                "text": "7:09 PM",
+                "time": 1780340940000
             },
             "itemsRemaining": null,
             "itemsShopped": null,
@@ -3375,6 +3408,12 @@
     "performance_orders_list/performance_orders_list_scrolled_tail.json": {
         "ruleId": "doordash.screen.performance_orders_list",
         "intent": "performance_orders_list",
+        "shape": null,
+        "fields": {}
+    },
+    "performance_rate_detail/2026-07-29_15-18-24-090__doordash__accessibility.window__UNKNOWN__b062f1.json": {
+        "ruleId": "doordash.screen.performance_rate_detail",
+        "intent": "performance_rate_detail",
         "shape": null,
         "fields": {}
     },
@@ -5204,6 +5243,25 @@
             "lifetimeShoppingOrders": null,
             "onTimeRate": 100.0,
             "originalItemsFoundRate": 100.0,
+            "substitutionIssuesRate": null,
+            "totalItemsFoundRate": null
+        }
+    },
+    "ratings/2026-07-29_15-19-05-861__doordash__accessibility.window__UNKNOWN__dd3695.json": {
+        "ruleId": "doordash.screen.ratings",
+        "intent": "ratings",
+        "shape": "ratings",
+        "fields": {
+            "acceptanceRate": null,
+            "completionRate": null,
+            "customerRating": null,
+            "deliveriesLast30Days": null,
+            "itemsWithQualityIssuesRate": null,
+            "itemsWrongOrMissingRate": null,
+            "lifetimeDeliveries": null,
+            "lifetimeShoppingOrders": null,
+            "onTimeRate": null,
+            "originalItemsFoundRate": null,
             "substitutionIssuesRate": null,
             "totalItemsFoundRate": null
         }

--- a/app/src/test/resources/snapshots/customer_rating_detail/2026-07-29_15-19-01-381__doordash__accessibility.window__UNKNOWN__948ec3.json
+++ b/app/src/test/resources/snapshots/customer_rating_detail/2026-07-29_15-19-01-381__doordash__accessibility.window__UNKNOWN__948ec3.json
@@ -1,0 +1,1748 @@
+{
+    "captureId": "74192f57-9af3-4177-8dd8-ac0353362941",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785356341363,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Navigate up",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 144,
+                                                                            "right": 125,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 1080,
+                                                                            "top": 144,
+                                                                            "right": 1080,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/fragment",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 278,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 278,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 278,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 278,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/rating",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 278,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1952
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/rating_header_card_compose_view",
+                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 278,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1275
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 278,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 1275
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 305,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 1239
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Customer rating",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 72,
+                                                                                                                            "top": 341,
+                                                                                                                            "right": 398,
+                                                                                                                            "bottom": 393
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "4.96",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 72,
+                                                                                                                            "top": 400,
+                                                                                                                            "right": 220,
+                                                                                                                            "bottom": 484
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 331,
+                                                                                                                            "top": 388,
+                                                                                                                            "right": 511,
+                                                                                                                            "bottom": 495
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Very high",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 331,
+                                                                                                                                    "top": 418,
+                                                                                                                                    "right": 511,
+                                                                                                                                    "bottom": 465
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 470,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 576
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Points toward your overall rating",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 72,
+                                                                                                                            "top": 560,
+                                                                                                                            "right": 654,
+                                                                                                                            "bottom": 607
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "10 of 10 points",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 72,
+                                                                                                                            "top": 607,
+                                                                                                                            "right": 346,
+                                                                                                                            "bottom": 654
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "desc": "Collapse",
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 955,
+                                                                                                                            "top": 581,
+                                                                                                                            "right": 1008,
+                                                                                                                            "bottom": 634
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 690,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1239
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 72,
+                                                                                                                                    "top": 670,
+                                                                                                                                    "right": 256,
+                                                                                                                                    "bottom": 777
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 260,
+                                                                                                                                    "top": 670,
+                                                                                                                                    "right": 444,
+                                                                                                                                    "bottom": 766
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 448,
+                                                                                                                                    "top": 670,
+                                                                                                                                    "right": 632,
+                                                                                                                                    "bottom": 777
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 636,
+                                                                                                                                    "top": 670,
+                                                                                                                                    "right": 820,
+                                                                                                                                    "bottom": 777
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 824,
+                                                                                                                                    "top": 670,
+                                                                                                                                    "right": 1008,
+                                                                                                                                    "bottom": 777
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 28,
+                                                                                                                                    "top": 737,
+                                                                                                                                    "right": 134,
+                                                                                                                                    "bottom": 843
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "Very high (4.88 - 5.00)",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 108,
+                                                                                                                                    "top": 766,
+                                                                                                                                    "right": 535,
+                                                                                                                                    "bottom": 813
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "9 - 10 pts",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 853,
+                                                                                                                                    "top": 768,
+                                                                                                                                    "right": 1008,
+                                                                                                                                    "bottom": 811
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 28,
+                                                                                                                                    "top": 802,
+                                                                                                                                    "right": 134,
+                                                                                                                                    "bottom": 908
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "High (4.76 - 4.87)",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 108,
+                                                                                                                                    "top": 831,
+                                                                                                                                    "right": 420,
+                                                                                                                                    "bottom": 878
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "7 - 8 pts",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 875,
+                                                                                                                                    "top": 833,
+                                                                                                                                    "right": 1008,
+                                                                                                                                    "bottom": 876
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 28,
+                                                                                                                                    "top": 867,
+                                                                                                                                    "right": 134,
+                                                                                                                                    "bottom": 973
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "Moderate (4.58 - 4.75)",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 108,
+                                                                                                                                    "top": 896,
+                                                                                                                                    "right": 516,
+                                                                                                                                    "bottom": 943
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "4 - 6 pts",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 874,
+                                                                                                                                    "top": 898,
+                                                                                                                                    "right": 1008,
+                                                                                                                                    "bottom": 941
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 28,
+                                                                                                                                    "top": 932,
+                                                                                                                                    "right": 134,
+                                                                                                                                    "bottom": 1038
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "Low (4.41 - 4.57)",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 108,
+                                                                                                                                    "top": 961,
+                                                                                                                                    "right": 405,
+                                                                                                                                    "bottom": 1008
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "1 - 3 pts",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 882,
+                                                                                                                                    "top": 963,
+                                                                                                                                    "right": 1008,
+                                                                                                                                    "bottom": 1006
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 28,
+                                                                                                                                    "top": 997,
+                                                                                                                                    "right": 134,
+                                                                                                                                    "bottom": 1103
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "Very low (0.00 - 4.40)",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 108,
+                                                                                                                                    "top": 1026,
+                                                                                                                                    "right": 509,
+                                                                                                                                    "bottom": 1073
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "0 pts",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 923,
+                                                                                                                                    "top": 1028,
+                                                                                                                                    "right": 1008,
+                                                                                                                                    "bottom": 1071
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 72,
+                                                                                                                                    "top": 1109,
+                                                                                                                                    "right": 1008,
+                                                                                                                                    "bottom": 1203
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Very low ratings put you at risk for deactivation. Learn more",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 72,
+                                                                                                                                            "top": 1109,
+                                                                                                                                            "right": 1008,
+                                                                                                                                            "bottom": 1203
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/rating_trend_celebration_compose_view",
+                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1275,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1438
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1275,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 1438
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "0.00",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 222,
+                                                                                                                    "top": 1293,
+                                                                                                                    "right": 317,
+                                                                                                                    "bottom": 1340
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "this week",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 192,
+                                                                                                                    "top": 1340,
+                                                                                                                    "right": 347,
+                                                                                                                    "bottom": 1383
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 487,
+                                                                                                                    "top": 1285,
+                                                                                                                    "right": 593,
+                                                                                                                    "bottom": 1391
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "1",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 825,
+                                                                                                                    "top": 1293,
+                                                                                                                    "right": 842,
+                                                                                                                    "bottom": 1340
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "in a row",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 747,
+                                                                                                                    "top": 1340,
+                                                                                                                    "right": 874,
+                                                                                                                    "bottom": 1383
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1384,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 1438
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Last 100 ratings",
+                                                                                                "id": "com.doordash.driverapp:id/rating_section_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1438,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1548
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_five",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1575,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1615
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 27,
+                                                                                                            "top": 1575,
+                                                                                                            "right": 1053,
+                                                                                                            "bottom": 1615
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "5",
+                                                                                                                "id": "com.doordash.driverapp:id/rating",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 27,
+                                                                                                                    "top": 1575,
+                                                                                                                    "right": 79,
+                                                                                                                    "bottom": 1612
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "97%",
+                                                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 98,
+                                                                                                                    "top": 1585,
+                                                                                                                    "right": 995,
+                                                                                                                    "bottom": 1603
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "97",
+                                                                                                                "id": "com.doordash.driverapp:id/rating_count",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 999,
+                                                                                                                    "top": 1575,
+                                                                                                                    "right": 1052,
+                                                                                                                    "bottom": 1615
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_four",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1642,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1682
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 27,
+                                                                                                            "top": 1642,
+                                                                                                            "right": 1053,
+                                                                                                            "bottom": 1682
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "4",
+                                                                                                                "id": "com.doordash.driverapp:id/rating",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 27,
+                                                                                                                    "top": 1642,
+                                                                                                                    "right": 78,
+                                                                                                                    "bottom": 1679
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "2%",
+                                                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 98,
+                                                                                                                    "top": 1652,
+                                                                                                                    "right": 995,
+                                                                                                                    "bottom": 1670
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "2",
+                                                                                                                "id": "com.doordash.driverapp:id/rating_count",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 999,
+                                                                                                                    "top": 1642,
+                                                                                                                    "right": 1052,
+                                                                                                                    "bottom": 1682
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_three",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1709,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1749
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 27,
+                                                                                                            "top": 1709,
+                                                                                                            "right": 1053,
+                                                                                                            "bottom": 1749
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "3",
+                                                                                                                "id": "com.doordash.driverapp:id/rating",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 27,
+                                                                                                                    "top": 1709,
+                                                                                                                    "right": 77,
+                                                                                                                    "bottom": 1746
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "1%",
+                                                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 98,
+                                                                                                                    "top": 1719,
+                                                                                                                    "right": 995,
+                                                                                                                    "bottom": 1737
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "1",
+                                                                                                                "id": "com.doordash.driverapp:id/rating_count",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 999,
+                                                                                                                    "top": 1709,
+                                                                                                                    "right": 1052,
+                                                                                                                    "bottom": 1749
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_two",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1776,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1816
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 27,
+                                                                                                            "top": 1776,
+                                                                                                            "right": 1053,
+                                                                                                            "bottom": 1816
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "2",
+                                                                                                                "id": "com.doordash.driverapp:id/rating",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 27,
+                                                                                                                    "top": 1776,
+                                                                                                                    "right": 77,
+                                                                                                                    "bottom": 1813
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "0%",
+                                                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 98,
+                                                                                                                    "top": 1786,
+                                                                                                                    "right": 995,
+                                                                                                                    "bottom": 1804
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "0",
+                                                                                                                "id": "com.doordash.driverapp:id/rating_count",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 999,
+                                                                                                                    "top": 1776,
+                                                                                                                    "right": 1052,
+                                                                                                                    "bottom": 1816
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/progress_bar_one",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1843,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1883
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 27,
+                                                                                                            "top": 1843,
+                                                                                                            "right": 1053,
+                                                                                                            "bottom": 1883
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "text": "1",
+                                                                                                                "id": "com.doordash.driverapp:id/rating",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 27,
+                                                                                                                    "top": 1843,
+                                                                                                                    "right": 71,
+                                                                                                                    "bottom": 1880
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "state": "0%",
+                                                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                                                "class": "android.widget.ProgressBar",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 98,
+                                                                                                                    "top": 1853,
+                                                                                                                    "right": 995,
+                                                                                                                    "bottom": 1871
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "0",
+                                                                                                                "id": "com.doordash.driverapp:id/rating_count",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 999,
+                                                                                                                    "top": 1843,
+                                                                                                                    "right": 1052,
+                                                                                                                    "bottom": 1883
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/unfair_ratings_container",
+                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 27,
+                                                                                                    "top": 1910,
+                                                                                                    "right": 429,
+                                                                                                    "bottom": 1952
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/shield_icon",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 27,
+                                                                                                            "top": 1913,
+                                                                                                            "right": 63,
+                                                                                                            "bottom": 1949
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "0 ratings excluded",
+                                                                                                        "id": "com.doordash.driverapp:id/unfair_ratings_text",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 81,
+                                                                                                            "top": 1910,
+                                                                                                            "right": 384,
+                                                                                                            "bottom": 1952
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/unfair_ratings_more_info",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 393,
+                                                                                                            "top": 1913,
+                                                                                                            "right": 429,
+                                                                                                            "bottom": 1949
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/customer_feedback",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1952,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Customer Feedback",
+                                                                                                "id": "com.doordash.driverapp:id/feedback_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 2023,
+                                                                                                    "right": 498,
+                                                                                                    "bottom": 2080
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/feedback_category_tiles",
+                                                                                                "class": "androidx.recyclerview.widget.StaggeredGridLayoutManager",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 18,
+                                                                                                    "top": 2116,
+                                                                                                    "right": 1062,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/category_item_compose_view",
+                                                                                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 18,
+                                                                                                            "top": 2116,
+                                                                                                            "right": 540,
+                                                                                                            "bottom": 2336
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 18,
+                                                                                                                    "top": 2116,
+                                                                                                                    "right": 540,
+                                                                                                                    "bottom": 2336
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 2134,
+                                                                                                                            "right": 522,
+                                                                                                                            "bottom": 2318
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Communication",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 63,
+                                                                                                                                    "top": 2161,
+                                                                                                                                    "right": 495,
+                                                                                                                                    "bottom": 2208
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 63,
+                                                                                                                                    "top": 2250,
+                                                                                                                                    "right": 99,
+                                                                                                                                    "bottom": 2286
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "7",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 108,
+                                                                                                                                    "top": 2244,
+                                                                                                                                    "right": 130,
+                                                                                                                                    "bottom": 2291
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 166,
+                                                                                                                                    "top": 2250,
+                                                                                                                                    "right": 202,
+                                                                                                                                    "bottom": 2286
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "–",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 211,
+                                                                                                                                    "top": 2244,
+                                                                                                                                    "right": 232,
+                                                                                                                                    "bottom": 2291
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "right_arrow",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 459,
+                                                                                                                                    "top": 2250,
+                                                                                                                                    "right": 495,
+                                                                                                                                    "bottom": 2286
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/category_item_compose_view",
+                                                                                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 18,
+                                                                                                            "top": 2336,
+                                                                                                            "right": 540,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 18,
+                                                                                                                    "top": 2336,
+                                                                                                                    "right": 540,
+                                                                                                                    "bottom": 2556
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 2354,
+                                                                                                                            "right": 522,
+                                                                                                                            "bottom": 2538
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Order Handling",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 63,
+                                                                                                                                    "top": 2381,
+                                                                                                                                    "right": 495,
+                                                                                                                                    "bottom": 2428
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 63,
+                                                                                                                                    "top": 2470,
+                                                                                                                                    "right": 99,
+                                                                                                                                    "bottom": 2506
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "8",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 108,
+                                                                                                                                    "top": 2464,
+                                                                                                                                    "right": 134,
+                                                                                                                                    "bottom": 2511
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 170,
+                                                                                                                                    "top": 2470,
+                                                                                                                                    "right": 206,
+                                                                                                                                    "bottom": 2506
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "–",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 215,
+                                                                                                                                    "top": 2464,
+                                                                                                                                    "right": 236,
+                                                                                                                                    "bottom": 2511
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "right_arrow",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 459,
+                                                                                                                                    "top": 2470,
+                                                                                                                                    "right": 495,
+                                                                                                                                    "bottom": 2506
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/category_item_compose_view",
+                                                                                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 540,
+                                                                                                            "top": 2116,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 540,
+                                                                                                                    "top": 2116,
+                                                                                                                    "right": 1062,
+                                                                                                                    "bottom": 2392
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 558,
+                                                                                                                            "top": 2134,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 2374
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Followed Delivery Instructions",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 585,
+                                                                                                                                    "top": 2161,
+                                                                                                                                    "right": 1017,
+                                                                                                                                    "bottom": 2264
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 585,
+                                                                                                                                    "top": 2306,
+                                                                                                                                    "right": 621,
+                                                                                                                                    "bottom": 2342
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "8",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 630,
+                                                                                                                                    "top": 2300,
+                                                                                                                                    "right": 656,
+                                                                                                                                    "bottom": 2347
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 692,
+                                                                                                                                    "top": 2306,
+                                                                                                                                    "right": 728,
+                                                                                                                                    "bottom": 2342
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "–",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 737,
+                                                                                                                                    "top": 2300,
+                                                                                                                                    "right": 758,
+                                                                                                                                    "bottom": 2347
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "right_arrow",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 981,
+                                                                                                                                    "top": 2306,
+                                                                                                                                    "right": 1017,
+                                                                                                                                    "bottom": 2342
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/category_item_compose_view",
+                                                                                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 540,
+                                                                                                            "top": 2392,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 540,
+                                                                                                                    "top": 2392,
+                                                                                                                    "right": 1062,
+                                                                                                                    "bottom": 2612
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 558,
+                                                                                                                            "top": 2410,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 2594
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Friendliness",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 585,
+                                                                                                                                    "top": 2437,
+                                                                                                                                    "right": 1017,
+                                                                                                                                    "bottom": 2484
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 585,
+                                                                                                                                    "top": 2526,
+                                                                                                                                    "right": 621,
+                                                                                                                                    "bottom": 2562
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "9",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 630,
+                                                                                                                                    "top": 2520,
+                                                                                                                                    "right": 655,
+                                                                                                                                    "bottom": 2567
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "thumbs_up_thumbs_down_icon",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 691,
+                                                                                                                                    "top": 2526,
+                                                                                                                                    "right": 727,
+                                                                                                                                    "bottom": 2562
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "text": "–",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 736,
+                                                                                                                                    "top": 2520,
+                                                                                                                                    "right": 757,
+                                                                                                                                    "bottom": 2567
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "right_arrow",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 981,
+                                                                                                                                    "top": 2526,
+                                                                                                                                    "right": 1017,
+                                                                                                                                    "bottom": 2562
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/customer_compliments",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2612,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Customer Compliments",
+                                                                                                "id": "com.doordash.driverapp:id/compliment_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 2683,
+                                                                                                    "right": 579,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/ic_compliments",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 2776,
+                                                                                                    "right": 196,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Above and Beyond",
+                                                                                                "id": "com.doordash.driverapp:id/above_beyond",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 214,
+                                                                                                    "top": 2793,
+                                                                                                    "right": 557,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "5",
+                                                                                                "id": "com.doordash.driverapp:id/above_beyond_count",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 87,
+                                                                                                    "top": 2896,
+                                                                                                    "right": 145,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Number of times customers thought you went 'Above and Beyond'.",
+                                                                                                "id": "com.doordash.driverapp:id/above_beyond_desc",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 214,
+                                                                                                    "top": 2844,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Quotes from customers",
+                                                                                                "id": "com.doordash.driverapp:id/quotes_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 3028,
+                                                                                                    "right": 478,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/quotes_recycler",
+                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 3111,
+                                                                                                    "right": 44,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Customer quotes from 5-star reviews will appear here.",
+                                                                                                "id": "com.doordash.driverapp:id/no_compliments",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 3111,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/learn_more",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 3285,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Learn more",
+                                                                                                "id": "com.doordash.driverapp:id/learn_more_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 3356,
+                                                                                                    "right": 296,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/learn_more_section_compose_view",
+                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 3431,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 3431,
+                                                                                                            "right": 1044,
+                                                                                                            "bottom": 3785
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 3431,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 3532
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "How we're collecting data",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 3458,
+                                                                                                                            "right": 501,
+                                                                                                                            "bottom": 3505
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 3480,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 3532
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 3532,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 3637
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "How we calculate Customer Ratings",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 3561,
+                                                                                                                            "right": 688,
+                                                                                                                            "bottom": 3608
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 3583,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 3637
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 3637,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 3785
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "Deactivation Policy",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 3664,
+                                                                                                                            "right": 386,
+                                                                                                                            "bottom": 3711
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Eligible if below 4.2",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 3715,
+                                                                                                                            "right": 354,
+                                                                                                                            "bottom": 3758
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/dropoff_handoff/2026-07-29_17-55-50-627__doordash__accessibility.window__dropoff_handoff__b23b66.json
+++ b/app/src/test/resources/snapshots/dropoff_handoff/2026-07-29_17-55-50-627__doordash__accessibility.window__dropoff_handoff__b23b66.json
@@ -1,0 +1,813 @@
+{
+    "captureId": "4da8245c-b812-4d4e-ac5d-b2b19c50de68",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785365750610,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.dropoff_handoff",
+    "classificationName": "dropoff_handoff",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 136
+                                                        }
+                                                    },
+                                                    {
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2347
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 243,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2032
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 243,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 535
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Deliver to [redacted]",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 288,
+                                                                                                                                            "right": 516,
+                                                                                                                                            "bottom": 354
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "by 6:03 PM",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 363,
+                                                                                                                                            "right": 245,
+                                                                                                                                            "bottom": 410
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 419,
+                                                                                                                                            "right": 204,
+                                                                                                                                            "bottom": 526
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 28,
+                                                                                                                                                    "top": 420,
+                                                                                                                                                    "right": 134,
+                                                                                                                                                    "bottom": 526
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Call",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 108,
+                                                                                                                                                    "top": 451,
+                                                                                                                                                    "right": 175,
+                                                                                                                                                    "bottom": 494
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 437,
+                                                                                                                                                    "right": 204,
+                                                                                                                                                    "bottom": 508
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 222,
+                                                                                                                                            "top": 419,
+                                                                                                                                            "right": 472,
+                                                                                                                                            "bottom": 526
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 214,
+                                                                                                                                                    "top": 420,
+                                                                                                                                                    "right": 320,
+                                                                                                                                                    "bottom": 526
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Message",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 294,
+                                                                                                                                                    "top": 451,
+                                                                                                                                                    "right": 443,
+                                                                                                                                                    "bottom": 494
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 222,
+                                                                                                                                                    "top": 437,
+                                                                                                                                                    "right": 472,
+                                                                                                                                                    "bottom": 508
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 571,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1356
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 179,
+                                                                                                                                            "top": 603,
+                                                                                                                                            "right": 1008,
+                                                                                                                                            "bottom": 710
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "[redacted:723a]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 607,
+                                                                                                                                                    "right": 766,
+                                                                                                                                                    "bottom": 659
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "[redacted]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 659,
+                                                                                                                                                    "right": 595,
+                                                                                                                                                    "bottom": 706
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 607,
+                                                                                                                                                    "right": 1008,
+                                                                                                                                                    "bottom": 706
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 742,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1145
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 690,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 744
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 744,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1145
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1093,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1199
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 178,
+                                                                                                                                            "top": 1198,
+                                                                                                                                            "right": 991,
+                                                                                                                                            "bottom": 1305
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Apt/Suite",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 178,
+                                                                                                                                                    "top": 1200,
+                                                                                                                                                    "right": 364,
+                                                                                                                                                    "bottom": 1247
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Apt [redacted:e7fa]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 178,
+                                                                                                                                                    "top": 1256,
+                                                                                                                                                    "right": 331,
+                                                                                                                                                    "bottom": 1303
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1392,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1764
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 179,
+                                                                                                                                            "top": 1420,
+                                                                                                                                            "right": 910,
+                                                                                                                                            "bottom": 1526
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Hand it to customer",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": -34,
+                                                                                                                                                    "top": 1447,
+                                                                                                                                                    "right": 370,
+                                                                                                                                                    "bottom": 1499
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 23,
+                                                                                                                                                    "top": 1447,
+                                                                                                                                                    "right": 763,
+                                                                                                                                                    "bottom": 1499
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 910,
+                                                                                                                                            "top": 1419,
+                                                                                                                                            "right": 1017,
+                                                                                                                                            "bottom": 1526
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 754,
+                                                                                                                                                    "top": 1419,
+                                                                                                                                                    "right": 861,
+                                                                                                                                                    "bottom": 1526
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1501,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1607
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "[redacted:249e]",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 178,
+                                                                                                                                            "top": 1608,
+                                                                                                                                            "right": 991,
+                                                                                                                                            "bottom": 1711
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1800,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1943
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": -119,
+                                                                                                                                            "top": 1800,
+                                                                                                                                            "right": 888,
+                                                                                                                                            "bottom": 1943
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "[redacted]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 23,
+                                                                                                                                                    "top": 1846,
+                                                                                                                                                    "right": 100,
+                                                                                                                                                    "bottom": 1898
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1980,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2086
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 2034,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2347
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": -119,
+                                                                                                                                    "top": 2070,
+                                                                                                                                    "right": 888,
+                                                                                                                                    "bottom": 2177
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.Button",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": -119,
+                                                                                                                                            "top": 2070,
+                                                                                                                                            "right": 888,
+                                                                                                                                            "bottom": 2177
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Mark as delivered",
+                                                                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 203,
+                                                                                                                                                    "top": 2091,
+                                                                                                                                                    "right": 565,
+                                                                                                                                                    "bottom": 2157
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": -119,
+                                                                                                                                    "top": 2204,
+                                                                                                                                    "right": 888,
+                                                                                                                                    "bottom": 2311
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.Button",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": -119,
+                                                                                                                                            "top": 2204,
+                                                                                                                                            "right": 888,
+                                                                                                                                            "bottom": 2311
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Directions",
+                                                                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 279,
+                                                                                                                                                    "top": 2225,
+                                                                                                                                                    "right": 490,
+                                                                                                                                                    "bottom": 2291
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": -155,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": -48,
+                                                                                                                            "bottom": 243
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "Settings",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": -128,
+                                                                                                                                    "top": 163,
+                                                                                                                                    "right": -75,
+                                                                                                                                    "bottom": 216
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": -146,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": -57,
+                                                                                                                                    "bottom": 234
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": -48,
+                                                                                                                            "top": 137,
+                                                                                                                            "right": 710,
+                                                                                                                            "bottom": 243
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 710,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 817,
+                                                                                                                            "bottom": 243
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "Safety",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 737,
+                                                                                                                                    "top": 163,
+                                                                                                                                    "right": 790,
+                                                                                                                                    "bottom": 216
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 719,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": 808,
+                                                                                                                                    "bottom": 234
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 817,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 924,
+                                                                                                                            "bottom": 243
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "Help",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 844,
+                                                                                                                                    "top": 163,
+                                                                                                                                    "right": 897,
+                                                                                                                                    "bottom": 216
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 826,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": 915,
+                                                                                                                                    "bottom": 234
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/dropoff_handoff/2026-07-29_17-55-50-627__doordash__accessibility.window__dropoff_handoff__b23b66.json
+++ b/app/src/test/resources/snapshots/dropoff_handoff/2026-07-29_17-55-50-627__doordash__accessibility.window__dropoff_handoff__b23b66.json
@@ -432,7 +432,7 @@
                                                                                                                                                 }
                                                                                                                                             },
                                                                                                                                             {
-                                                                                                                                                "text": "Apt [redacted:e7fa]",
+                                                                                                                                                "text": "Apt [redacted]",
                                                                                                                                                 "class": "android.widget.TextView",
                                                                                                                                                 "isEnabled": true,
                                                                                                                                                 "bounds": {

--- a/app/src/test/resources/snapshots/dropoff_pre_arrival/2026-07-29_19-02-29-477__doordash__accessibility.window__dropoff_pre_arrival__8fe217.json
+++ b/app/src/test/resources/snapshots/dropoff_pre_arrival/2026-07-29_19-02-29-477__doordash__accessibility.window__dropoff_pre_arrival__8fe217.json
@@ -1,0 +1,627 @@
+{
+    "captureId": "b8ef8387-d351-44ae-a7e4-17296adbbec9",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785369749472,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.dropoff_pre_arrival",
+    "classificationName": "dropoff_pre_arrival",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": -213,
+            "top": 0,
+            "right": 866,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 136
+                                                        }
+                                                    },
+                                                    {
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2347
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 243,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2032
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 243,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 535
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Deliver to [redacted]",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 288,
+                                                                                                                                            "right": 519,
+                                                                                                                                            "bottom": 354
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "by 7:09 PM",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 363,
+                                                                                                                                            "right": 244,
+                                                                                                                                            "bottom": 410
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 419,
+                                                                                                                                            "right": 204,
+                                                                                                                                            "bottom": 526
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 28,
+                                                                                                                                                    "top": 420,
+                                                                                                                                                    "right": 134,
+                                                                                                                                                    "bottom": 526
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Call",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 108,
+                                                                                                                                                    "top": 451,
+                                                                                                                                                    "right": 175,
+                                                                                                                                                    "bottom": 494
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 437,
+                                                                                                                                                    "right": 204,
+                                                                                                                                                    "bottom": 508
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 222,
+                                                                                                                                            "top": 419,
+                                                                                                                                            "right": 472,
+                                                                                                                                            "bottom": 526
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 214,
+                                                                                                                                                    "top": 420,
+                                                                                                                                                    "right": 320,
+                                                                                                                                                    "bottom": 526
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Message",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 294,
+                                                                                                                                                    "top": 451,
+                                                                                                                                                    "right": 443,
+                                                                                                                                                    "bottom": 494
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 222,
+                                                                                                                                                    "top": 437,
+                                                                                                                                                    "right": 472,
+                                                                                                                                                    "bottom": 508
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 571,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1495
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 179,
+                                                                                                                                            "top": 603,
+                                                                                                                                            "right": 1008,
+                                                                                                                                            "bottom": 710
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "[redacted:bfb7]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 607,
+                                                                                                                                                    "right": 665,
+                                                                                                                                                    "bottom": 659
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "[redacted]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 659,
+                                                                                                                                                    "right": 536,
+                                                                                                                                                    "bottom": 706
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 607,
+                                                                                                                                                    "right": 1008,
+                                                                                                                                                    "bottom": 706
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 742,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1145
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 690,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 744
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 744,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1145
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1093,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1199
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 178,
+                                                                                                                                            "top": 1200,
+                                                                                                                                            "right": 991,
+                                                                                                                                            "bottom": 1442
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Entry code",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 178,
+                                                                                                                                                    "top": 1200,
+                                                                                                                                                    "right": 384,
+                                                                                                                                                    "bottom": 1247
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "[redacted]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 178,
+                                                                                                                                                    "top": 1256,
+                                                                                                                                                    "right": 267,
+                                                                                                                                                    "bottom": 1303
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Apt/Suite",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 598,
+                                                                                                                                                    "top": 1200,
+                                                                                                                                                    "right": 784,
+                                                                                                                                                    "bottom": 1247
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "[redacted]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 598,
+                                                                                                                                                    "top": 1256,
+                                                                                                                                                    "right": 664,
+                                                                                                                                                    "bottom": 1303
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Building [redacted]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 178,
+                                                                                                                                                    "top": 1339,
+                                                                                                                                                    "right": 457,
+                                                                                                                                                    "bottom": 1386
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "[redacted:f847]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 178,
+                                                                                                                                                    "top": 1395,
+                                                                                                                                                    "right": 664,
+                                                                                                                                                    "bottom": 1442
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1531,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1692
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": -34,
+                                                                                                                                            "top": 1559,
+                                                                                                                                            "right": 696,
+                                                                                                                                            "bottom": 1665
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Leave it at the door",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": -34,
+                                                                                                                                                    "top": 1586,
+                                                                                                                                                    "right": 360,
+                                                                                                                                                    "bottom": 1638
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 117,
+                                                                                                                                                    "top": 1586,
+                                                                                                                                                    "right": 857,
+                                                                                                                                                    "bottom": 1638
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 848,
+                                                                                                                                            "top": 1558,
+                                                                                                                                            "right": 955,
+                                                                                                                                            "bottom": 1665
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 898,
+                                                                                                                                                    "top": 1558,
+                                                                                                                                                    "right": 1005,
+                                                                                                                                                    "bottom": 1665
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 26,
+                                                                                                                                    "top": 1728,
+                                                                                                                                    "right": 1034,
+                                                                                                                                    "bottom": 1871
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 26,
+                                                                                                                                            "top": 1728,
+                                                                                                                                            "right": 1034,
+                                                                                                                                            "bottom": 1871
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 44,
+                                                                                                                                                    "top": 1746,
+                                                                                                                                                    "right": 151,
+                                                                                                                                                    "bottom": 1853
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/performance_rate_detail/2026-07-29_15-18-24-090__doordash__accessibility.window__UNKNOWN__b062f1.json
+++ b/app/src/test/resources/snapshots/performance_rate_detail/2026-07-29_15-18-24-090__doordash__accessibility.window__UNKNOWN__b062f1.json
@@ -1,0 +1,669 @@
+{
+    "captureId": "40c507bf-ba9e-4f1f-a60e-72e3709070e1",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785356304077,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 156,
+                    "top": 0,
+                    "right": 1236,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 156,
+                            "top": 136,
+                            "right": 1236,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 156,
+                                    "top": 136,
+                                    "right": 1236,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 156,
+                                            "top": 136,
+                                            "right": 1236,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/main_content",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 156,
+                                                    "top": 136,
+                                                    "right": 1236,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 156,
+                                                            "top": 136,
+                                                            "right": 1236,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 156,
+                                                                    "top": 136,
+                                                                    "right": 1236,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Navigate up",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 156,
+                                                                            "top": 144,
+                                                                            "right": 281,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 1236,
+                                                                            "top": 144,
+                                                                            "right": 1236,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 156,
+                                                            "top": 278,
+                                                            "right": 1236,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 156,
+                                                                    "top": 278,
+                                                                    "right": 1236,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 156,
+                                                                            "top": 278,
+                                                                            "right": 1236,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.widget.ScrollView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 156,
+                                                                                    "top": 278,
+                                                                                    "right": 1236,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 192,
+                                                                                            "top": 305,
+                                                                                            "right": 1200,
+                                                                                            "bottom": 1044
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Last 30-day orders",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 228,
+                                                                                                    "top": 341,
+                                                                                                    "right": 608,
+                                                                                                    "bottom": 393
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "80",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 228,
+                                                                                                    "top": 400,
+                                                                                                    "right": 322,
+                                                                                                    "bottom": 484
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 376,
+                                                                                                    "top": 388,
+                                                                                                    "right": 560,
+                                                                                                    "bottom": 495
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "Moderate",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 376,
+                                                                                                            "top": 418,
+                                                                                                            "right": 560,
+                                                                                                            "bottom": 465
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 192,
+                                                                                                    "top": 470,
+                                                                                                    "right": 1200,
+                                                                                                    "bottom": 576
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Points toward your overall rating",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 228,
+                                                                                                    "top": 560,
+                                                                                                    "right": 810,
+                                                                                                    "bottom": 607
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "2 of 5 points",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 228,
+                                                                                                    "top": 607,
+                                                                                                    "right": 461,
+                                                                                                    "bottom": 654
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "desc": "Collapse",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 1111,
+                                                                                                    "top": 581,
+                                                                                                    "right": 1164,
+                                                                                                    "bottom": 634
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 192,
+                                                                                                    "top": 690,
+                                                                                                    "right": 1200,
+                                                                                                    "bottom": 1044
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 228,
+                                                                                                            "top": 670,
+                                                                                                            "right": 459,
+                                                                                                            "bottom": 777
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 463,
+                                                                                                            "top": 670,
+                                                                                                            "right": 694,
+                                                                                                            "bottom": 777
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 698,
+                                                                                                            "top": 670,
+                                                                                                            "right": 929,
+                                                                                                            "bottom": 777
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 933,
+                                                                                                            "top": 670,
+                                                                                                            "right": 1164,
+                                                                                                            "bottom": 777
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 184,
+                                                                                                            "top": 737,
+                                                                                                            "right": 290,
+                                                                                                            "bottom": 843
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "Very high (200+)",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 264,
+                                                                                                            "top": 766,
+                                                                                                            "right": 573,
+                                                                                                            "bottom": 813
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "5 pts",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 1082,
+                                                                                                            "top": 768,
+                                                                                                            "right": 1164,
+                                                                                                            "bottom": 811
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 184,
+                                                                                                            "top": 802,
+                                                                                                            "right": 290,
+                                                                                                            "bottom": 908
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "High (100 - 199)",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 264,
+                                                                                                            "top": 831,
+                                                                                                            "right": 553,
+                                                                                                            "bottom": 878
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "3 - 4 pts",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 1031,
+                                                                                                            "top": 833,
+                                                                                                            "right": 1164,
+                                                                                                            "bottom": 876
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 184,
+                                                                                                            "top": 867,
+                                                                                                            "right": 290,
+                                                                                                            "bottom": 973
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "Moderate (50 - 99)",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 264,
+                                                                                                            "top": 896,
+                                                                                                            "right": 622,
+                                                                                                            "bottom": 943
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "1 - 2 pts",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 1035,
+                                                                                                            "top": 898,
+                                                                                                            "right": 1164,
+                                                                                                            "bottom": 941
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 184,
+                                                                                                            "top": 932,
+                                                                                                            "right": 290,
+                                                                                                            "bottom": 1038
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "Low (0 - 49)",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 264,
+                                                                                                            "top": 961,
+                                                                                                            "right": 486,
+                                                                                                            "bottom": 1008
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "0 pts",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 1079,
+                                                                                                            "top": 963,
+                                                                                                            "right": 1164,
+                                                                                                            "bottom": 1006
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Last 30 days",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 192,
+                                                                                            "top": 1116,
+                                                                                            "right": 475,
+                                                                                            "bottom": 1173
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 192,
+                                                                                            "top": 1209,
+                                                                                            "right": 1200,
+                                                                                            "bottom": 1520
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "3 orders 6/29",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 208,
+                                                                                                    "top": 1227,
+                                                                                                    "right": 376,
+                                                                                                    "bottom": 1280
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "7/1",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 275,
+                                                                                                    "top": 1460,
+                                                                                                    "right": 310,
+                                                                                                    "bottom": 1492
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "7/8",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 488,
+                                                                                                    "top": 1460,
+                                                                                                    "right": 529,
+                                                                                                    "bottom": 1492
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "7/15",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 701,
+                                                                                                    "top": 1460,
+                                                                                                    "right": 751,
+                                                                                                    "bottom": 1492
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "7/22",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 915,
+                                                                                                    "top": 1460,
+                                                                                                    "right": 970,
+                                                                                                    "bottom": 1492
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "7/29",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 1118,
+                                                                                                    "top": 1460,
+                                                                                                    "right": 1173,
+                                                                                                    "bottom": 1492
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 192,
+                                                                                            "top": 1556,
+                                                                                            "right": 1200,
+                                                                                            "bottom": 1749
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 228,
+                                                                                                    "top": 1592,
+                                                                                                    "right": 1164,
+                                                                                                    "bottom": 1713
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "Expires tomorrow",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 228,
+                                                                                                            "top": 1592,
+                                                                                                            "right": 974,
+                                                                                                            "bottom": 1639
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "3 orders",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 1010,
+                                                                                                            "top": 1592,
+                                                                                                            "right": 1164,
+                                                                                                            "bottom": 1639
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "New total tomorrow",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 228,
+                                                                                                            "top": 1666,
+                                                                                                            "right": 954,
+                                                                                                            "bottom": 1713
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "77 orders",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 990,
+                                                                                                            "top": 1666,
+                                                                                                            "right": 1164,
+                                                                                                            "bottom": 1713
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "About last 30-day orders",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 192,
+                                                                                            "top": 1821,
+                                                                                            "right": 751,
+                                                                                            "bottom": 1878
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 192,
+                                                                                            "top": 1914,
+                                                                                            "right": 1200,
+                                                                                            "bottom": 2180
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "This rating is based on the number of orders you complete within a 30-day period and is updated as you complete new orders. Orders grouped together in a single offer each count separately. Completed orders over 30 days old expire at the end of each day.",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 192,
+                                                                                                    "top": 1914,
+                                                                                                    "right": 1200,
+                                                                                                    "bottom": 2180
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/ratings/2026-07-29_15-19-05-861__doordash__accessibility.window__UNKNOWN__dd3695.json
+++ b/app/src/test/resources/snapshots/ratings/2026-07-29_15-19-05-861__doordash__accessibility.window__UNKNOWN__dd3695.json
@@ -1,0 +1,1056 @@
+{
+    "captureId": "bd83c5e7-ec87-481b-a540-30c6e651a933",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1785356345848,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/overlay_gesture_manager",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/root_constraint_layout",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/side_nav_content_container",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/main_fragment",
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 880
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 285
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 357,
+                                                                                                                                            "top": 156,
+                                                                                                                                            "right": 724,
+                                                                                                                                            "bottom": 285
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 469,
+                                                                                                                                            "top": 205,
+                                                                                                                                            "right": 611,
+                                                                                                                                            "bottom": 387
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 405,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 512
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Silver",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 405,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 512
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 348,
+                                                                                                                                            "top": 512,
+                                                                                                                                            "right": 677,
+                                                                                                                                            "bottom": 577
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Overall rating 73",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 348,
+                                                                                                                                                    "top": 512,
+                                                                                                                                                    "right": 677,
+                                                                                                                                                    "bottom": 577
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "desc": "info/line",
+                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 660,
+                                                                                                                                            "top": 492,
+                                                                                                                                            "right": 766,
+                                                                                                                                            "bottom": 598
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "desc": "SILVER gem",
+                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 189,
+                                                                                                                                            "top": 637,
+                                                                                                                                            "right": 234,
+                                                                                                                                            "bottom": 682
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "55",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 190,
+                                                                                                                                            "top": 711,
+                                                                                                                                            "right": 233,
+                                                                                                                                            "bottom": 754
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "desc": "GOLD gem disabled",
+                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 518,
+                                                                                                                                            "top": 637,
+                                                                                                                                            "right": 563,
+                                                                                                                                            "bottom": 682
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "75",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 520,
+                                                                                                                                            "top": 711,
+                                                                                                                                            "right": 561,
+                                                                                                                                            "bottom": 754
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "desc": "PLATINUM gem disabled",
+                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 846,
+                                                                                                                                            "top": 637,
+                                                                                                                                            "right": 891,
+                                                                                                                                            "bottom": 682
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "85",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 847,
+                                                                                                                                            "top": 711,
+                                                                                                                                            "right": 891,
+                                                                                                                                            "bottom": 754
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 782,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 889
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "View your rewards",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 367,
+                                                                                                                                                    "top": 812,
+                                                                                                                                                    "right": 712,
+                                                                                                                                                    "bottom": 859
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 791,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 880
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 952,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2240
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Your rating factors",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 952,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1009
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1045,
+                                                                                                                                            "right": 522,
+                                                                                                                                            "bottom": 1333
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Acceptance rate",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 63,
+                                                                                                                                                    "top": 1072,
+                                                                                                                                                    "right": 360,
+                                                                                                                                                    "bottom": 1119
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "23%",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 63,
+                                                                                                                                                    "top": 1123,
+                                                                                                                                                    "right": 175,
+                                                                                                                                                    "bottom": 1189
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "8 of 30 points",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 63,
+                                                                                                                                                    "top": 1193,
+                                                                                                                                                    "right": 495,
+                                                                                                                                                    "bottom": 1236
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 19,
+                                                                                                                                                    "top": 1232,
+                                                                                                                                                    "right": 125,
+                                                                                                                                                    "bottom": 1338
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Low",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 94,
+                                                                                                                                                    "top": 1263,
+                                                                                                                                                    "right": 165,
+                                                                                                                                                    "bottom": 1306
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Rating band icon",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 459,
+                                                                                                                                                    "top": 1267,
+                                                                                                                                                    "right": 495,
+                                                                                                                                                    "bottom": 1303
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1369,
+                                                                                                                                            "right": 522,
+                                                                                                                                            "bottom": 1657
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "On-time rate",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 63,
+                                                                                                                                                    "top": 1396,
+                                                                                                                                                    "right": 299,
+                                                                                                                                                    "bottom": 1443
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "100%",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 63,
+                                                                                                                                                    "top": 1447,
+                                                                                                                                                    "right": 212,
+                                                                                                                                                    "bottom": 1513
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "30 of 30 points",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 63,
+                                                                                                                                                    "top": 1517,
+                                                                                                                                                    "right": 495,
+                                                                                                                                                    "bottom": 1560
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 19,
+                                                                                                                                                    "top": 1556,
+                                                                                                                                                    "right": 125,
+                                                                                                                                                    "bottom": 1662
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Very high",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 94,
+                                                                                                                                                    "top": 1587,
+                                                                                                                                                    "right": 255,
+                                                                                                                                                    "bottom": 1630
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Rating band icon",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 459,
+                                                                                                                                                    "top": 1591,
+                                                                                                                                                    "right": 495,
+                                                                                                                                                    "bottom": 1627
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1693,
+                                                                                                                                            "right": 522,
+                                                                                                                                            "bottom": 1981
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Customer rating",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 63,
+                                                                                                                                                    "top": 1720,
+                                                                                                                                                    "right": 358,
+                                                                                                                                                    "bottom": 1767
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "5",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 63,
+                                                                                                                                                    "top": 1771,
+                                                                                                                                                    "right": 98,
+                                                                                                                                                    "bottom": 1837
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Rating value icon",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 116,
+                                                                                                                                                    "top": 1786,
+                                                                                                                                                    "right": 152,
+                                                                                                                                                    "bottom": 1822
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "10 of 10 points",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 63,
+                                                                                                                                                    "top": 1841,
+                                                                                                                                                    "right": 495,
+                                                                                                                                                    "bottom": 1884
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 19,
+                                                                                                                                                    "top": 1880,
+                                                                                                                                                    "right": 125,
+                                                                                                                                                    "bottom": 1986
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Very high",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 94,
+                                                                                                                                                    "top": 1911,
+                                                                                                                                                    "right": 255,
+                                                                                                                                                    "bottom": 1954
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Rating band icon",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 459,
+                                                                                                                                                    "top": 1915,
+                                                                                                                                                    "right": 495,
+                                                                                                                                                    "bottom": 1951
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 558,
+                                                                                                                                            "top": 1045,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1333
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Completion rate",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 585,
+                                                                                                                                                    "top": 1072,
+                                                                                                                                                    "right": 881,
+                                                                                                                                                    "bottom": 1119
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "99%",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 585,
+                                                                                                                                                    "top": 1123,
+                                                                                                                                                    "right": 701,
+                                                                                                                                                    "bottom": 1189
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "13 of 15 points",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 585,
+                                                                                                                                                    "top": 1193,
+                                                                                                                                                    "right": 1017,
+                                                                                                                                                    "bottom": 1236
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 541,
+                                                                                                                                                    "top": 1232,
+                                                                                                                                                    "right": 647,
+                                                                                                                                                    "bottom": 1338
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Very high",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 616,
+                                                                                                                                                    "top": 1263,
+                                                                                                                                                    "right": 777,
+                                                                                                                                                    "bottom": 1306
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Rating band icon",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 981,
+                                                                                                                                                    "top": 1267,
+                                                                                                                                                    "right": 1017,
+                                                                                                                                                    "bottom": 1303
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 558,
+                                                                                                                                            "top": 1369,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1657
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Quality rate",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 585,
+                                                                                                                                                    "top": 1396,
+                                                                                                                                                    "right": 800,
+                                                                                                                                                    "bottom": 1443
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "100%",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 585,
+                                                                                                                                                    "top": 1447,
+                                                                                                                                                    "right": 734,
+                                                                                                                                                    "bottom": 1513
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "10 of 10 points",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 585,
+                                                                                                                                                    "top": 1517,
+                                                                                                                                                    "right": 1017,
+                                                                                                                                                    "bottom": 1560
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 541,
+                                                                                                                                                    "top": 1556,
+                                                                                                                                                    "right": 647,
+                                                                                                                                                    "bottom": 1662
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Very high",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 616,
+                                                                                                                                                    "top": 1587,
+                                                                                                                                                    "right": 777,
+                                                                                                                                                    "bottom": 1630
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Rating band icon",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 981,
+                                                                                                                                                    "top": 1591,
+                                                                                                                                                    "right": 1017,
+                                                                                                                                                    "bottom": 1627
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 558,
+                                                                                                                                            "top": 1693,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1981
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Last 30-day orders",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 585,
+                                                                                                                                                    "top": 1720,
+                                                                                                                                                    "right": 927,
+                                                                                                                                                    "bottom": 1767
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "80",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 585,
+                                                                                                                                                    "top": 1771,
+                                                                                                                                                    "right": 659,
+                                                                                                                                                    "bottom": 1837
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "2 of 5 points",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 585,
+                                                                                                                                                    "top": 1841,
+                                                                                                                                                    "right": 1017,
+                                                                                                                                                    "bottom": 1884
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 541,
+                                                                                                                                                    "top": 1880,
+                                                                                                                                                    "right": 647,
+                                                                                                                                                    "bottom": 1986
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Moderate",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 616,
+                                                                                                                                                    "top": 1911,
+                                                                                                                                                    "right": 779,
+                                                                                                                                                    "bottom": 1954
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Rating band icon",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 981,
+                                                                                                                                                    "top": 1915,
+                                                                                                                                                    "right": 1017,
+                                                                                                                                                    "bottom": 1951
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 286,
+                                                                                                                    "top": 2202,
+                                                                                                                    "right": 794,
+                                                                                                                    "bottom": 2309
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 286,
+                                                                                                                            "top": 2202,
+                                                                                                                            "right": 540,
+                                                                                                                            "bottom": 2309
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Overall",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 345,
+                                                                                                                                    "top": 2232,
+                                                                                                                                    "right": 482,
+                                                                                                                                    "bottom": 2279
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 540,
+                                                                                                                            "top": 2202,
+                                                                                                                            "right": 794,
+                                                                                                                            "bottom": 2309
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Shopping",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 576,
+                                                                                                                                    "top": 2232,
+                                                                                                                                    "right": 758,
+                                                                                                                                    "bottom": 2279
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "side_menu_button",
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 136,
+                                                                                                            "right": 161,
+                                                                                                            "bottom": 261
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/side_nav_container",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 120,
+                                                                    "right": 641,
+                                                                    "bottom": 2280
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/side_nav_header_background",
+                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 356
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 356
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 356
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 356
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 712,
+                                                                                                    "bottom": 154
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -2155,6 +2155,25 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
     the pre-existing net-side overlap) that piece 2 (categorizing an orphan into its real
     session) is the actual fix for — no action needed beyond noting it if seen.
   - Confirmed: 0/2.
+- **Ratings-hub family no longer falls to UNKNOWN (2026-07-30 corpus pass).** Three recognition
+  gaps in DoorDash 0.230.0's redesigned Ratings area were closed against the 07-29 pull. All three
+  are **desk-verifiable from the next pull alone** — no dev-eyes needed on the road. Open the
+  in-app Ratings area during a dash (or any time the app is running with capture on), tap into a
+  couple of the rating factors, and then check the pull:
+  1. **The hub itself** (`Overall rating <N>` + the Silver/Gold/Platinum gem ladder + "Your rating
+     factors") must land in `captures/doordash/accessibility.window/ratings/` **with the side-nav
+     drawer CLOSED**. Before this change it only classified when the drawer happened to be open —
+     the rule was matching the drawer's "Ratings" menu row, not the screen.
+  2. **The "Last 30-day orders" drill-down** (the count factor, the one with no "Last 100 …" list)
+     must land in `performance_rate_detail/`, not `UNKNOWN/`.
+  3. **The Customer-rating drill-down with the band table EXPANDED** (tap the "Points toward your
+     overall rating" row to expand) must stay in `customer_rating_detail/` — the hero-score
+     container leaves the tree in that render and used to drop the frame to UNKNOWN.
+  Anything still landing in `UNKNOWN/` from that area is the item failing — grab the capture id.
+  Known, deliberate residual (NOT a bug to report): the hub's parsed rate fields all read `null` on
+  the redesign, because the parse is still anchored on the old `textView_title` layout. That was
+  already true before this change; re-anchoring the parse is separate, data-enrichment work.
+  - Confirmed: 0/2.
 
 ---
 

--- a/matchers/rules/doordash/ratings-feedback.json5
+++ b/matchers/rules/doordash/ratings-feedback.json5
@@ -28,14 +28,26 @@
       }
     },
     {
+      "comment": "2026-07-30 corpus pass — the 0.230.0 REDESIGNED hub ('Overall rating <N>' + the Silver/Gold/Platinum gem ladder + a 'Your rating factors' points list) never renders the literal word 'ratings' anywhere on the screen. The original conjunct only matched it by ACCIDENT, off the side-nav drawer's 'Ratings' menu row: the two fielded drawer-open frames (07-29 15:15:49 / 15:17:01) classified `ratings`, while the two drawer-closed frames of the SAME screen (…UNKNOWN__3544f5 / …UNKNOWN__dd3695) fell to UNKNOWN. Recognition must not depend on an unrelated overlay being open, so a second arm anchors on the redesign's own copy. 'Your rating factors' is corpus-unique (0 other snapshots) and the arm still demands both rate labels, so it cannot claim the single-metric drill-downs (performance_rate_detail / customer_rating_detail render ONE metric and no 'Your rating factors' header). DOCUMENTED RESIDUAL: the parse below is anchored on `textView_title` siblings, which the redesign does not render — every field reads null on this variant (it already did on the drawer-open frames, so this is a pre-existing parse gap the broadening makes VISIBLE, not one it introduces). The shape has no required fields, no effects and no state.flow, so a null parse is inert; re-anchoring the parse onto the points-list rows is a separate, data-enrichment-labelled change. PRIVACY: no customer PII — the dasher's own aggregate rating counters and fixed program copy.",
       "id": "doordash.screen.ratings",
       "priority": 90,
       "require": {
-        "allTextContainsAll": [
-          "ratings",
-          "acceptance rate",
-          "completion rate",
-          "overall"
+        "any": [
+          {
+            "allTextContainsAll": [
+              "ratings",
+              "acceptance rate",
+              "completion rate",
+              "overall"
+            ]
+          },
+          {
+            "allTextContainsAll": [
+              "your rating factors",
+              "acceptance rate",
+              "completion rate"
+            ]
+          }
         ]
       },
       "parse": {
@@ -233,7 +245,7 @@
       }
     },
     {
-      "comment": "#796/#865 — a performance-metric DETAIL screen (Completion rate / On-time rate / Quality rate / Acceptance rate): a metric header + score, a 'Last 100 <unit>' breakdown, a 'View all <unit>' button, and an 'About <metric> rate' explainer. RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse — the app already ships doordash.screen.ratings (the combined ratings hub); these are the single-metric drill-downs, which that rule's four-way 'ratings'+'acceptance rate'+'completion rate'+'overall' conjunct legitimately does NOT match. #865 BROADENED the anchor to the two UNIT variants of the SAME screen family: the order-denominated metrics render 'Last 100 orders' + 'View all orders', the offer-denominated Acceptance rate renders 'Last 100 offers' + 'View all offers' (the only textual difference — the layout, the 'About …' explainer and the tips section are identical), so it stays ONE intent rather than a near-duplicate sibling rule. All four anchor strings are corpus-unique (0 other snapshots); each variant requires its OWN header+button PAIR, so the sibling list modal (which shares the header but has NO 'View all …' button) still never collides. PRIVACY: no customer PII — the dasher's own aggregate counters + fixed program copy.",
+      "comment": "#796/#865 — a performance-metric DETAIL screen (Completion rate / On-time rate / Quality rate / Acceptance rate): a metric header + score, a 'Last 100 <unit>' breakdown, a 'View all <unit>' button, and an 'About <metric> rate' explainer. RECOGNIZE-ONLY (dev decision 2026-07-17, batch #796): no state.flow, no parse — the app already ships doordash.screen.ratings (the combined ratings hub); these are the single-metric drill-downs, which that rule's four-way 'ratings'+'acceptance rate'+'completion rate'+'overall' conjunct legitimately does NOT match. #865 BROADENED the anchor to the two UNIT variants of the SAME screen family: the order-denominated metrics render 'Last 100 orders' + 'View all orders', the offer-denominated Acceptance rate renders 'Last 100 offers' + 'View all offers' (the only textual difference — the layout, the 'About …' explainer and the tips section are identical), so it stays ONE intent rather than a near-duplicate sibling rule. All four anchor strings are corpus-unique (0 other snapshots); each variant requires its OWN header+button PAIR, so the sibling list modal (which shares the header but has NO 'View all …' button) still never collides. PRIVACY: no customer PII — the dasher's own aggregate counters + fixed program copy. 2026-07-30 corpus pass added a THIRD arm for the COUNT metric's drill-down ('Last 30-day orders'), the one rating factor in the 0.230.0 redesign that is a running total rather than a rate. Same family and same layout as the two rate arms (metric header + score + band, 'Points toward your overall rating', the collapsible band table, an 'About <metric>' explainer), but it has NO 'Last 100 …' sample window and therefore no 'View all …' button, so neither existing arm could reach it — 5 fielded frames fell to UNKNOWN on 07-29 (…UNKNOWN__b062f1 / __1aa7db / __c5f37f / __8dfab5 / __b1ac01). Anchored on the header + explainer PAIR: 'About last 30-day orders' is corpus-unique (0 other snapshots) and appears ONLY on the drill-down, so the redesigned ratings HUB — which also renders a 'Last 30-day orders' factor row but no explainer — is never claimed (and the hub is claimed first anyway at priority 90).",
       "id": "doordash.screen.performance_rate_detail",
       "priority": 116,
       "require": {
@@ -262,6 +274,20 @@
               {
                 "exists": {
                   "hasTextContaining": "View all offers"
+                }
+              }
+            ]
+          },
+          {
+            "all": [
+              {
+                "exists": {
+                  "hasTextContaining": "Last 30-day orders"
+                }
+              },
+              {
+                "exists": {
+                  "hasTextContaining": "About last 30-day orders"
                 }
               }
             ]
@@ -299,19 +325,26 @@
       }
     },
     {
-      "comment": "#865 — the Customer rating DETAIL drill-down from the ratings hub: the hero star score + the 5→1 star histogram, an 'N ratings excluded' unfair-ratings row, a 'Customer Feedback' category grid (Communication / Order Handling / Followed Delivery Instructions / Friendliness), a 'Customer Compliments' block ('Above and Beyond' count + 'Quotes from customers'), and a 'Learn more' section. RECOGNIZE-ONLY: no state.flow, no parse — same posture as the sibling performance_rate_detail / dasher_rewards drill-downs (the aggregate customerRating is already parsed off doordash.screen.ratings, the combined hub, which this screen is reached FROM and which its four-way 'ratings'+'acceptance rate'+'completion rate'+'overall' conjunct does not match). Anchored on the structural viewId pair `star_rating_container` + `progress_bar_five` — the hero score container and the 5-star histogram row. Both are corpus-unique (0 other snapshots, incl. all 15 ratings/ hub frames) and both are unconditional CHROME of this screen, present even on the still-loading frame whose score/count TextViews are still empty (capture …UNKNOWN__ce3033) — deliberately used INSTEAD of the 'Customer Compliments' / 'Above and Beyond' copy, which is data-conditional. PRIVACY: no customer PII in either fielded frame — the dasher's own aggregate rating counters, fixed category labels and fixed program copy. DOCUMENTED RESIDUAL: `quotes_recycler` is EMPTY in both fielded frames (the second renders the empty-state 'Customer quotes from 5-star reviews will appear here.'), but a dasher WITH compliments would render customer-authored free-text quotes there. DoorDash renders those quotes unattributed (no name, no address), so they are not the customer-identity PII the hash-at-edge chain covers; they are also not scoped-addressable by a `redact` predicate today (the quote TextViews carry no viewId and nodePredicate has no parent/descendant scoping), so no redact is declared. If a non-empty quotes frame is ever fielded, revisit — either a scoping predicate or a marker-backstop entry.",
+      "comment": "#865 — the Customer rating DETAIL drill-down from the ratings hub: the hero star score + the 5→1 star histogram, an 'N ratings excluded' unfair-ratings row, a 'Customer Feedback' category grid (Communication / Order Handling / Followed Delivery Instructions / Friendliness), a 'Customer Compliments' block ('Above and Beyond' count + 'Quotes from customers'), and a 'Learn more' section. RECOGNIZE-ONLY: no state.flow, no parse — same posture as the sibling performance_rate_detail / dasher_rewards drill-downs (the aggregate customerRating is already parsed off doordash.screen.ratings, the combined hub, which this screen is reached FROM and which its four-way 'ratings'+'acceptance rate'+'completion rate'+'overall' conjunct does not match). Anchored on the structural viewId pair `star_rating_container` + `progress_bar_five` — the hero score container and the 5-star histogram row. Both are corpus-unique (0 other snapshots, incl. all 15 ratings/ hub frames) and both are unconditional CHROME of this screen, present even on the still-loading frame whose score/count TextViews are still empty (capture …UNKNOWN__ce3033) — deliberately used INSTEAD of the 'Customer Compliments' / 'Above and Beyond' copy, which is data-conditional. PRIVACY: no customer PII in either fielded frame — the dasher's own aggregate rating counters, fixed category labels and fixed program copy. DOCUMENTED RESIDUAL: `quotes_recycler` is EMPTY in both fielded frames (the second renders the empty-state 'Customer quotes from 5-star reviews will appear here.'), but a dasher WITH compliments would render customer-authored free-text quotes there. DoorDash renders those quotes unattributed (no name, no address), so they are not the customer-identity PII the hash-at-edge chain covers; they are also not scoped-addressable by a `redact` predicate today (the quote TextViews carry no viewId and nodePredicate has no parent/descendant scoping), so no redact is declared. If a non-empty quotes frame is ever fielded, revisit — either a scoping predicate or a marker-backstop entry. 2026-07-30 corpus pass: the pair was SCROLL/EXPAND-fragile, the #865 `performance_orders_list` lesson one rule over. `star_rating_container` is the hero-score container, which the 0.230.0 band-table-EXPANDED render of the same screen replaces with the points header ('Customer rating' + score + 'Points toward your overall rating' + the collapsible band table) — one fielded frame (…UNKNOWN__948ec3, 07-29 15:19:01) therefore dropped out of recognition while still carrying the histogram, the unfair-ratings row, the feedback grid and the compliments block. The rule keeps a PAIR (never a single anchor) but the second conjunct is now satisfied by EITHER the hero container OR `feedback_title`: `progress_bar_five` + `feedback_title` are both present in all four known frames (the two corpus fixtures, the 07-29 loading frame …ce3033, and …948ec3), and both remain corpus-unique.",
       "id": "doordash.screen.customer_rating_detail",
       "priority": 126,
       "require": {
         "all": [
           {
             "exists": {
-              "hasIdSuffix": "star_rating_container"
+              "hasIdSuffix": "progress_bar_five"
             }
           },
           {
             "exists": {
-              "hasIdSuffix": "progress_bar_five"
+              "any": [
+                {
+                  "hasIdSuffix": "star_rating_container"
+                },
+                {
+                  "hasIdSuffix": "feedback_title"
+                }
+              ]
             }
           }
         ]


### PR DESCRIPTION
Inbox-Workflow pass over the **NEW capture slice from the 2026-07-29 dash** (`~/dashbuddy/logs/2026/07/30/captures/`, 358 files: doordash window 273 / click 66 / notification 17, uber notification 2).

**Capped-additions-only (the PR #800 pattern): 5 fixtures added, ZERO existing representatives evicted or modified, `approved-parse-output.json` diff strictly additive** (5 new entries, 0 changed entries — see below).

---

## Additions per category

| Fixture | Target folder | Why this one |
|---|---|---|
| `2026-07-29_17-55-50-627__…__dropoff_handoff__b23b66.json` | `dropoff_handoff/` (8 → 9) | First fielded handoff frame **after** the 2026-07-27 redact wave (#885/#886/#889). Address line 1, the city line, `Apt/Suite`, and the id-less instruction lines all arrive masked. |
| `2026-07-29_19-02-29-477__…__dropoff_pre_arrival__8fe217.json` | `dropoff_pre_arrival/` (23 → 24) | Richest address block in the slice: `Entry code`, `Apt/Suite`, `Building Name` **all masked**. The nearest existing fixture (`dropoff_handoff/…dc2403`, 07-17) still ships a **raw** customer gate note under its own `Entry code` label — the pair is the before/after of that wave on the same surface. |
| `2026-07-29_15-19-05-861__…__UNKNOWN__dd3695.json` | `ratings/` (15 → 16) | The 0.230.0 redesigned hub, drawer **closed** — the gap fixed below. |
| `2026-07-29_15-18-24-090__…__UNKNOWN__b062f1.json` | `performance_rate_detail/` (4 → 5) | The `Last 30-day orders` count-metric drill-down. |
| `2026-07-29_15-19-01-381__…__UNKNOWN__948ec3.json` | `customer_rating_detail/` (2 → 3) | The band-table-**expanded** render of the customer-rating drill-down. |

No click or notification corpus additions — the repo has no file-based intake for either (`clicks/` holds 5 hand-placed uber envelopes for `UberDeclineClickRuleTest`; notification coverage is synthetic fixtures in `TriageRulesTest`/`NotificationClassifierTest`). The slice's notification UNKNOWNs are triaged in "Findings" below instead.

### Deliberately NOT added

* **~250 recognized frames** in already-saturated categories (`pickup_shopping` 57, `side_nav_drawer` 27, `shopping_item` 26, `offer_popup` 15, …) — no new shape, nothing to pin.
* **2 `navigation_generic` frames** carrying `secondaryManeuverText` / `subManeuverText` masks. Dropped on purpose after checking: the whole `#886` maneuver cluster (`primaryManeuverText`, `subManeuverText`, `secondaryManeuverText`, `roadNameView`) is **already covered** by the legacy Jan-2026 `navigation_generic` / `dropoff_navigation` / `pickup_navigation` fixtures that `CaptureRedactionCorpusTest` injects into. Adding pre-masked frames to a folder already at the 15-variant retention cap would have bought redundant coverage at the cost of evicting real representatives.
* **13 empty-payload / chrome-only UNKNOWN frames** and the partially-rendered offer cards — the transient-render class.
* **The #912 batch** (Dash-Now loading, dropoff steps, 2-Orders sheet, self-unassign confirm). That issue is open and dev-planned against the *previous* census; this PR stays out of its way. Only the Dash-Now loading family recurs in this slice.

---

## Rules changed

One file: **`matchers/rules/doordash/ratings-feedback.json5`**. All three changes are **recognize-only** (no `state.flow`, no new parse, no effects, no `redact`), and every new anchor string/id is corpus-unique (0 other snapshots).

**1. `doordash.screen.ratings` — recognition depended on an unrelated overlay being open.**
DoorDash 0.230.0's redesigned hub (`Overall rating <N>` + the Silver/Gold/Platinum gem ladder + a `Your rating factors` points list) never renders the literal word "ratings" on the screen. The existing four-way conjunct matched it **only by accident**, off the side-nav drawer's "Ratings" menu row: the two drawer-open frames (07-29 15:15:49 / 15:17:01) classified `ratings`, while the two drawer-closed frames of the *same screen* (`…UNKNOWN__3544f5` / `…UNKNOWN__dd3695`) fell to UNKNOWN. Added a second `require` arm anchored on the redesign's own copy — `"your rating factors"` + both rate labels — which cannot claim the single-metric drill-downs (they render one metric and no `Your rating factors` header).

*Documented residual (in the rule comment):* the parse is anchored on `textView_title` siblings the redesign does not render, so every field reads **null** on this variant. That was **already true on the drawer-open frames** — the broadening makes a pre-existing parse gap visible, it does not introduce one. The shape has no required fields, no effects and no `state.flow`, so a null parse is inert; re-anchoring the parse onto the points-list rows is separate `data-enrichment` work.

**2. `doordash.screen.performance_rate_detail` — no arm reached the COUNT metric.**
`Last 30-day orders` is the one rating factor in the redesign that is a running total rather than a rate: same family, same layout, but **no** "Last 100 …" sample window and therefore **no** "View all …" button, so neither existing arm could match. 5 fielded frames fell to UNKNOWN (`b062f1` / `1aa7db` / `c5f37f` / `8dfab5` / `b1ac01`). Added a third arm on the header + explainer pair; `"About last 30-day orders"` appears only on the drill-down, so the hub — which also renders a `Last 30-day orders` factor row — is never claimed (and is claimed first anyway at priority 90).

**3. `doordash.screen.customer_rating_detail` — the #865 anchor pair was scroll/expand-fragile.**
`star_rating_container` is the hero-score container, which the band-table-**expanded** render of the same screen replaces with the points header. One fielded frame (`…UNKNOWN__948ec3`) therefore dropped out of recognition while still carrying the histogram, the unfair-ratings row, the feedback grid and the compliments block — the same lesson #865 learned one rule over on `performance_orders_list`. The rule still requires a **pair** (never a single anchor), but the second conjunct is now satisfied by the hero container **OR** `feedback_title`. `progress_bar_five` + `feedback_title` are present in all four known frames (both corpus fixtures, the 07-29 loading frame `…ce3033`, and `…948ec3`) and both remain corpus-unique.

---

## PII sweep

Manual sweep over **all 358 slice files** (walking `text` / `desc` / the five notification text fields / `actionLabels`), then a **second sweep over the exact committed bytes** of the 5 fixtures. Patterns: two-capitalized-words, `[A-Z][a-z]+\s{1,4}[A-Z]\.?` (the #885 `\s+` form, not a literal space), `For [A-Z][a-z]+\s+[A-Z]\.`, `Deliver to `/`Pickup for `/`Delivery for `/`Message from `, `pin \d{3,}`, gate/door/access codes, street addresses (strict **and** a loose `\d{2,6}\s+[A-Z0-9]` pass), apt/unit, `Customer Notes:`, phone, email.

**Result — one raw-PII file in the entire slice:**

* `…accessibility.window__UNKNOWN__6fa230.json` — an unrecognized pickup surface carrying `user_name_label` = `"Delivery for"` + `user_name` = a raw customer first-name + last-initial. **Set aside, not added** (and not redacted-and-added — the surface is unrecognized, so a redacted fixture would pin nothing). This is exactly the already-filed **#910** class: `"Delivery for "` is absent from `CustomerTextMarkers`, so the #806 UNKNOWN-envelope backstop does not scrub it. No new issue filed — #910 already names this string.

Everything else was clean:

* All customer names/addresses on **recognized** surfaces arrive already masked — 15 `Deliver to [redacted:xxxx]` / `Message from [redacted:xxxx]` instances, zero raw. **First field evidence that the #885/#886/#889 wave holds.**
* The only raw street address in the slice (`7330 N Loop 1604 W, San Antonio TX …`) is a **merchant** address on `pickup_navigation` — raw by design per #886.
* 51 hits on `Stephen T` — the **dasher's own** first-name + last-initial, explicitly permitted by the Pledge.
* Zero `pin \d{3,}`, zero gate/door/access codes, zero `Customer Notes:` free text, zero phone/email, zero DasherDirect/banking content.
* `SnapshotSecurityScanner` (run via `InboxProcessorTest`) flagged nothing toxic on any candidate.

Note on committed bytes: `SnapshotLibrarian.archiveSnapshot` runs `SnapshotRedactor` on the way in, which additionally strips the device's 4-hex mask suffix behind a name prefix (`Deliver to [redacted:8b3b]` → `Deliver to [redacted]`) and masks the `Building Name` label value. The `[redacted:xxxx]` tokens that remain are the device's own capture-time masks, consistent with the existing corpus.

---

## Tests

* `InboxProcessorTest` — all 5 candidates sorted to the intended folders, no toxic flags, no X-Ray unknowns left.
* `./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` — **838/838 green**.
* `./gradlew :app:testDebugUnitTest :domain:test :core:pipeline:testDebugUnitTest` — **green**.
* Golden regenerated deliberately with `-DupdateParseGolden=true`. **Diff reviewed: 58 lines, all insertions, 5 new entries, 0 modified entries** — i.e. no existing snapshot changed classification or parse output under the three rule broadenings.

### Eviction guard
`SnapshotLibrarian.pruneFolder` caps a folder at 15 distinct content variants, and legacy `20260128_*` filenames sort **above** the `2026-MM-DD__` convention, so a naive run evicts the newer representatives. The first `InboxProcessorTest` run deleted 8 `dropoff_pre_arrival` + 1 `ratings` fixture; **all 9 were restored with `git checkout`** before anything was staged. `git status` on the final tree shows only additions and the three intended modifications. (Worth its own cleanup issue — the sort order means every future corpus pass hits this.)

---

## Findings for triage (no code in this PR)

1. **`doordash.screen.timeline` misses the dash-control sheet when the dash has no scheduled end time.** `…UNKNOWN__d6a6ac` (07-29 18:02:46) renders `Current dash` / `Pause orders` / `Earnings` / `This dash` / **`$50.82`** / `End dash` / `Go to home screen`, but has neither `"dash ends at"` (no end time set) nor `"current task"`, so **both** `require` arms miss. This is the money-bearing surface the bubble's `runningEarnings` rides — a live session total went unread. Not fixed here on purpose: `timeline` carries `modeHint: online` and a real parse, so broadening it is a state-machine-visible change that wants its own issue + dev call, not a corpus PR.
2. **`Apt <n>` masks are brute-forceable on DoorDash too.** `Apt [redacted:e7fa]` on `dropoff_handoff`/`dropoff_pre_arrival` is the same class as the open **#895** (uber `active_trip`) — 4 hex over a small unit-number space. #895 is scoped uber-only; the DoorDash sites may want the same `plainMask` treatment.
3. **Possible pre-existing corpus residual:** `dropoff_handoff/2026-07-17_20-43-11-663__…__dc2403.json` (already committed) carries a customer-authored gate instruction in the clear under its `Entry code` label. Id-less, so `SnapshotRedactor`'s id pass misses it and no shape pattern catches it. #806/#910 class — flagging, not touching, since evicting/rewriting an existing representative is out of scope here.
4. **Notification UNKNOWNs (6, all marketing/service).** DoorDash `dasher-notification-channel-dash-update`: two "N min avg. wait time near you" pushes and one "Busy in TX: …" push; one silent `NAVIGATION_NOTIFICATION_CHANNEL` service notification with no text at all. Uber `normal_priority`: "Earn extra with Quest" and "New Boost+ starts soon!". All are promo/noise-class with no customer PII (they address the dasher by his own first name). Cheap `noise` rules would clear them from the UNKNOWN census; no corpus mechanism exists to pin them today, so they're left for a rules pass.
5. **Click UNKNOWNs (37)** are all in-app buttons on already-recognized `screenTarget`s — `Scan again`, `Got it`, `Don't send`, `Mark as delivered`, `End dash`, `Open digital Red Card`, shopping `Increment`/`Add to cart`, and Google-Nav `maneuverView` taps. Nothing PII-bearing; nothing that needs a click rule for state.

---

### Design-goal review

**1 — UDF.** Untouched. Recognition stays data; no reducer, no effect, no wall-clock read.

**3 — Single responsibility.** The rule diff is confined to one surface file (`ratings-feedback.json5`) and to the three rules that own those screens. No rule grew a second job — all three stay recognize-only.

**5 — SSOT.** Each new anchor is added to the **one** rule that owns its screen; no duplicated predicate, no second copy of an anchor string. The three rules keep their existing separation of concerns (hub at priority 90, drill-downs at 116/126) rather than collapsing into a shared "metric detail" arm that would have re-routed the existing `customer_rating_detail` corpus.

**6 — Security & privacy.** The primary posture of this PR.
* *Trusted/untrusted:* unchanged — corpus fixtures are inert test data; no new ingestion path, no regex added to a runtime-compiled rule.
* *Block side not downgraded:* no `sensitive.*` rule touched; the three broadened rules sit at priorities 90/116/126, all far above the `sensitive.known` priority-0 + `overrideable: false` partition, so nothing added here can pre-empt a sensitive classification. `SensitiveMarkerAssetCoverageTest` and the `SENSITIVE/` golden guard both stay green.
* *Hash side not loosened:* no new `parse` field, no new `sha256` transform, no `redact` block added or removed. The screens recognized are the dasher's own aggregate rating data.
* *Fixtures:* manual sweep on all 358 slice files + on the committed bytes; the one raw-PII file excluded; `SnapshotSecurityScanner` clean. New masked-address fixtures **increase** `CaptureRedactionCorpusTest`'s coverage of the #885/#886/#889 shapes.

**7 — Semantic logging.** No log sites added or moved.

**8 — Platform-agnostic core.** Mandatory here (the diff touches rule JSON). The change is entirely **inside a per-platform ruleset file** — the mechanism the principle prescribes. Zero edits to `:core:state` / `:core:pipeline` / `:domain`; no new platform literal in logic; no new rule↔state vocabulary (no `state.flow`, no new parse shape, no effect intent), so nothing needed to go through `StateMachineContract`. The anchors are DoorDash *copy* consumed by a DoorDash *ruleset* — which is precisely where platform-specific strings belong.

*Reactive UI rules:* not touched (no UI in the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
