### PR TITLE
privacy(rules): #895 — plainMask the fused 'Apt <n>' unit entries (uber #825 family + doordash #889/#892 family)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -958,7 +958,11 @@ class CaptureRedactionCorpusTest {
         assertTrue("on_job_view anchor kept", masked.contains("on_job_view"))
         assertTrue("benign order line kept", masked.contains("Dropoff • 1 order"))
         assertTrue("benign ETA kept", masked.contains("Expected by 7:17 PM"))
-        assertTrue("apt marker kept", masked.contains("Apt [redacted:"))
+        // #895: the fused unit number is a bounded ~10^4 alphabet over the length floor —
+        // the rule declares plainMask, so the marker keeps NO 4-hex suffix (a revert to the
+        // brute-recoverable hash form goes red here).
+        assertTrue("apt marker kept, plain-masked", masked.contains("Apt [redacted]"))
+        assertFalse("apt mask must not carry a distinctness hex", masked.contains("Apt [redacted:"))
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -965,6 +965,38 @@ class CaptureRedactionCorpusTest {
         assertFalse("apt mask must not carry a distinctness hex", masked.contains("Apt [redacted:"))
     }
 
+    /**
+     * #895 — every fused-`Apt ` keepPrefix entry across BOTH platforms' surface
+     * families must declare `plainMask`: the post-strip unit token is a bounded
+     * ~10^4 alphabet over the #889 length floor, so a 4-hex suffix would be
+     * brute-recoverable. The 8 entries are byte-identical SSOT siblings today;
+     * this ratchet keeps a future edit from silently splitting one back to the
+     * hash form (only `active_trip`'s entry has direct mask-output teeth above).
+     */
+    @Test
+    fun `every Apt keepPrefix redact entry declares plainMask on both platforms (#895)`() {
+        val ruleIds = listOf(
+            "uber.screen.splash",
+            "uber.screen.pickup_verification_items",
+            "uber.screen.customer_chat",
+            "uber.screen.active_trip",
+            "doordash.screen.dropoff_pin_entry",
+            "doordash.screen.dropoff_handoff",
+            "doordash.screen.dropoff_pre_arrival",
+            "doordash.screen.dropoff_pre_arrival_completion",
+        )
+        for (id in ruleIds) {
+            val rule = TestRulesetFactory.screenRuleset.ruleById(id)
+            org.junit.Assert.assertNotNull("rule $id must exist", rule)
+            val aptEntries = rule!!.redact.entries.filter { it.keepPrefix.contains("Apt ") }
+            assertFalse("$id must carry an 'Apt ' keepPrefix entry", aptEntries.isEmpty())
+            assertTrue(
+                "$id: every fused-Apt entry must declare plainMask (#895 — bounded alphabet over the length floor)",
+                aptEntries.all { it.plainMask },
+            )
+        }
+    }
+
     @Test
     fun `uber active_trip bare-name redact carries the normalize customerName distinctness hex (#825)`() {
         val rule = TestRulesetFactory.screenRuleset.ruleById("uber.screen.active_trip")!!

--- a/matchers/rules/doordash/dropoff.json5
+++ b/matchers/rules/doordash/dropoff.json5
@@ -326,12 +326,14 @@
           "plainMask": true
         },
         {
+          "comment": "#895 (+ the 07-29 F4 field finding): plainMask. The fused 'Apt <n>' unit number is a bounded ~10^4 alphabet over the 4-char length floor, so a 4-hex distinctness suffix is brute-recoverable (the #892/#795 oracle argument); distinctness is redundant here — the same surface's name/street entries keep per-customer hashes. The split label/value form already plains via the id-less digit-shape entry.",
           "find": {
             "hasTextStartsWith": "Apt "
           },
           "keepPrefix": [
             "Apt "
-          ]
+          ],
+          "plainMask": true
         },
         {
           "find": {
@@ -529,12 +531,14 @@
           "plainMask": true
         },
         {
+          "comment": "#895 (+ the 07-29 F4 field finding): plainMask. The fused 'Apt <n>' unit number is a bounded ~10^4 alphabet over the 4-char length floor, so a 4-hex distinctness suffix is brute-recoverable (the #892/#795 oracle argument); distinctness is redundant here — the same surface's name/street entries keep per-customer hashes. The split label/value form already plains via the id-less digit-shape entry.",
           "find": {
             "hasTextStartsWith": "Apt "
           },
           "keepPrefix": [
             "Apt "
-          ]
+          ],
+          "plainMask": true
         },
         {
           "find": {
@@ -757,12 +761,14 @@
           "plainMask": true
         },
         {
+          "comment": "#895 (+ the 07-29 F4 field finding): plainMask. The fused 'Apt <n>' unit number is a bounded ~10^4 alphabet over the 4-char length floor, so a 4-hex distinctness suffix is brute-recoverable (the #892/#795 oracle argument); distinctness is redundant here — the same surface's name/street entries keep per-customer hashes. The split label/value form already plains via the id-less digit-shape entry.",
           "find": {
             "hasTextStartsWith": "Apt "
           },
           "keepPrefix": [
             "Apt "
-          ]
+          ],
+          "plainMask": true
         },
         {
           "find": {
@@ -1062,12 +1068,14 @@
           "plainMask": true
         },
         {
+          "comment": "#895 (+ the 07-29 F4 field finding): plainMask. The fused 'Apt <n>' unit number is a bounded ~10^4 alphabet over the 4-char length floor, so a 4-hex distinctness suffix is brute-recoverable (the #892/#795 oracle argument); distinctness is redundant here — the same surface's name/street entries keep per-customer hashes. The split label/value form already plains via the id-less digit-shape entry.",
           "find": {
             "hasTextStartsWith": "Apt "
           },
           "keepPrefix": [
             "Apt "
-          ]
+          ],
+          "plainMask": true
         },
         {
           "find": {

--- a/matchers/rules/uber.json5
+++ b/matchers/rules/uber.json5
@@ -617,12 +617,14 @@
           }
         },
         {
+          "comment": "#895 (+ the 07-29 F4 field finding): plainMask. The fused 'Apt <n>' unit number is a bounded ~10^4 alphabet over the 4-char length floor, so a 4-hex distinctness suffix is brute-recoverable (the #892/#795 oracle argument); distinctness is redundant here — the same surface's name/street entries keep per-customer hashes. The split label/value form already plains via the id-less digit-shape entry.",
           "find": {
             "hasTextStartsWith": "Apt "
           },
           "keepPrefix": [
             "Apt "
-          ]
+          ],
+          "plainMask": true
         },
         {
           "find": {
@@ -780,12 +782,14 @@
           }
         },
         {
+          "comment": "#895 (+ the 07-29 F4 field finding): plainMask. The fused 'Apt <n>' unit number is a bounded ~10^4 alphabet over the 4-char length floor, so a 4-hex distinctness suffix is brute-recoverable (the #892/#795 oracle argument); distinctness is redundant here — the same surface's name/street entries keep per-customer hashes. The split label/value form already plains via the id-less digit-shape entry.",
           "find": {
             "hasTextStartsWith": "Apt "
           },
           "keepPrefix": [
             "Apt "
-          ]
+          ],
+          "plainMask": true
         },
         {
           "find": {
@@ -906,12 +910,14 @@
           }
         },
         {
+          "comment": "#895 (+ the 07-29 F4 field finding): plainMask. The fused 'Apt <n>' unit number is a bounded ~10^4 alphabet over the 4-char length floor, so a 4-hex distinctness suffix is brute-recoverable (the #892/#795 oracle argument); distinctness is redundant here — the same surface's name/street entries keep per-customer hashes. The split label/value form already plains via the id-less digit-shape entry.",
           "find": {
             "hasTextStartsWith": "Apt "
           },
           "keepPrefix": [
             "Apt "
-          ]
+          ],
+          "plainMask": true
         },
         {
           "find": {
@@ -1169,12 +1175,14 @@
           }
         },
         {
+          "comment": "#895 (+ the 07-29 F4 field finding): plainMask. The fused 'Apt <n>' unit number is a bounded ~10^4 alphabet over the 4-char length floor, so a 4-hex distinctness suffix is brute-recoverable (the #892/#795 oracle argument); distinctness is redundant here — the same surface's name/street entries keep per-customer hashes. The split label/value form already plains via the id-less digit-shape entry.",
           "find": {
             "hasTextStartsWith": "Apt "
           },
           "keepPrefix": [
             "Apt "
-          ]
+          ],
+          "plainMask": true
         },
         {
           "find": {


### PR DESCRIPTION
## What

Adds `plainMask: true` to the eight byte-identical `"Apt "` `keepPrefix` redact entries:

- **uber.json5** (the #825 trip-surface family): `active_trip`, `splash`, `pickup_verification_items`, `customer_chat` — the entry #895 names, extended to its three byte-identical siblings in the same family.
- **doordash/dropoff.json5** (the #889/#892 family): `dropoff_pin_entry`, `dropoff_handoff`, `dropoff_pre_arrival`, `dropoff_pre_arrival_completion` — scope extension justified by the 07-30 desk analysis of the 07-29 dash (finding F4): the fused `Apt <n>` form was field-sighted keeping a 4-hex suffix (`Apt [redacted:e7fa]` on `dropoff_handoff`/`dropoff_pre_arrival`) while the split label/value form on the same surfaces correctly degraded to plain.

## Why

The fused token after `keepPrefix` strip is a 1–4 char unit number — a bounded ~10⁴ alphabet that sits ABOVE the #889 length floor (which bounds LENGTH, not ALPHABET), so its `[redacted:<4hex>]` suffix is brute-recoverable (~85% injective over the 65 536 buckets). Same oracle argument as #892 (DoorDash digit shapes) and #795 (PIN keypad). Distinctness is redundant on these surfaces: the sibling name/street entries keep per-customer hashes.

## Tests

- The #825 pin in `CaptureRedactionCorpusTest` now asserts the plain mask AND that no hex suffix survives — a revert to the hash form goes red (mutation teeth).
- `ShortTokenMaskFloorTest` unchanged — it documents the floor's own semantics (a 4-char token WITHOUT plainMask keeps hex), which is exactly why the declaration is needed.
- `AllMatchersSuite` + full `:core:pipeline:testDebugUnitTest` green (`--rerun-tasks`). Capture-only change; no parse; goldens byte-identical (no regen).

## Security/privacy posture

Strictly tightening: eight masks lose a recoverable 16-bit fingerprint and gain nothing raw. Fail-closed paths untouched.

### Design-goal review

- **#5 SSOT:** the eight entries remain byte-identical to each other (one shared comment text), so the family moves together — same doctrine as the #885 name-shape SSOT note.
- **#6 Security & privacy:** the change is the Pledge control itself; posture stated above.
- **#8 Platform-agnostic:** pure ruleset data; no Kotlin, no platform literals. The same class got the same fix on both platforms' data.

Closes #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)