### PR TITLE
ci: #902 — workflow_dispatch escape hatch + [force ci] skip-token override

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -3,17 +3,37 @@ name: PR Check
 on:
   pull_request:
     branches: [ master ]
+  # #902 — escape hatch for a dispatch-refused PR (Actions refused to create runs for one
+  # PR's tree across 4 shas/3 PRs on 2026-07-27; branch protection made it unmergeable).
+  # Dispatch with the PR number: the job checks out that PR's MERGE ref (the same tree a
+  # pull_request run would test) and reports a `build-and-test` commit status back onto the
+  # PR's head SHA, so the required check turns green through the normal path instead of an
+  # admin override.
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to run against (checks out refs/pull/<pr>/merge, reports status to its head SHA)'
+        required: true
+        type: string
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.body, '[skip ci]') }}
+    # Docs-only PRs skip via the literal token `[skip ci]` in the PR BODY (see CLAUDE.md).
+    # #902 footgun guard: a PR whose body merely DESCRIBES the token (PR #928 documented the
+    # mechanism and silently skipped its own CI) can force the run back on with `[force ci]`.
+    # A workflow_dispatch run has no PR body — contains(null, …) is false — so it always runs.
+    if: ${{ !contains(github.event.pull_request.body, '[skip ci]') || contains(github.event.pull_request.body, '[force ci]') }}
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Empty ref (pull_request events) keeps the default merge-commit checkout; a
+          # workflow_dispatch run substitutes the named PR's merge ref (#902).
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/merge', inputs.pr) || '' }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -61,6 +81,22 @@ jobs:
       - name: Upload debug APK
         uses: actions/upload-artifact@v4
         with:
-          name: debug-apk-${{ github.event.pull_request.number }}
+          name: debug-apk-${{ github.event.pull_request.number || inputs.pr }}
           path: app/build/outputs/apk/debug/app-debug.apk
           retention-days: 7
+
+      - name: Report status to PR head (dispatch runs only)
+        # #902 — a workflow_dispatch run is not attached to the PR, so its result would never
+        # satisfy the required `build-and-test` check. Post a commit status with that exact
+        # context onto the PR's HEAD sha (branch protection accepts a commit status of the
+        # same name). `always()` so a red dispatch run reports failure, not silence.
+        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          HEAD_SHA=$(gh pr view "${{ inputs.pr }}" --repo "${{ github.repository }}" --json headRefOid -q .headRefOid)
+          gh api "repos/${{ github.repository }}/statuses/$HEAD_SHA" \
+            -f state="${{ job.status == 'success' && 'success' || 'failure' }}" \
+            -f context="build-and-test" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f description="manual dispatch run (#902 escape hatch)"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -100,3 +100,5 @@ jobs:
             -f context="build-and-test" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             -f description="manual dispatch run (#902 escape hatch)"
+
+# (tree-nudge: Actions refused to dispatch for the original tree — the exact #902 class this PR mitigates; see issue #902 forensics)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -954,11 +954,19 @@ pass is clean or its findings are triaged.
 
 **Docs-only / non-code PRs can skip CI.** The `pr-check.yml` workflow skips the
 `build-and-test` job when the **PR description (body)** contains the literal
-string **`[skip ci]`** (`if: ${{ !contains(github.event.pull_request.body, '[skip ci]') }}`).
-So for a PR that touches no compiled code (only Markdown/docs), put `[skip ci]`
-in the PR body to avoid a pointless ~6-minute build. Note the exact token is
-`[skip ci]` in the **body** — not `[no-ci]`, not a comment, not a label. Only use
-it when the diff genuinely has no code; when in doubt, let CI run.
+string **`[skip ci]`**. So for a PR that touches no compiled code (only
+Markdown/docs), put `[skip ci]` in the PR body to avoid a pointless ~6-minute
+build. Note the exact token is `[skip ci]` in the **body** — not `[no-ci]`, not a
+comment, not a label. Only use it when the diff genuinely has no code; when in
+doubt, let CI run. **Footgun (#902/#928):** the check is a bare `contains()`, so
+a code PR whose body merely *describes* the token skips its own CI — either
+paraphrase ("the skip-ci token") or add the override token **`[force ci]`** to
+the body, which forces the run back on. And if Actions ever **refuses to
+dispatch** runs for a PR's tree (the 2026-07-27 class — no run object across
+shas/branches), use the `workflow_dispatch` escape hatch: Actions → PR Check →
+Run workflow → enter the PR number; it builds that PR's merge ref and reports a
+real `build-and-test` commit status onto the PR head, satisfying branch
+protection without an admin override.
 
 **PR CI gates `:app:lintVitalRelease` (#907).** Until #907, `pr-check.yml` only ever
 built/tested the **debug** variant, so a release-only break (16 `ExtraTranslation`


### PR DESCRIPTION
## What

Two escape hatches for `pr-check.yml`, both fielded needs:

1. **`workflow_dispatch` with a `pr` input** (Ask 1 of #902). For a dispatch-refused PR (the 2026-07-27 class: Actions created no run object for one tree across 4 shas / 3 branches / 3 PRs, and branch protection made it unmergeable without an admin override): Actions → PR Check → Run workflow → PR number. The job checks out `refs/pull/<pr>/merge` (the same tree a `pull_request` run tests) and a final `always()` step posts a `build-and-test` **commit status onto the PR's head SHA** — branch protection accepts a same-context commit status, so the required check goes green (or honestly red) through the normal path. On `pull_request` events the `ref` expression collapses to empty → default checkout, byte-identical behavior.

2. **`[force ci]` override for the skip-token footgun** (fielded TODAY on #928: a code PR whose body *described* the skip-ci token silently skipped its own CI, because the check is a bare `contains()`). A body carrying the override token forces the run back on. Backwards compatible — no existing PR behavior changes unless the new token is present.

CLAUDE.md's skip-ci paragraph documents both (and drops the inlined `if:` expression, which was about to be stale — the mechanism description now lives in the workflow itself).

**Not in scope:** Ask 2 (the stuck "Claude"-app check suites) — dev-gated app-integration review, untouched.

## Verification

- YAML validated (`yaml.safe_load`).
- `contains(null, …)` is `false` for dispatch runs (no PR body) → the job always runs on dispatch.
- The dispatch status step uses `always()` so a failing run reports `failure` to the head SHA rather than silence; `github.token` scope suffices for `statuses:write` on same-repo runs.
- This PR's own CI run exercises the `pull_request` path of the edited expressions end-to-end (checkout ref fallback, skip/force condition, artifact name fallback).
- The dispatch path itself can only be proven by a live dispatch — cheap to try on this very PR after merge-to-master makes the workflow definition available (`workflow_dispatch` reads the default branch's definition).

### Design-goal review

- **#5 SSOT:** the skip/force mechanism is now described once in the workflow (comments) and once in CLAUDE.md prose (pointer-style, no inlined expression to drift).
- Other principles untouched (CI-only diff, no app code).

Closes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)