### PR TITLE
fix(privacy): #910 — customer-PII redacts for delivery_summary_collapsed + multi-pickup, click-envelope screen-redact, UNKNOWN id backstop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,11 +308,27 @@ iterate it instead of hand-listing the fields, so a field added to the model can
 scrub site; the UNKNOWN-notification `SensitiveTextMarkers` scan and the `CustomerTextMarkers`
 backstop both also scan `actionLabels` now (#666) — a push action button label is serialized into
 the envelope the same as the text fields and was previously excluded from every scrub layer.
-UNKNOWN frames and UNKNOWN clicks remain the documented
+**Two #910 additions close the SPLIT-NODE class** — DoorDash renders the customer card as separate
+nodes (a `user_name_label` reading exactly `"Delivery for"` beside a BARE `user_name`), which a
+text-PREFIX scan can never own since the marker and the PII are in different nodes. (1) A **click
+envelope inherits the SCREEN rule's `redact`**: a tapped node is serialized in isolation, so a tap on
+a recognized `pickup_post_arrival_multi` row shipped the same `customer_name` node the screen
+envelope masked correctly — `captureClick` consulted no rule at all. `Observation.Click.screenRuleId`
+(stamped beside `screenTarget` from the classifier's per-platform screen-context cache) drives the
+same `redactFor` lookup; applied to recognized AND UNKNOWN clicks, envelope-only (the dedup
+`contentHash` stays on the original node), fail-OPEN (no screen rule / no `redact` ⇒ untouched).
+(2) `CustomerTextMarkers.ID_MARKERS` — an enumerated, cross-platform-DATA list of view-id suffixes
+whose node VALUE is customer PII (`customer_name`/`user_name`/`address_line_1`/`address_line_2`),
+matched with `hasIdSuffix` semantics and scrubbed on the **UNKNOWN screen + click envelopes only**
+(a recognized frame keeps its rule's deliberate decisions — #886 leaves `pickup_navigation`'s
+MERCHANT address raw — so an id scan there would fight the ruleset). Label siblings are chrome and
+survive; scrubbing the dasher's own `user_name` greeting on an UNKNOWN frame is the accepted
+fail-toward-privacy cost. UNKNOWN frames and UNKNOWN clicks remain the documented
 debug-only exception (behind the release `NoOpCaptureBus` #346 + the `SensitiveTextMarkers`
 drop backstop + the #806 `CustomerTextMarkers` scrub on the UNKNOWN screen/notification/click
-envelopes); the prefix-less residual (a name-at-start body, an address/gate-code line with no
-customer lead-in) persists on UNKNOWN frames until the surface is recognized (#806 direction 1). `PipelineV2.events` is a HOT `shareIn` stream — one upstream pass feeds
+envelopes + the #910 id scan); the residual (a name-at-start body, an id-less address/gate-code line
+with no customer lead-in) persists on UNKNOWN frames until the surface is recognized (#806
+direction 1). `PipelineV2.events` is a HOT `shareIn` stream — one upstream pass feeds
 all collectors, so side effects (captures, dedup state) can never double-run (#361). The merged
 upstream is supervised — a crash logs + counts a restart and resubscribes with backoff instead of
 silencing all sensing (#430) — and `PipelineStats` counts every gate decision, mapping failure,

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/data/log/ScrubDiagnosticSurvivesSinkTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/data/log/ScrubDiagnosticSurvivesSinkTest.kt
@@ -83,6 +83,7 @@ class ScrubDiagnosticSurvivesSinkTest {
                     packageName = "com.doordash.driverapp",
                 ),
                 screenTarget = null,
+                screenRuleId = null,
             )
         } finally {
             Timber.uproot(recording)

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureBackstopCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureBackstopCorpusTest.kt
@@ -23,6 +23,17 @@ import java.io.File
  * which is non-recursive) so the session frames are covered too; the shared loader
  * stays non-recursive because GoldenSnapshotRegressionTest iterates the session
  * dir as an intent folder and would break if it recursed.
+ *
+ * SCOPE (#910): this pin covers the TEXT-marker scan on the RECOGNIZED path only —
+ * that is the contract, and it is unchanged. #910's sibling
+ * [CustomerTextMarkers.firstUnredactedIdMarker] is deliberately NOT run here: it is
+ * an UNKNOWN-envelope-only control, and the `user_name` id it scans legitimately
+ * carries MERCHANT text on recognized pickup frames ("Pickup from <store>", which
+ * `pickup_pre_arrival` parses as `storeName`), so running it over this recognized
+ * corpus would report false positives for values the rules keep raw BY DESIGN. Its
+ * own coverage lives in `CustomerTextMarkersTest` + `CaptureScrubTest` (UNKNOWN
+ * screen/click envelopes). Nothing here is weakened — no assertion was removed or
+ * narrowed for #910.
  */
 class CaptureBackstopCorpusTest {
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
@@ -41,16 +41,30 @@ class ClickClassifierTest {
         contentDescription = contentDescription,
     )
 
+    /**
+     * Prime (or clear) a platform's cached screen context so rules with a `screenIs`
+     * constraint can match (#438 item 2 — the classifier keys screen targets per
+     * platform wire). #910 turned the cache value into a `ScreenContext(target,
+     * ruleId)` pair — the click envelope now inherits the screen RULE's redact — so
+     * this reflects the nested value type rather than a bare String.
+     */
+    private fun primeScreenContext(wire: String, target: String?) {
+        @Suppress("UNCHECKED_CAST")
+        val contexts = ObservationClassifier::class.java
+            .getDeclaredField("lastScreenContexts").apply { isAccessible = true }
+            .get(classifier) as MutableMap<String, Any>
+        contexts.clear()
+        if (target == null) return
+        val ctor = Class.forName("cloud.trotter.dashbuddy.core.pipeline.ObservationClassifier\u0024ScreenContext")
+            .declaredConstructors.first().apply { isAccessible = true }
+        contexts[wire] = ctor.newInstance(target, null)
+    }
+
     private fun classifyClick(node: UiNode, screenTarget: String? = null): Observation.Click {
         // Prime this platform's screen context so rules with screenIs constraints can
         // match (#438 item 2 — the classifier now keys screen targets per platform wire).
         // The click carries DoorDash's package so it resolves to the "doordash" wire.
-        @Suppress("UNCHECKED_CAST")
-        val targets = ObservationClassifier::class.java
-            .getDeclaredField("lastScreenTargets").apply { isAccessible = true }
-            .get(classifier) as MutableMap<String, String>
-        targets.clear()
-        if (screenTarget != null) targets[Platform.DoorDash.wire] = screenTarget
+        primeScreenContext(Platform.DoorDash.wire, screenTarget)
         return classifier.classify(
             PipelineEvent.Click(
                 System.currentTimeMillis(), node,
@@ -175,12 +189,7 @@ class ClickClassifierTest {
         // DoorDash click whose rule requires screenIs=pickup_arrival. Before item 2
         // the single global would have leaked Uber's screen and matched; now the
         // DoorDash click has no primed target of its own and stays Unknown.
-        @Suppress("UNCHECKED_CAST")
-        val targets = ObservationClassifier::class.java
-            .getDeclaredField("lastScreenTargets").apply { isAccessible = true }
-            .get(classifier) as MutableMap<String, String>
-        targets.clear()
-        targets[Platform.Uber.wire] = "pickup_arrival"
+        primeScreenContext(Platform.Uber.wire, "pickup_arrival")
 
         val result = classifier.classify(
             PipelineEvent.Click(

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -1269,6 +1269,186 @@ class CaptureRedactionCorpusTest {
         assertTrue(Regex("""^Meet at door for \[redacted:[0-9a-f]{4}\]$""").matches(meet.title!!))
     }
 
+    /**
+     * #910 V1 — `delivery_summary_collapsed` shipped with NO redact block, and it is
+     * not only the pay-breakdown card: its require is a text-only
+     * `allTextContainsAny:['this offer','delivery complete']`, which a LIVE DROP-OFF
+     * sheet satisfies, so 4 of the 8 fielded 07-28 envelopes under this classification
+     * carried the customer block whole — name, house-number street line, city/ST/ZIP,
+     * the dasher instruction body, and the customer's per-item note. `CustomerTextMarkers`
+     * cannot own any of it: the "Delivery for" lead-in is a SEPARATE `user_name_label`
+     * sibling, so the value nodes are bare and a prefix scan is structurally blind.
+     *
+     * Node shape is ground truth from that capture (the id set only); every VALUE below
+     * is invented. Teeth: delete any entry from the rule's redact block and its
+     * assertion here goes RED.
+     */
+    @Test
+    fun `delivery_summary_collapsed masks the customer block, keeps merchant and pay (#910)`() {
+        val rule = TestRulesetFactory.screenRuleset
+            .ruleById("doordash.screen.delivery_summary_collapsed")!!
+        assertFalse("delivery_summary_collapsed must declare a redact block", rule.redact.isEmpty())
+
+        fun dd(id: String, text: String) = UiNode(
+            viewIdResourceName = "com.doordash.driverapp:id/$id",
+            className = "android.widget.TextView",
+            text = text,
+        )
+
+        val card = UiNode(
+            className = "android.view.View",
+            children = listOf(
+                // The customer block (split nodes: chrome label, then bare value).
+                dd("user_name_label", "Delivery for"),
+                dd("user_name", "Testname Q"),
+                dd("address_line_1", "1234 Testfixture Dr"),
+                dd("address_line_2", "San Antonio, TX 78299, USA"),
+                dd("address_subpremise_line", "Apt/Suite: 704"),
+                dd("dasher_instruction_content_collapsed", "Leave at my door: gate 4417"),
+                dd("dasher_instruction_content_expanded", "Leave at my door: gate 4417, call on arrival"),
+                dd("order_item_instructions", "test gate code 1234, ring the bell twice"),
+                // Over-match guards: merchant, catalog, chrome and pay are driver-owned.
+                dd("instructions_title", "Dropoff instructions"),
+                dd("order_contents_header_title", "Sample Pizza Co (41709)"),
+                dd("order_item_name", "Large Pepperoni"),
+                dd("order_item_count", "1x"),
+                dd("current_order_pay", "$8.25"),
+                dd("final_value", "$8.25"),
+                dd("textView_prism_button_title", "Complete delivery"),
+            ),
+        ).restoreParents()
+
+        val masked = serialize(rule.redact.apply(card))
+
+        assertFalse("customer name must not persist", masked.contains("Testname Q"))
+        assertFalse("street line must not persist", masked.contains("1234 Testfixture Dr"))
+        assertFalse("city/ST/ZIP must not persist", masked.contains("78299"))
+        assertFalse("apt/suite value must not persist", masked.contains("704"))
+        assertFalse("gate code in the instruction body must not persist", masked.contains("gate 4417"))
+        assertFalse("customer item note must not persist", masked.contains("ring the bell twice"))
+        assertTrue(
+            "the masked nodes carry the hash family [redacted:<4hex>]",
+            Regex("""\[redacted:[0-9a-f]{4}]""").containsMatchIn(masked),
+        )
+        // The label sibling is app vocabulary — kept, so a replayed frame keeps its shape.
+        assertTrue("the 'Delivery for' label is chrome and stays raw", masked.contains("Delivery for"))
+        assertTrue("Apt/Suite lead-in kept", masked.contains("Apt/Suite: "))
+        // Over-match guards.
+        assertTrue("merchant kept (driver-owned)", masked.contains("Sample Pizza Co (41709)"))
+        assertTrue("catalog item kept", masked.contains("Large Pepperoni"))
+        assertTrue("instruction LABEL kept", masked.contains("Dropoff instructions"))
+        assertTrue("pay kept", masked.contains("$8.25"))
+        assertTrue("CTA kept", masked.contains("Complete delivery"))
+
+        // #733 cross-surface stability: the name's hex must equal the SAME customer's hex on
+        // the "Deliver to <name>" nav title — one customer, one mask, every surface.
+        val hex = Regex("""\[redacted:([0-9a-f]{4})]""")
+        val nameHex = hex.find(rule.redact.apply(dd("user_name", "Testname Q")).text!!)!!.groupValues[1]
+        val navRule = TestRulesetFactory.screenRuleset.ruleById("doordash.screen.dropoff_navigation")!!
+        val navHex = hex.find(
+            navRule.redact.apply(
+                UiNode(
+                    viewIdResourceName = "com.dd:id/bottom_sheet_task_title",
+                    text = "Deliver to Testname Quill",
+                ),
+            ).text!!,
+        )!!.groupValues[1]
+        assertEquals("user_name masks to the customer's canonical hex", navHex, nameHex)
+    }
+
+    /**
+     * #910 V2/V3 — the multi-order pickup list renders one row per order, each with a
+     * BARE `customer_name` node (no in-node lead-in: "Order for" is a separate sibling
+     * on the single-order card, the #526 D6a shape). Both `pickup_post_arrival_multi`
+     * and `pickup_pre_arrival_multi` shipped with no redact block, so every row's
+     * customer name reached the recognized envelope raw (three of them on the fielded
+     * 07-28 frame).
+     *
+     * The post-arrival case runs over the COMMITTED corpus fixture with its two
+     * already-masked names replaced by distinct synthetic ones, so it also pins that
+     * two customers on one screen get two DIFFERENT suffixes (per-customer replay
+     * fidelity, #623). The pre-arrival twin has no committed fixture, so it asserts the
+     * same shape directly.
+     *
+     * Teeth: delete either rule's redact entry and that rule's assertion goes RED.
+     */
+    @Test
+    fun `multi-order pickup rules mask every customer_name row, keep the merchant (#910)`() {
+        val hex = Regex("""\[redacted:([0-9a-f]{4})]""")
+
+        // --- post_arrival: the committed fixture, re-seeded with synthetic names ---
+        val postRule = TestRulesetFactory.screenRuleset
+            .ruleById("doordash.screen.pickup_post_arrival_multi")!!
+        assertFalse("pickup_post_arrival_multi must declare a redact block", postRule.redact.isEmpty())
+
+        val fixture = File("src/test/resources/snapshots/pickup_post_arrival_multi")
+            .listFiles { _, n -> n.endsWith(".json") }!!
+            .sorted().first()
+        val names = ArrayDeque(listOf("Testname Q", "Othername R"))
+        fun reseed(node: UiNode): UiNode = node.copy(
+            text = if (node.viewIdResourceName?.endsWith("customer_name") == true && names.isNotEmpty()) {
+                names.removeFirst()
+            } else {
+                node.text
+            },
+            children = node.children.map { reseed(it) },
+        )
+        val seeded = reseed(TestResourceLoader.loadNode(fixture)).restoreParents()
+        assertTrue("fixture must carry the two customer_name rows", names.isEmpty())
+
+        val maskedPost = serialize(postRule.redact.apply(seeded))
+        assertFalse("first customer name must not persist", maskedPost.contains("Testname Q"))
+        assertFalse("second customer name must not persist", maskedPost.contains("Othername R"))
+        assertTrue("merchant kept (driver-owned)", maskedPost.contains("Pei Wei"))
+        assertTrue("row item count kept", maskedPost.contains("1 item"))
+
+        fun rowHex(rule: cloud.trotter.dashbuddy.core.pipeline.rules.CompiledRedact, name: String): String {
+            val masked = rule.apply(
+                UiNode(
+                    viewIdResourceName = "com.doordash.driverapp:id/customer_name",
+                    text = name,
+                ),
+            ).text!!
+            return hex.find(masked)?.groupValues?.get(1)
+                ?: error("customer_name was not masked; got '$masked'")
+        }
+        assertFalse(
+            "two customers on one screen must not collide on one mask",
+            rowHex(postRule.redact, "Testname Q") == rowHex(postRule.redact, "Othername R"),
+        )
+
+        // --- pre_arrival twin: same list, one CTA state earlier; no committed fixture ---
+        val preRule = TestRulesetFactory.screenRuleset
+            .ruleById("doordash.screen.pickup_pre_arrival_multi")!!
+        assertFalse("pickup_pre_arrival_multi must declare a redact block", preRule.redact.isEmpty())
+
+        val row = UiNode(
+            className = "android.view.View",
+            children = listOf(
+                UiNode(viewIdResourceName = "com.doordash.driverapp:id/customer_name", text = "Testname Q"),
+                UiNode(viewIdResourceName = "com.doordash.driverapp:id/merchant_name", text = "Sample Pizza Co"),
+                UiNode(viewIdResourceName = "com.doordash.driverapp:id/num_items", text = "2 items"),
+            ),
+        ).restoreParents()
+        val maskedPre = serialize(preRule.redact.apply(row))
+        assertFalse("customer name must not persist", maskedPre.contains("Testname Q"))
+        assertTrue("merchant kept (driver-owned)", maskedPre.contains("Sample Pizza Co"))
+        assertTrue("item count kept", maskedPre.contains("2 items"))
+
+        // #733: one customer, one hex — across BOTH multi surfaces and the single-order card.
+        val arrivalRule = TestRulesetFactory.screenRuleset.ruleById("doordash.screen.pickup_arrival")!!
+        assertEquals(
+            "the pre/post multi rows mask to the same customer hex",
+            rowHex(postRule.redact, "Testname Q"),
+            rowHex(preRule.redact, "Testname Q"),
+        )
+        assertEquals(
+            "and to the same hex the single-order pickup card produces",
+            rowHex(arrivalRule.redact, "Testname Q"),
+            rowHex(postRule.redact, "Testname Q"),
+        )
+    }
+
     private fun jsonUsesSha256(element: kotlinx.serialization.json.JsonElement): Boolean = when (element) {
         is kotlinx.serialization.json.JsonPrimitive -> element.isString && element.content == "sha256"
         is kotlinx.serialization.json.JsonObject -> element.values.any { jsonUsesSha256(it) }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
@@ -95,7 +95,7 @@ class CaptureWriter @Inject constructor(
         //    name/address/gate-code verbatim. SensitiveTextMarkers above (dasher-
         //    banking) correctly ignores customer content, so this scan is the ONLY
         //    customer control on the UNKNOWN screen path. Fail toward privacy:
-        //    scrubbing a benign marker-shaped string is the accepted cost.  #910 adds
+        //    scrubbing a benign marker-shaped string is the accepted cost. #910 adds
         //    the node-ID scan beside it (see scrubUnknownTree) for the split-node
         //    shape a prefix scan structurally cannot own.
         // The VET V1 already-redacted skip keeps a rule's OWN redact output from

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
@@ -11,6 +11,7 @@ import cloud.trotter.dashbuddy.domain.capture.schema.ClickCapturePayload
 import cloud.trotter.dashbuddy.domain.capture.schema.ClickContextSchema
 import cloud.trotter.dashbuddy.domain.capture.schema.RawNotificationSchema
 import cloud.trotter.dashbuddy.domain.capture.schema.UiNodeSchema
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.UNKNOWN_TARGET
@@ -94,25 +95,17 @@ class CaptureWriter @Inject constructor(
         //    name/address/gate-code verbatim. SensitiveTextMarkers above (dasher-
         //    banking) correctly ignores customer content, so this scan is the ONLY
         //    customer control on the UNKNOWN screen path. Fail toward privacy:
-        //    scrubbing a benign marker-shaped string is the accepted cost.
+        //    scrubbing a benign marker-shaped string is the accepted cost.  #910 adds
+        //    the node-ID scan beside it (see scrubUnknownTree) for the split-node
+        //    shape a prefix scan structurally cannot own.
         // The VET V1 already-redacted skip keeps a rule's OWN redact output from
         // re-tripping. FrameGate's UNKNOWN suppressor already dedups UNKNOWN frames
         // upstream, so the WARN below is at most one per admitted frame — no storm.
         val payloadTree = run {
             val marker = CustomerTextMarkers.firstUnredactedMarker(redactedTree)
             when {
+                obs.target == UNKNOWN_TARGET -> scrubUnknownTree(redactedTree, marker)
                 marker == null -> redactedTree
-                obs.target == UNKNOWN_TARGET -> {
-                    stats.onUnknownCustomerScrub()
-                    // Principle 7: log the MARKER ID only (#862) — NEVER the leaked value,
-                    // and never the marker verbatim (that self-scrubs at the sink).
-                    Timber.tag("Pipeline").w(
-                        "Capture backstop: UNKNOWN screen carried customer marker id '%s' — " +
-                            "scrubbing node from envelope",
-                        MarkerLogId.of(marker),
-                    )
-                    CustomerTextMarkers.scrub(redactedTree)
-                }
                 else -> {
                     stats.onRedactBackstopScrub()
                     // Principle 7: log the MARKER ID + rule id only (#862) — NEVER the leaked
@@ -152,10 +145,19 @@ class CaptureWriter @Inject constructor(
         return obs.copy(captureId = captureId)
     }
 
+    /**
+     * @param screenTarget the classification of the screen the tap landed on
+     *   (serialized into the envelope as click context, #438 item 2).
+     * @param screenRuleId the RULE that produced that classification, or null when
+     *   the screen was UNKNOWN / unattributable. Drives the #910 screen-redact
+     *   inheritance below; fail-OPEN by construction (a null id, a rule with no
+     *   `redact`, leaves the node untouched — exactly as before #910).
+     */
     fun captureClick(
         obs: Observation.Click,
         event: PipelineEvent.Click,
         screenTarget: String?,
+        screenRuleId: String?,
     ): Observation.Click {
         // #435 item 5: skip the envelope build for a disabled bus (see captureScreen).
         if (!captureBus.isEnabled) return obs
@@ -174,30 +176,38 @@ class CaptureWriter @Inject constructor(
                 return obs
             }
         }
+        // #910: the click envelope INHERITS the redact of the rule that recognized the
+        // screen the tap landed on. A tapped node is serialized in ISOLATION — the
+        // fielded leak was a `customer_name` row on a recognized `pickup_post_arrival_multi`
+        // list, where the screen envelope masks correctly and the click envelope shipped
+        // the same node raw, because captureClick consulted no rule at all. The screen's
+        // rule is the one authority on which of ITS nodes are PII, and the tapped node is
+        // one of them, so applying that same compiled block here is the smallest correct
+        // control (no second enumeration to drift, principle 5). Applies to recognized AND
+        // UNKNOWN clicks: a tap can be UNKNOWN while its screen is recognized (exactly the
+        // fielded shape). Fail-OPEN: no screen rule / no redact block leaves the node
+        // untouched. Sibling-anchored predicates that need a node the subtree doesn't carry
+        // simply don't match (fail toward keeping) — the full-frame screen envelope is the
+        // primary control for those; the id/text entries that name the tapped node itself
+        // are what carry here.
+        val screenRedact = screenRuleId?.let { redactionSource.redactFor(it) }
+        val redactedNode = screenRedact?.apply(event.node) ?: event.node
         // #806 customer-PII backstop for the UNKNOWN click node: a tap on a
         // "Deliver to <name>"/"Pickup for <name>" row on an unrecognized screen would
         // otherwise persist the raw customer text in the click envelope. Rule-matched
         // clicks are app-vocabulary buttons (Accept/Decline/confirm) whose labels carry
         // no PII, so — like the recognized-screen path — only UNKNOWN clicks are scanned
-        // (recognized clicks stay byte-identical). Fail toward privacy. The dedup hash
-        // below is still on the ORIGINAL node (the scrub is envelope-only).
+        // (recognized clicks stay byte-identical). #910 adds the node-ID scan beside the
+        // text scan (see scrubUnknownTree). Fail toward privacy. The dedup hash below is
+        // still on the ORIGINAL node (both the redact and the scrub are envelope-only).
         val payloadNode = if (obs.target == UNKNOWN_TARGET) {
-            val marker = CustomerTextMarkers.firstUnredactedMarker(event.node)
-            if (marker != null) {
-                stats.onUnknownCustomerScrub()
-                // Principle 7: log the MARKER ID only (#862) — NEVER the leaked value,
-                // and never the marker verbatim (that self-scrubs at the sink).
-                Timber.tag("Pipeline").w(
-                    "Capture backstop: UNKNOWN click node carried customer marker id '%s' — " +
-                        "scrubbing node from envelope",
-                    MarkerLogId.of(marker),
-                )
-                CustomerTextMarkers.scrub(event.node)
-            } else {
-                event.node
-            }
+            scrubUnknownTree(
+                redactedNode,
+                CustomerTextMarkers.firstUnredactedMarker(redactedNode),
+                kind = "click node",
+            )
         } else {
-            event.node
+            redactedNode
         }
         val platform = Platform.fromPackage(event.packageName).wire
         val capture = EnvelopeBuilder.build(
@@ -231,6 +241,44 @@ class CaptureWriter @Inject constructor(
             obs.target, obs.ruleId, captureId != null,
         )
         return obs.copy(captureId = captureId)
+    }
+
+    /**
+     * The UNKNOWN-envelope customer scrub shared by the screen and click paths.
+     *
+     * Two structurally different scans, one traversal:
+     *  - the #806 TEXT-marker scan ([textMarker], already computed by the caller so
+     *    the recognized path can reuse it), which owns a lead-in inside one node
+     *    ("Deliver to <name>"); and
+     *  - the #910 node-ID scan, which owns the SPLIT shape that scan is blind to by
+     *    construction — a `user_name_label` reading exactly "Delivery for" beside a
+     *    BARE `user_name` sibling (fielded 07-28 and again 07-29, once per job, as an
+     *    UNKNOWN window; the same `customer_name` shape reached the click path).
+     *
+     * Returns [tree] unchanged when both scans are clean, so a benign UNKNOWN frame
+     * is never rebuilt. Counts ONE scrub per envelope either way.
+     */
+    private fun scrubUnknownTree(
+        tree: UiNode,
+        textMarker: String?,
+        kind: String = "screen",
+    ): UiNode {
+        val idMarker = CustomerTextMarkers.firstUnredactedIdMarker(tree)
+        if (textMarker == null && idMarker == null) return tree
+        stats.onUnknownCustomerScrub()
+        // Principle 7: a text marker is named by its log-safe id (#862) — the marker
+        // constants are themselves scanned by the shareable-log sink, so naming one
+        // verbatim would self-scrub the WARN. A node-ID marker is NOT a marker
+        // constant: it is a view-id token ("user_name"), carries no PII and matches
+        // no sensitive marker, so it logs verbatim and stays decodable.
+        Timber.tag("Pipeline").w(
+            "Capture backstop: UNKNOWN %s carried customer PII (textMarker=%s nodeId=%s) — " +
+                "scrubbing node from envelope",
+            kind,
+            textMarker?.let { MarkerLogId.of(it) } ?: "-",
+            idMarker ?: "-",
+        )
+        return CustomerTextMarkers.scrubUnknown(tree)
     }
 
     fun captureNotification(

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
@@ -73,9 +73,13 @@ import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
  * an id scan there could fight the ruleset instead of backing it up. The text-marker
  * backstop above still covers the recognized path.
  *
- * Accepted cost: `user_name` also renders the DASHER's own name in some DoorDash
- * chrome. Scrubbing that on an UNKNOWN frame loses a little triage text and leaks
- * nothing — fail toward privacy, exactly as the text scan does.
+ * Accepted cost — the `user_name` id is REUSED for non-customer values: it renders
+ * the DASHER's own name in some DoorDash chrome, and on a pickup card it holds the
+ * MERCHANT ("Pickup from <store>", which `pickup_pre_arrival` parses as `storeName`).
+ * Scrubbing those on an UNKNOWN frame loses a little triage text and leaks nothing —
+ * fail toward privacy, exactly as the text scan does. It costs nothing on the
+ * RECOGNIZED path, which this scan deliberately does not touch, so no rule's
+ * merchant-keeps-raw decision is affected.
  */
 object CustomerTextMarkers {
 

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
@@ -52,6 +52,30 @@ import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
  * is the ONLY capture control there (and the #548 guard pins the parse to it). The
  * `CaptureBackstopCorpusTest` pins the set to ZERO false positives on the committed
  * (already-redacted) corpus.
+ *
+ * ## The node-ID half ([ID_MARKERS], #910)
+ *
+ * That split-node shape is not an exception, it is the DOMINANT rendering: the 07-28
+ * pull shipped a customer name AND a full street address on an UNKNOWN window whose
+ * lead-in node read exactly `"Delivery for"` — no trailing space, no name — while the
+ * name lived in a bare sibling. A prefix scan can never own that: the marker is in one
+ * node and the PII is in another. So the UNKNOWN paths carry a SECOND, structural scan
+ * keyed on the node's own view id ([unredactedIdMarker] / [firstUnredactedIdMarker] /
+ * [scrubUnknown]) — an enumerated list of ids whose VALUE is customer PII by
+ * construction, matched with the same `endsWith` suffix semantics the rules'
+ * `hasIdSuffix` predicate uses (the `com.<vendor>:id/` prefix varies by package).
+ * Like [MARKERS], the ids are cross-platform recognition DATA in one SSOT, not
+ * per-platform Kotlin (principle 8).
+ *
+ * Scope is deliberately UNKNOWN-only (screen + click envelopes). On a RECOGNIZED frame
+ * the rule's declared `redact` is the primary control and its decisions are deliberate
+ * — #886 keeps `pickup_navigation`'s address raw because it is a MERCHANT address — so
+ * an id scan there could fight the ruleset instead of backing it up. The text-marker
+ * backstop above still covers the recognized path.
+ *
+ * Accepted cost: `user_name` also renders the DASHER's own name in some DoorDash
+ * chrome. Scrubbing that on an UNKNOWN frame loses a little triage text and leaks
+ * nothing — fail toward privacy, exactly as the text scan does.
  */
 object CustomerTextMarkers {
 
@@ -68,6 +92,30 @@ object CustomerTextMarkers {
         // uber.json5 trip_at_dropoff redact declares.
         "Leave the order at ", // Uber trip_at_dropoff title -> dropoff ADDRESS.
         "Meet at door for ", // Uber trip_at_dropoff title -> customer name.
+    )
+
+    /**
+     * View-id SUFFIXES whose node value IS customer PII, independent of any text
+     * prefix (#910). Matched case-insensitively with `endsWith`, the same semantics
+     * as the rules' `hasIdSuffix` predicate, because the `com.<vendor>:id/` prefix
+     * varies by package.
+     *
+     * Scanned on the UNKNOWN screen/click envelope paths ONLY — see the class KDoc
+     * for why the recognized path keeps the rule's `redact` as its primary control.
+     * Every entry is a node whose ONLY content is a customer name or a customer
+     * address line, so scrubbing it can never take app vocabulary with it: the
+     * label siblings (`user_name_label`, `customer_name_label`) are deliberately
+     * absent, so a replayed UNKNOWN frame keeps its shape for triage.
+     */
+    val ID_MARKERS: List<String> = listOf(
+        // DoorDash multi-order pickup rows / pickup arrival card -> customer name.
+        "customer_name",
+        // DoorDash drop-off + pickup contact blocks -> customer name (the node the
+        // "Delivery for" label sibling names; #910 V5).
+        "user_name",
+        // DoorDash address block -> street line and city/ST/ZIP line (#910 V1/V5).
+        "address_line_1",
+        "address_line_2",
     )
 
     /** Substring that classifies a node's text as already-redacted (VET V1). */
@@ -109,6 +157,53 @@ object CustomerTextMarkers {
             },
         children = tree.children.map { scrub(it) },
     )
+
+    // --- Node-id path, UNKNOWN envelopes only (#910) --------------------------
+
+    /**
+     * The [ID_MARKERS] suffix [node]'s own view id carries while the node still
+     * holds UN-redacted text/description, or null. A node whose every value is
+     * already masked (a rule's own `[redacted:…]` output, or an empty node) returns
+     * null — same already-redacted skip as [unredactedMarker], so this never
+     * re-scrubs a mask.
+     */
+    fun unredactedIdMarker(node: UiNode): String? {
+        val id = node.viewIdResourceName
+        if (id.isNullOrEmpty()) return null
+        val marker = ID_MARKERS.firstOrNull { id.endsWith(it, ignoreCase = true) } ?: return null
+        val carriesRaw = sequenceOf(node.text, node.contentDescription)
+            .any { !it.isNullOrEmpty() && !it.contains(REDACTED_MARK) }
+        return if (carriesRaw) marker else null
+    }
+
+    /**
+     * The first [ID_MARKERS] hit anywhere in [tree], or null when clean. Cheap
+     * structural scan (no text comparison); the [scrubUnknown] copy is built only
+     * on a hit.
+     */
+    fun firstUnredactedIdMarker(tree: UiNode): String? =
+        unredactedIdMarker(tree) ?: tree.children.firstNotNullOfOrNull { firstUnredactedIdMarker(it) }
+
+    /**
+     * The UNKNOWN-envelope scrub: a copy of [tree] with every node scrubbed to
+     * [CompiledRedact.REDACTED] that carries EITHER an un-redacted text marker
+     * ([unredactedMarker]) OR a customer-PII view id ([unredactedIdMarker]). One
+     * traversal for both scans, so an UNKNOWN frame is never rebuilt twice. Call
+     * only after one of the two scans returned non-null.
+     */
+    fun scrubUnknown(tree: UiNode): UiNode {
+        val byId = unredactedIdMarker(tree) != null
+        return tree.copy(
+            text = if (byId || unredactedMarker(tree.text) != null) CompiledRedact.REDACTED else tree.text,
+            contentDescription =
+                if (byId || unredactedMarker(tree.contentDescription) != null) {
+                    CompiledRedact.REDACTED
+                } else {
+                    tree.contentDescription
+                },
+            children = tree.children.map { scrubUnknown(it) },
+        )
+    }
 
     // --- Notification path (#632) --------------------------------------------
     // Notification captures are FLAT fields, not a UiNode tree — so a hit scrubs

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
@@ -45,14 +45,22 @@ class ObservationClassifier @Inject constructor(
      * Honest keying: only a frame whose package resolves to a real platform (a
      * non-null wire) WRITES here — a null/Unknown-platform frame can't clobber a
      * real platform's entry. On the read side a click whose platform is Unknown
-     * gets NO screen context (`screenTargetFor` returns null): we won't gate a
+     * gets NO screen context (`screenContextFor` returns null): we won't gate a
      * click rule with cross-frame screen context we can't attribute to a platform.
      */
-    private val lastScreenTargets = ConcurrentHashMap<String, String>()
+    private val lastScreenContexts = ConcurrentHashMap<String, ScreenContext>()
 
-    /** THIS platform's last non-sensitive screen target, or null when unattributable. */
-    private fun screenTargetFor(platformWire: String?): String? =
-        platformWire?.let { lastScreenTargets[it] }
+    /**
+     * A platform's last non-sensitive screen classification AND the rule that produced
+     * it, cached as ONE value (principle 5): the two are written and read together, and
+     * two parallel maps could drift into a click carrying one screen's target with
+     * another screen's redact block.
+     */
+    private data class ScreenContext(val target: String, val ruleId: String?)
+
+    /** THIS platform's last non-sensitive screen context, or null when unattributable. */
+    private fun screenContextFor(platformWire: String?): ScreenContext? =
+        platformWire?.let { lastScreenContexts[it] }
 
     /** True once rulesets are published — pipelines drop frames until then (#432). */
     val isReady: Boolean get() = interpreter.isLoaded
@@ -140,7 +148,7 @@ class ObservationClassifier @Inject constructor(
         // frame's platform (#438 item 2). An Unknown/null-platform frame (null wire)
         // is skipped so it can't clobber a real platform's screen context.
         if (obs.parsed !is ParsedFields.SensitiveFields && platformWire != null) {
-            obs.target?.let { lastScreenTargets[platformWire] = it }
+            obs.target?.let { lastScreenContexts[platformWire] = ScreenContext(it, obs.ruleId) }
         }
 
         return obs
@@ -178,7 +186,8 @@ class ObservationClassifier @Inject constructor(
         now: Long,
     ): Observation.Click {
         // Gate this click against ITS OWN platform's last screen (#438 item 2).
-        val screenTarget = screenTargetFor(platformWire)
+        val screenContext = screenContextFor(platformWire)
+        val screenTarget = screenContext?.target
         val ruleset = interpreter.clickRuleset
         if (ruleset != null) {
             val result = ruleset.matchFirst(event.node, platformWire, screenTarget)
@@ -196,6 +205,7 @@ class ObservationClassifier @Inject constructor(
                     effects = DedupeTokens.resolve(result.effects, parsed),
                     transitionOverrides = result.transitionOverrides,
                     screenTarget = screenTarget,
+                    screenRuleId = screenContext?.ruleId,
                 )
             }
         }
@@ -219,6 +229,7 @@ class ObservationClassifier @Inject constructor(
             ),
             target = UNKNOWN_TARGET,
             screenTarget = screenTarget,
+            screenRuleId = screenContext?.ruleId,
         )
     }
 

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
@@ -156,8 +156,10 @@ class AccessibilityPipeline @Inject constructor(
                 obs is Observation.Screen && event is PipelineEvent.Screen ->
                     captureWriter.captureScreen(obs, event)
                 obs is Observation.Click && event is PipelineEvent.Click ->
-                    // #438 item 2: capture with the click's own per-platform screen context.
-                    captureWriter.captureClick(obs, event, obs.screenTarget)
+                    // #438 item 2: capture with the click's own per-platform screen context —
+                    // its classification (envelope context) AND the rule that produced it
+                    // (#910: the click envelope inherits that rule's `redact`).
+                    captureWriter.captureClick(obs, event, obs.screenTarget, obs.screenRuleId)
                 else -> obs
             }
         }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubDiagnosticLogTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubDiagnosticLogTest.kt
@@ -107,6 +107,7 @@ class CaptureScrubDiagnosticLogTest {
                 packageName = "com.doordash.driverapp",
             ),
             screenTarget = null,
+            screenRuleId = null,
         )
         writer.captureNotification(notifObs(), rawNotif(title = "Promo", actionLabels = listOf("Cash out")))
 
@@ -124,6 +125,7 @@ class CaptureScrubDiagnosticLogTest {
                 packageName = "com.doordash.driverapp",
             ),
             screenTarget = null,
+            screenRuleId = null,
         )
         writer.captureNotification(notifObs(), rawNotif(title = "Message from Jane"))
         writer.captureNotification(

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
@@ -105,6 +105,7 @@ class CaptureScrubTest {
             unknownClickObs(),
             PipelineEvent.Click(timestamp = 1_000L, node = toxic, packageName = "com.doordash.driverapp"),
             screenTarget = null,
+            screenRuleId = null,
         )
 
         verify(captureBus, never()).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
@@ -118,6 +119,7 @@ class CaptureScrubTest {
             unknownClickObs(),
             PipelineEvent.Click(timestamp = 1_000L, node = benign, packageName = "com.doordash.driverapp"),
             screenTarget = null,
+            screenRuleId = null,
         )
 
         verify(captureBus, times(1)).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
@@ -138,6 +140,7 @@ class CaptureScrubTest {
         unknownClickObs(),
         PipelineEvent.Click(timestamp = 1_000L, node = node, packageName = "com.doordash.driverapp"),
         screenTarget = "side_nav_drawer",
+        screenRuleId = null,
     )
 
     @Test
@@ -264,12 +267,96 @@ class CaptureScrubTest {
             unknownClickObs(),
             PipelineEvent.Click(timestamp = 1_000L, node = node, packageName = "com.doordash.driverapp"),
             screenTarget = null,
+            screenRuleId = null,
         )
         val json = offeredEnvelope()
         assertFalse("leaked customer name scrubbed", json.contains("Jane D."))
         assertTrue("node became [redacted]", json.contains("[redacted]"))
         assertEquals(1L, stats.unknownCustomerScrubCount)
         assertEquals(0L, stats.scrubbedUnknownCaptureCount)
+    }
+
+    // #910: the UNKNOWN envelopes carry a SECOND, structural scan keyed on the node's
+    // own view id — the split-node shape the text scan is blind to by construction.
+
+    /**
+     * The fielded UNKNOWN window: a "Delivery for" label + a BARE name sibling.
+     *
+     * Ground truth from two independent pulls — `…/2026/07/29/captures/doordash/
+     * accessibility.window/UNKNOWN/2026-07-28_16-40-44-160__…__6fa230.json` and, on the
+     * next dash, `…/2026/07/30/captures/…/UNKNOWN/2026-07-29_18-14-06-648__…__6fa230.json`
+     * (same window signature, once per job). Node IDS are ground truth; every VALUE below
+     * is invented.
+     */
+    private fun deliveryForCard() = UiNode(
+        children = listOf(
+            UiNode(
+                viewIdResourceName = "com.doordash.driverapp:id/user_name_label",
+                // Exactly "Delivery for" — no trailing space, no name. The
+                // "Delivery for " marker cannot match it.
+                text = "Delivery for",
+            ),
+            UiNode(viewIdResourceName = "com.doordash.driverapp:id/user_name", text = "Testname Q"),
+            UiNode(viewIdResourceName = "com.doordash.driverapp:id/address_line_1", text = "1234 Testfixture Dr"),
+            UiNode(viewIdResourceName = "com.doordash.driverapp:id/address_line_2", text = "Austin, TX 78701"),
+            UiNode(text = "Directions"),
+        ),
+    )
+
+    @Test
+    fun `UNKNOWN screen with a bare customer_name-user_name node is scrubbed by id (#910)`() {
+        writer.captureScreen(unknownObs(), screenEvent(deliveryForCard()))
+
+        val json = offeredEnvelope()
+        assertFalse("bare customer name scrubbed", json.contains("Testname Q"))
+        assertFalse("street line scrubbed", json.contains("1234 Testfixture Dr"))
+        assertFalse("city/ST/ZIP scrubbed", json.contains("78701"))
+        assertTrue("nodes became [redacted]", json.contains("[redacted]"))
+        // The label is app chrome — kept, so the frame stays triage-useful.
+        assertTrue("the 'Delivery for' label survives", json.contains("Delivery for"))
+        assertTrue("unrelated chrome survives", json.contains("Directions"))
+        assertEquals(1L, stats.unknownCustomerScrubCount)
+        assertEquals(0L, stats.scrubbedUnknownCaptureCount)
+    }
+
+    @Test
+    fun `UNKNOWN click node carrying a bare customer_name is scrubbed by id (#910)`() {
+        val node = UiNode(
+            viewIdResourceName = "com.doordash.driverapp:id/pickup_row",
+            isClickable = true,
+            children = listOf(
+                UiNode(viewIdResourceName = "com.doordash.driverapp:id/customer_name", text = "Testname Q"),
+                UiNode(viewIdResourceName = "com.doordash.driverapp:id/merchant_name", text = "Pei Wei"),
+            ),
+        )
+        writer.captureClick(
+            unknownClickObs(),
+            PipelineEvent.Click(timestamp = 1_000L, node = node, packageName = "com.doordash.driverapp"),
+            screenTarget = "pickup_post_arrival_multi",
+            // No screen redact available here (the #910 B path is tested separately) —
+            // this is the id backstop standing alone.
+            screenRuleId = null,
+        )
+
+        val json = offeredEnvelope()
+        assertFalse("bare customer name scrubbed", json.contains("Testname Q"))
+        assertTrue("merchant kept — merchants are not PII", json.contains("Pei Wei"))
+        assertEquals(1L, stats.unknownCustomerScrubCount)
+    }
+
+    @Test
+    fun `the id backstop is UNKNOWN-only - a recognized frame keeps its rule's decisions (#910)`() {
+        // On a recognized frame the rule's declared `redact` is the primary control and
+        // its decisions are deliberate (#886 keeps pickup_navigation's MERCHANT address
+        // raw). An id scan there could fight the ruleset, so scope stays UNKNOWN-only.
+        val recognized = unknownObs().copy(
+            ruleId = "doordash.screen.test",
+            target = "pickup_navigation",
+        )
+        writer.captureScreen(recognized, screenEvent(deliveryForCard()))
+
+        assertTrue("recognized frame is not id-scrubbed", offeredEnvelope().contains("Testname Q"))
+        assertEquals(0L, stats.unknownCustomerScrubCount)
     }
 
     @Test
@@ -279,6 +366,7 @@ class CaptureScrubTest {
             unknownClickObs(),
             PipelineEvent.Click(timestamp = 1_000L, node = node, packageName = "com.doordash.driverapp"),
             screenTarget = null,
+            screenRuleId = null,
         )
         assertTrue(offeredEnvelope().contains("Some new button"))
         assertEquals(0L, stats.unknownCustomerScrubCount)

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriterDisabledBusTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriterDisabledBusTest.kt
@@ -80,7 +80,7 @@ class CaptureWriterDisabledBusTest {
             packageName = "com.doordash.driverapp",
         )
 
-        val result = writer.captureClick(obs, event, screenTarget = "offer_popup")
+        val result = writer.captureClick(obs, event, screenTarget = "offer_popup", screenRuleId = null)
 
         verify(disabledBus, never()).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
         assertSame("observation must pass through untouched (captureId stays null)", obs, result)

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/ClickCaptureNoDedupTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/ClickCaptureNoDedupTest.kt
@@ -55,8 +55,8 @@ class ClickCaptureNoDedupTest {
             .thenReturn("cap-1")
 
         // The same button tapped twice — identical node content, identical screen.
-        writer.captureClick(clickObs(1_000L), clickEvent(1_000L), screenTarget = "offer_popup")
-        writer.captureClick(clickObs(2_000L), clickEvent(2_000L), screenTarget = "offer_popup")
+        writer.captureClick(clickObs(1_000L), clickEvent(1_000L), screenTarget = "offer_popup", screenRuleId = null)
+        writer.captureClick(clickObs(2_000L), clickEvent(2_000L), screenTarget = "offer_popup", screenRuleId = null)
 
         val hashCaptor = argumentCaptor<Int?>()
         verify(captureBus, times(2)).offer(

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/ClickEnvelopeScreenRedactTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/ClickEnvelopeScreenRedactTest.kt
@@ -1,0 +1,164 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.core.pipeline.rules.CompiledRedact
+import cloud.trotter.dashbuddy.core.pipeline.rules.CompiledRedactEntry
+import cloud.trotter.dashbuddy.core.pipeline.rules.ScreenRedactionSource
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.pipeline.UNKNOWN_TARGET
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #910 V4 — a click envelope INHERITS the redact of the rule that recognized the
+ * screen the tap landed on.
+ *
+ * The fielded leak: tapping a row of the recognized `pickup_post_arrival_multi` list
+ * produced an UNKNOWN click envelope whose payload was the tapped subtree, carrying a
+ * bare `customer_name` node RAW — while the screen envelope for the very same surface
+ * masked it correctly. `captureClick` consulted no rule at all, and the marker backstop
+ * is structurally blind to a bare name node, so nothing covered the click path.
+ *
+ * The screen's rule is the one authority on which of ITS nodes are PII, so the fix
+ * applies that same compiled block to the click payload rather than inventing a second
+ * enumeration (principle 5). These tests pin the wiring: applied on BOTH recognized and
+ * UNKNOWN clicks, fail-OPEN when there is no screen rule or no redact block, and
+ * envelope-only (the original node is never mutated, so the dedup identity upstream —
+ * `clickDedupHash(event.node, screenTarget)` — is unaffected).
+ */
+class ClickEnvelopeScreenRedactTest {
+
+    private val offered = mutableListOf<String>()
+
+    private val bus = object : CaptureBus {
+        override fun offer(
+            captureId: String,
+            source: String,
+            classification: String?,
+            platform: String,
+            envelopeJson: String,
+            contentHash: Int?,
+        ): String {
+            offered += envelopeJson
+            return captureId
+        }
+    }
+
+    /** A stand-in for the live interpreter: one rule id, one compiled `redact` block. */
+    private object CustomerNameRedaction : ScreenRedactionSource {
+        private val block = CompiledRedact(
+            listOf(
+                CompiledRedactEntry(
+                    find = { node -> node.viewIdResourceName?.endsWith("customer_name") == true },
+                ),
+            ),
+        )
+
+        override fun redactFor(ruleId: String): CompiledRedact? =
+            block.takeIf { ruleId == RULE_ID }
+
+        const val RULE_ID = "doordash.screen.pickup_post_arrival_multi"
+    }
+
+    private val stats = PipelineStats()
+    private val writer = CaptureWriter(bus, stats, CustomerNameRedaction)
+
+    /** The fielded shape: the tapped row subtree, one bare customer name + merchant. */
+    private fun row() = UiNode(
+        viewIdResourceName = "com.doordash.driverapp:id/pickup_row",
+        isClickable = true,
+        children = listOf(
+            UiNode(viewIdResourceName = "com.doordash.driverapp:id/customer_name", text = "Testname Q"),
+            UiNode(viewIdResourceName = "com.doordash.driverapp:id/merchant_name", text = "Pei Wei"),
+        ),
+    )
+
+    private fun clickObs(target: String = UNKNOWN_TARGET, ruleId: String? = null) = Observation.Click(
+        timestamp = 1_000L,
+        captureId = null,
+        ruleId = ruleId,
+        metadata = ReplayMetadata.EMPTY,
+        flow = null,
+        modeHint = null,
+        parsed = ParsedFields.None,
+        target = target,
+    )
+
+    private fun capture(
+        node: UiNode,
+        target: String = UNKNOWN_TARGET,
+        ruleId: String? = null,
+        screenRuleId: String?,
+    ): String {
+        offered.clear()
+        writer.captureClick(
+            clickObs(target, ruleId),
+            PipelineEvent.Click(timestamp = 1_000L, node = node, packageName = "com.doordash.driverapp"),
+            screenTarget = "pickup_post_arrival_multi",
+            screenRuleId = screenRuleId,
+        )
+        return offered.single()
+    }
+
+    @Test
+    fun `an UNKNOWN click on a recognized screen inherits that screen rule's redact`() {
+        val json = capture(row(), screenRuleId = CustomerNameRedaction.RULE_ID)
+
+        assertFalse("the tapped row's customer name must not persist", json.contains("Testname Q"))
+        assertTrue("masked to the hash family", Regex("""\[redacted:[0-9a-f]{4}]""").containsMatchIn(json))
+        assertTrue("merchant kept — the rule masks only what it declares", json.contains("Pei Wei"))
+        // The rule-declared mask is not a backstop scrub: the backstop counter stays 0.
+        assertEquals(0L, stats.unknownCustomerScrubCount)
+    }
+
+    @Test
+    fun `a RECOGNIZED click on a recognized screen inherits it too`() {
+        // A rule-matched click is usually an app-vocabulary button, but the fielded
+        // surface proves a tapped node can be a customer row — so the inheritance is
+        // not gated on the click's own classification.
+        val json = capture(
+            row(),
+            target = "pickup_row_tap",
+            ruleId = "doordash.click.pickup_row",
+            screenRuleId = CustomerNameRedaction.RULE_ID,
+        )
+
+        assertFalse("customer name must not persist", json.contains("Testname Q"))
+        assertTrue("merchant kept", json.contains("Pei Wei"))
+    }
+
+    @Test
+    fun `no screen rule means no inheritance - fail OPEN, byte-identical to pre-910`() {
+        // A benign node under an unattributable screen: nothing to inherit, nothing masked.
+        val benign = UiNode(viewIdResourceName = "com.doordash.driverapp:id/some_button", text = "Continue")
+        val json = capture(benign, screenRuleId = null)
+
+        assertTrue("node persists untouched", json.contains("Continue"))
+        assertFalse("nothing masked", json.contains("[redacted"))
+    }
+
+    @Test
+    fun `a screen rule with no redact block leaves the node untouched`() {
+        val json = capture(
+            UiNode(viewIdResourceName = "com.doordash.driverapp:id/some_button", text = "Continue"),
+            screenRuleId = "doordash.screen.some_other_rule",
+        )
+
+        assertTrue("node persists untouched", json.contains("Continue"))
+    }
+
+    @Test
+    fun `the redact is envelope-only - the original node is never mutated`() {
+        // The dedup identity (clickDedupHash) and every downstream consumer read the
+        // ORIGINAL node; masking a copy is what keeps that hash stable across the fix.
+        val original = row()
+        capture(original, screenRuleId = CustomerNameRedaction.RULE_ID)
+
+        assertEquals("Testname Q", original.children[0].text)
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkersTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkersTest.kt
@@ -260,6 +260,21 @@ class CustomerTextMarkersTest {
     }
 
     @Test
+    fun `the id scan over-scrubs a reused user_name node - the documented UNKNOWN-only cost`() {
+        // `user_name` is not exclusively a customer node: it renders the DASHER's own
+        // name in some chrome, and on a pickup card it holds the MERCHANT ("Pickup from
+        // <store>", which pickup_pre_arrival parses as storeName). On an UNKNOWN frame
+        // the scan cannot tell them apart, so it masks them too — losing triage text,
+        // leaking nothing. This is the accepted fail-toward-privacy cost, pinned here so
+        // it is a DECISION rather than a surprise. The RECOGNIZED path is untouched, so
+        // no rule's merchant-keeps-raw decision is affected.
+        assertEquals(
+            "user_name",
+            CustomerTextMarkers.unredactedIdMarker(dd("user_name", "Pickup from Sample Pizza Co")),
+        )
+    }
+
+    @Test
     fun `a clean tree yields no id marker`() {
         val tree = UiNode(
             children = listOf(dd("merchant_name", "Pei Wei"), UiNode(text = "Continue")),

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkersTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkersTest.kt
@@ -166,6 +166,107 @@ class CustomerTextMarkersTest {
         assertEquals("Deliver to ", CustomerTextMarkers.firstUnredactedMarkerInNotif(raw))
     }
 
+    // --- The node-ID half, UNKNOWN envelopes only (#910) -----------------------
+
+    private fun dd(id: String, text: String? = null, desc: String? = null) = UiNode(
+        viewIdResourceName = "com.doordash.driverapp:id/$id",
+        text = text,
+        contentDescription = desc,
+    )
+
+    @Test
+    fun `a customer-PII node id is detected even though its text carries no marker`() {
+        // The whole point: these values are BARE — no lead-in for the prefix scan.
+        assertEquals("user_name", CustomerTextMarkers.unredactedIdMarker(dd("user_name", "Jane Q")))
+        assertEquals("customer_name", CustomerTextMarkers.unredactedIdMarker(dd("customer_name", "Jane Q")))
+        assertEquals("address_line_1", CustomerTextMarkers.unredactedIdMarker(dd("address_line_1", "123 Main St")))
+        assertEquals(
+            "address_line_2",
+            CustomerTextMarkers.unredactedIdMarker(dd("address_line_2", "Austin, TX 78701")),
+        )
+        // The prefix scan is blind to every one of them — that is the gap this closes.
+        assertNull(CustomerTextMarkers.unredactedMarker("Jane Q"))
+        assertNull(CustomerTextMarkers.unredactedMarker("123 Main St"))
+    }
+
+    @Test
+    fun `the id match is a SUFFIX match, like the rules' hasIdSuffix predicate`() {
+        // The `com.<vendor>:id/` prefix varies by package, so only the tail is pinned.
+        assertEquals(
+            "customer_name",
+            CustomerTextMarkers.unredactedIdMarker(
+                UiNode(viewIdResourceName = "com.example.other:id/customer_name", text = "Jane Q"),
+            ),
+        )
+        // A bare id with no package prefix still matches.
+        assertEquals(
+            "user_name",
+            CustomerTextMarkers.unredactedIdMarker(UiNode(viewIdResourceName = "user_name", text = "Jane Q")),
+        )
+    }
+
+    @Test
+    fun `the LABEL siblings are app vocabulary and are not id markers`() {
+        // "Delivery for" / "Order for" chrome must survive so a scrubbed UNKNOWN frame
+        // keeps its shape for triage.
+        assertNull(CustomerTextMarkers.unredactedIdMarker(dd("user_name_label", "Delivery for")))
+        assertNull(CustomerTextMarkers.unredactedIdMarker(dd("customer_name_label", "Order for")))
+        assertNull(CustomerTextMarkers.unredactedIdMarker(dd("merchant_name", "Pei Wei")))
+    }
+
+    @Test
+    fun `an id-marked node whose values are already redacted is skipped`() {
+        assertNull(CustomerTextMarkers.unredactedIdMarker(dd("user_name", "[redacted:ab12]")))
+        assertNull(CustomerTextMarkers.unredactedIdMarker(dd("address_line_1", "[redacted]")))
+        // An empty/valueless node has nothing to leak either.
+        assertNull(CustomerTextMarkers.unredactedIdMarker(dd("user_name")))
+        assertNull(CustomerTextMarkers.unredactedIdMarker(UiNode(text = "Jane Q")))
+    }
+
+    @Test
+    fun `a customer-PII id carrying its value in the contentDescription is caught too`() {
+        assertEquals("user_name", CustomerTextMarkers.unredactedIdMarker(dd("user_name", desc = "Jane Q")))
+    }
+
+    @Test
+    fun `scrubUnknown masks BOTH the id-marked node and the text-marked node in one pass`() {
+        // THE FIELDED SHAPE (07-28 and again 07-29, once per job): the lead-in reads
+        // exactly "Delivery for" with NO trailing name, so the marker "Delivery for "
+        // never matches — and the name lives in a bare sibling. Neither node is
+        // reachable by the prefix scan alone.
+        val tree = UiNode(
+            children = listOf(
+                dd("user_name_label", "Delivery for"),
+                dd("user_name", "Jane Q"),
+                dd("address_line_1", "123 Main St"),
+                dd("address_line_2", "Austin, TX 78701"),
+                UiNode(text = "Deliver to Jane Q"), // text-marker node, the #806 half
+                UiNode(text = "Directions"), // over-match guard
+            ),
+        )
+        assertNull("the label's exact text does not match the marker", CustomerTextMarkers.unredactedMarker("Delivery for"))
+        assertEquals("user_name", CustomerTextMarkers.firstUnredactedIdMarker(tree))
+
+        val scrubbed = CustomerTextMarkers.scrubUnknown(tree)
+        assertEquals("Delivery for", scrubbed.children[0].text) // chrome kept
+        assertEquals("[redacted]", scrubbed.children[1].text)
+        assertEquals("[redacted]", scrubbed.children[2].text)
+        assertEquals("[redacted]", scrubbed.children[3].text)
+        assertEquals("[redacted]", scrubbed.children[4].text)
+        assertEquals("Directions", scrubbed.children[5].text)
+        // Clean under BOTH scans afterwards.
+        assertNull(CustomerTextMarkers.firstUnredactedIdMarker(scrubbed))
+        assertNull(CustomerTextMarkers.firstUnredactedMarker(scrubbed))
+    }
+
+    @Test
+    fun `a clean tree yields no id marker`() {
+        val tree = UiNode(
+            children = listOf(dd("merchant_name", "Pei Wei"), UiNode(text = "Continue")),
+        )
+        assertNull(CustomerTextMarkers.firstUnredactedIdMarker(tree))
+    }
+
     @Test
     fun `no-lead-in customer shapes are the documented residual the rule redact owns`() {
         // Uber trip_en_route_dropoff title is a WHOLE address with NO lead-in marker —

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
@@ -78,6 +78,15 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
         override val transitionOverrides: Map<TransitionTrigger, List<RequestedEffect>> = emptyMap(),
         /** The last classified screen target when this click occurred. */
         val screenTarget: String? = null,
+        /**
+         * The RULE that produced [screenTarget] (#910). Recognition context for the
+         * capture stage only: a tapped node is serialized in isolation, so the click
+         * envelope inherits the screen rule's `redact` block to mask customer PII the
+         * screen envelope already masks. Null when the screen was UNKNOWN or
+         * unattributable — the inheritance is fail-open, and nothing in the state
+         * machine reads this.
+         */
+        val screenRuleId: String? = null,
     ) : FlowObservation
 
     /** A notification event classified by the notification pipeline. */

--- a/matchers/rules/doordash/dropoff.json5
+++ b/matchers/rules/doordash/dropoff.json5
@@ -1379,6 +1379,50 @@
     {
       "id": "doordash.screen.delivery_summary_collapsed",
       "priority": 31,
+      "redact": [
+        {
+          "comment": "#910 V1 — this rule shipped with NO redact block and it is the HIGHEST-severity site of the 07-29 pull: 4 of the 8 fielded `delivery_summary_collapsed` envelopes are not the pay-breakdown card at all but the DROP-OFF card (the require is a text-only `allTextContainsAny:['this offer','delivery complete']`, which a live drop-off sheet satisfies), so they carry the full customer block — `user_name`, `address_line_1` (house number + street), `address_line_2` (city/ST/ZIP), the dasher instruction body and the customer's per-item note — all raw on a RECOGNIZED envelope. `CustomerTextMarkers` cannot own any of it: DoorDash renders this block as SPLIT nodes (the 'Delivery for' lead-in is its own `user_name_label` sibling), so the name/address nodes are BARE and a text-prefix scan is structurally blind to them. The entries below are the `dropoff_pre_arrival` (priority 73) id set — the same ids, the same masks — so one customer redacts to one hex everywhere. Capture-only: this rule parses none of these nodes, so the parse goldens are byte-identical. Genuine summary frames (the committed corpus) carry none of these ids, so the block is inert there. Deliberately NOT redacted: `order_contents_header_title` (the merchant — driver-owned, not PII), `order_item_name` (catalog item), and every pay node.",
+          "find": {
+            "hasIdSuffix": "user_name"
+          },
+          "normalize": "customerName"
+        },
+        {
+          "find": {
+            "hasIdSuffix": "address_line_1"
+          }
+        },
+        {
+          "find": {
+            "hasIdSuffix": "address_line_2"
+          }
+        },
+        {
+          "comment": "The Apt/Suite VALUE, keeping its app-vocabulary label prefix exactly as `dropoff_pre_arrival` does.",
+          "find": {
+            "hasIdSuffix": "address_subpremise_line"
+          },
+          "keepPrefix": [
+            "Apt/Suite: "
+          ]
+        },
+        {
+          "find": {
+            "hasIdSuffix": "dasher_instruction_content_collapsed"
+          }
+        },
+        {
+          "find": {
+            "hasIdSuffix": "dasher_instruction_content_expanded"
+          }
+        },
+        {
+          "comment": "The customer's free-text note on an order item — the #803 class (a note routinely carries a gate code, an apartment number, or a callback instruction). Masked whole; the item NAME node (`order_item_name`) is catalog data and stays raw.",
+          "find": {
+            "hasIdSuffix": "order_item_instructions"
+          }
+        }
+      ],
       "state": {
         "flow": "post:task",
         "modeHint": "online"

--- a/matchers/rules/doordash/pickup.json5
+++ b/matchers/rules/doordash/pickup.json5
@@ -536,6 +536,15 @@
     {
       "id": "doordash.screen.pickup_post_arrival_multi",
       "priority": 99,
+      "redact": [
+        {
+          "comment": "#910 V2 — the multi-order pickup list renders ONE row per order, each carrying a bare `customer_name` node (the fielded 07-28 frames carry three), and this rule shipped with no redact block, so every one reached the recognized envelope raw. The node has no in-node lead-in ('Order for' is a separate sibling on the single-order card), so `CustomerTextMarkers` is structurally blind to it — the same split-node shape #526 D6a documents for `pickup_arrival`, whose identical `customer_name` + `normalize: customerName` entry this mirrors so a customer's mask hex matches across surfaces and the persisted `customerNameHash`. Recognize-only rule: redact without parse is legal (the `pickup_select_issue` precedent) and the parse goldens are untouched. `merchant_name` stays raw (the merchant is driver-owned data, not PII); so do `num_items`/`header_text`/`description_text`, which are app chrome.",
+          "find": {
+            "hasIdSuffix": "customer_name"
+          },
+          "normalize": "customerName"
+        }
+      ],
       "state": {
         "flow": "task:pickup:arrived",
         "modeHint": "online"
@@ -561,6 +570,15 @@
     {
       "id": "doordash.screen.pickup_pre_arrival_multi",
       "priority": 100,
+      "redact": [
+        {
+          "comment": "#910 V3 — the pre-arrival twin of `pickup_post_arrival_multi` (same list, before 'Confirm at store'); the fielded 07-28 frame carries the same bare `customer_name` node. Same entry, same reasoning, same `normalize: customerName` so the mask hex is one-customer-one-hex across both surfaces.",
+          "find": {
+            "hasIdSuffix": "customer_name"
+          },
+          "normalize": "customerName"
+        }
+      ],
       "state": {
         "flow": "task:pickup:navigation",
         "modeHint": "online"


### PR DESCRIPTION
Closes #910.

## What leaked

Five customer-PII sites on DoorDash surfaces in the 07-29 pull, all on **recognized** or **UNKNOWN** capture envelopes. No values are reproduced anywhere in this PR — every test value is invented; only node IDS are ground truth.

| # | Surface | What shipped raw |
|---|---|---|
| V1 | `delivery_summary_collapsed` (recognized) | customer name, **full street line**, city/ST/ZIP, dasher-instruction body, per-item note — the rule had **no `redact` block at all** |
| V2/V3 | `pickup_post_arrival_multi` / `_pre_arrival_multi` (recognized) | one bare `customer_name` per order row (three on the fielded frame); no `redact` block |
| V4 | UNKNOWN **click** envelopes | the tapped row's bare `customer_name`, while the screen envelope for that same surface masked it correctly |
| V5 | UNKNOWN **window** | customer name + address lines on the workflow-sheet pre-render |

**V1 is worse than the issue's framing.** `delivery_summary_collapsed`'s require is a text-only `allTextContainsAny:['this offer','delivery complete']`, which a **live drop-off sheet** satisfies — so 4 of the 8 fielded envelopes under that classification are not the pay-breakdown card at all, but the customer card carrying the whole block.

**The issue's V5 premise is wrong** (correction already posted on the issue): `"Delivery for "` has been in `CustomerTextMarkers.MARKERS` since #624. The marker could not reach this leak *even in principle* — DoorDash renders the card as **split nodes**, so the label node holds a marker and no PII, and the value node holds PII and no marker. A text-prefix scan is structurally blind to it. That is the class this PR closes.

**Field evidence** (paths only, never values): `~/dashbuddy/logs/2026/07/30/captures/doordash/accessibility.window/UNKNOWN/2026-07-29_18-14-06-648__doordash__accessibility.window__UNKNOWN__6fa230.json` — the live 07-29 confirmation, `user_name_label` = "Delivery for" beside a bare `user_name` sibling, 34 ms before its correctly-masked recognized twin; recurs once per job. Same window signature as the 07-28 frame in the previous pull. Both shapes are reproduced as tests.

## The three mechanisms

**A. Rule redacts (V1–V3)** — `delivery_summary_collapsed` gets the `dropoff_pre_arrival` id set (`user_name` + `normalize: customerName`, `address_line_1`, `address_line_2`, `address_subpremise_line` w/ `Apt/Suite: ` keepPrefix, both `dasher_instruction_content_*`, `order_item_instructions`). Both multi-pickup rules get the `pickup_arrival` entry (`customer_name` + `normalize: customerName`). Mirroring the reference rules is deliberate: `normalize: customerName` keeps **one customer → one mask hex** across every surface and the persisted `customerNameHash`. Merchant (`order_contents_header_title`, `merchant_name`), catalog (`order_item_name`), counts and pay stay raw.

**B. Click envelopes inherit the SCREEN rule's `redact` (V4)** — a tapped node is serialized in **isolation**, so `captureClick` had no rule context at all and shipped a node the screen envelope masked. `Observation.Click.screenRuleId` is now stamped beside `screenTarget` from the classifier's per-platform screen-context cache (the two became one `ScreenContext` value so they cannot drift), and drives the existing `redactFor` lookup. Applied to recognized **and** UNKNOWN clicks (a tap can be UNKNOWN while its screen is recognized — exactly the fielded shape). No second enumeration is introduced: the screen's rule is the one authority on which of its nodes are PII.

**C. `CustomerTextMarkers.ID_MARKERS` (V5, + V4 depth)** — an enumerated view-id-suffix list (`customer_name`, `user_name`, `address_line_1`, `address_line_2`) whose node VALUE is customer PII by construction, matched with `hasIdSuffix` (`endsWith`) semantics, scrubbed on **UNKNOWN screen + click envelopes only**. Label siblings are app chrome and survive, so a scrubbed frame stays triage-useful.

## Security / privacy posture

- **Envelope-only, everywhere.** Recognition, parse, the state machine, and every dedup identity (`event.tree.stableHash`, `clickDedupHash(event.node, screenTarget)`) still run on the ORIGINAL tree/node. `ParseOutputGoldenTest` is **green with no regen** — the goldens are byte-identical and no corpus file was modified.
- **Fail-closed where it must be, fail-open where opening is safe.** The rule redacts and the id backstop are *additive* masking — they can only remove data from an envelope. The click inheritance is deliberately fail-OPEN (null `screenRuleId`, unknown rule, or a rule with no `redact` ⇒ node untouched, byte-identical to pre-#910): it is a *second* control layered over the marker/id backstops, never the only one, so opening it degrades to today's behaviour rather than to a crash.
- **Scope of the id scan is UNKNOWN-only, by design.** On a recognized frame the rule's `redact` is the primary control and its decisions are deliberate (#886 keeps `pickup_navigation`'s MERCHANT address raw); an id scan there would fight the ruleset.
- **Accepted, documented cost:** the `user_name` id is reused — the dasher's own name in some chrome, and the MERCHANT on a pickup card (`pickup_pre_arrival` parses it as `storeName`). On an UNKNOWN frame the scan cannot tell them apart and masks them too: triage text lost, nothing leaked. Pinned by a test so it reads as a decision, not a surprise.
- **No new logging risk.** The backstop WARN names the text marker by its #862 log-safe id (marker constants self-scrub at the shareable sink) and the node id verbatim — a view-id token carries no PII and matches no sensitive marker. No scanned third-party value is ever logged.
- `CaptureBackstopCorpusTest`'s zero-false-positive pin is **untouched** — no assertion removed or narrowed. Its KDoc now records why the id scan is deliberately outside it.

## Tests (mutation-verified)

Every control was reverted one at a time and the suite confirmed RED:

| Mutation | Result |
|---|---|
| neutralise `delivery_summary_collapsed`'s `user_name` entry | RED — `CaptureRedactionCorpusTest` |
| drop `pickup_post_arrival_multi`'s `redact` block | RED — `CaptureRedactionCorpusTest` |
| drop `user_name` from `ID_MARKERS` | RED — 5 tests across `CustomerTextMarkersTest` + `CaptureScrubTest` |
| stop applying the screen redact on the click path | RED — `ClickEnvelopeScreenRedactTest` |

Coverage: production redacts run over a committed corpus fixture and ground-truth node shapes; over-match guards (merchant/catalog/pay/chrome stay raw); cross-surface hex stability (`normalize: customerName` — one customer, one hex, across the multi-pickup rows, the single-order card and the nav title); per-customer distinctness (two customers on one screen ⇒ two suffixes); fail-open and UNKNOWN-only scope pins; and the exact V5 field shape.

Green: `:core:pipeline:testDebugUnitTest`, `:app:testDebugUnitTest` (incl. `AllMatchersSuite`, `ParseOutputGoldenTest`), `:domain:test`. Merged with `master` (post-#927) before opening — the `dropoff.json5` redact-family edits compose cleanly.

Related: #919. Follow-up candidate reported separately (not fixed here — it predates this PR and spans a family): the three `address_subpremise_line` entries hash-mask a bounded unit-number alphabet, the same class #895/#927 just gave `plainMask` to on the fused-`Apt ` entries.

## Field-test checklist

Not added to `docs/field-testing/README.md` — the main loop owns that file this session. Suggested items:
- **#910 recognized-surface redacts** — after a drop-off and a multi-order pickup, confirm the `delivery_summary_collapsed` / `pickup_*_multi` envelopes carry `[redacted:<4hex>]` where the name/address/instructions were, and that merchant + pay are still readable. (Confirmed: 0/2)
- **#910 click + UNKNOWN masking** — confirm no `accessibility.click` envelope and no UNKNOWN window envelope carries a raw name or street line; the `user_name_label` "Delivery for" chrome should still be present beside a `[redacted]` value. (Confirmed: 0/2)

### Design-goal review

- **5 (SSOT).** The click path reuses the screen rule's *existing* compiled `redact` rather than adding a second enumeration that could drift from it. The classifier's two per-platform screen values became **one** `ScreenContext` so a click can never carry one screen's target with another's redact. `normalize: customerName` routes every new mask through the existing canonical-name chain, so the mask hex stays equal to the persisted `customerNameHash`. `ID_MARKERS` lives beside `MARKERS` in the one backstop SSOT.
- **6 (Security & privacy).** The subject of the PR — see the posture section. Bounded-ingestion and fail-closed properties of the compile/ingest path are untouched; this only adds masking to serialization.
- **8 (Platform-agnostic core).** No new `Platform` literal, branch, or package check in Kotlin. `ID_MARKERS` is cross-platform recognition **data** in the SSOT, exactly the posture of the DoorDash/Uber marker strings already there; the ids happen to be DoorDash vocabulary today and any platform's ids can join the list without a code change. The rule redacts are data in the per-platform ruleset. `screenRuleId` flows through the existing per-platform (`platformWire`-keyed) cache, so the #438 item-2 per-platform isolation is preserved.
- **1 (UDF).** Masking stays at the capture edge; no reducer or state-machine behaviour changes. `Observation.Click.screenRuleId` is recognition context that nothing in the state machine reads.
- **3 (Single responsibility).** One shared `scrubUnknownTree` helper replaces the duplicated screen/click backstop blocks (one traversal for both scans, one WARN, one counter).
- **7 (Semantic, PII-safe logging).** WARN level (a defended invariant fired), marker named by log-safe id, node id verbatim (safe by inspection), no scanned value logged.
- **2, 4** — touched only incidentally (idiomatic Kotlin, immutable copies); no deviations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
