### PR TITLE
test(rules): #900 — scope UberIdleMapOfflineEvidenceTest matchFirst to platformWire=uber

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/UberIdleMapOfflineEvidenceTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/UberIdleMapOfflineEvidenceTest.kt
@@ -74,7 +74,11 @@ class UberIdleMapOfflineEvidenceTest(
 
     @Test
     fun `partially rendered uber home makes no offline claim`() {
-        val intent = screenRuleset.matchFirst(node)?.intent ?: "UNKNOWN"
+        // #900 (#898 review F5): scope to the uber partition like production does
+        // (ObservationClassifier partitions by wire at all three call sites) — unscoped,
+        // a future fixture carrying an "Inbox, N new notifications" desc would be claimed
+        // cross-platform by doordash.screen.notifications_view via allText folding.
+        val intent = screenRuleset.matchFirst(node, platformWire = "uber")?.intent ?: "UNKNOWN"
         assertEquals(
             "$filename classified '$intent' — a partially rendered Uber home carries no offline " +
                 "evidence, so claiming one forges an Online→Offline edge (#857)",


### PR DESCRIPTION
One-line test fix from PR #898's review (F5): the #872 must-stay-UNKNOWN pin called `matchFirst` UNSCOPED, green today only because its fixtures carry no notification-badge descs — a future fixture with an "Inbox, N new notifications" contentDescription would be claimed cross-platform by `doordash.screen.notifications_view` (priority 96) via allText folding, a shape unreachable in production (the classifier partitions by wire at all three call sites). Now passes `platformWire = "uber"`, matching the #898 sibling test, with a comment naming the trap.

Verified: `UberIdleMapOfflineEvidenceTest` green (`--rerun-tasks`).

### Design-goal review
Test-only, production-faithfulness fix — conforms to #8 (tests exercise the same platform partition production does). No other principles touched.

Closes #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)