### PR TITLE
ci: #940 — nightly propExplore workflow (unseeded 10× property exploration)

### DIFF
--- a/.github/workflows/prop-explore.yml
+++ b/.github/workflows/prop-explore.yml
@@ -1,0 +1,74 @@
+# #940 — the #878 seeded-CI design's missing exploration half.
+#
+# PR CI pins every kotest property to an explicit seed (deterministic, reproducible reds);
+# the breadth that seeding traded away lives behind -Ddashbuddy.propExplore=true (10x samples,
+# unseeded) and was designed to run "off the PR path (nightly/manual)" — this is that home.
+#
+# When a property fails here, the kotest output REPORTS THE SEED. The whole point of this
+# workflow is harvesting that seed: paste it into the failing property's pinned SEED const
+# (PropSeeds) so the finding becomes a permanent, deterministic regression test — never
+# re-run-and-move-on (the #878 doctrine).
+name: Property Exploration (nightly)
+
+on:
+  schedule:
+    # 09:17 UTC ≈ 04:17 America/Chicago, Mon/Wed/Sat — off-peak, 3x weekly (dev decision
+    # welcome to retune; odd minute avoids the top-of-hour Actions scheduling pile-up).
+    - cron: '17 9 * * 1,3,6'
+  workflow_dispatch: {}
+
+jobs:
+  prop-explore:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Explore (unseeded, 10x samples)
+        run: ./gradlew :core:pipeline:testDebugUnitTest :app:testDebugUnitTest -Ddashbuddy.propExplore=true
+
+      - name: Surface failing-property reports
+        # A red exploration run's value IS the seed in the kotest failure output — put the
+        # test reports where the dev finds them without spelunking the raw log.
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: prop-explore-failure-reports-${{ github.run_id }}
+          path: |
+            core/pipeline/build/reports/tests/
+            app/build/reports/tests/
+          retention-days: 14
+
+      - name: Failure summary
+        if: ${{ failure() }}
+        run: |
+          {
+            echo "## Property exploration found a counterexample"
+            echo "An UNSEEDED 10x run went red. Download the reports artifact, find the"
+            echo "reported kotest seed in the failing property's output, and pin it into"
+            echo "that property's SEED const (PropSeeds) so the finding becomes a"
+            echo "deterministic regression test — the #878 doctrine. Never bump a seed to"
+            echo "turn a red run green."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The #878 seeded-CI design deliberately moved exploration breadth behind `-Ddashbuddy.propExplore=true` "off the PR path (nightly/manual)" — but that nightly was never built, so PR CI draws the same pinned sample sets forever (adversarial review §4.4 item 3, filed as #940).

**New workflow `prop-explore.yml`:** `schedule` (Mon/Wed/Sat 09:17 UTC, off-peak, odd-minute to dodge the top-of-hour Actions pile-up) + `workflow_dispatch`. Runs `:core:pipeline:testDebugUnitTest :app:testDebugUnitTest -Ddashbuddy.propExplore=true` (the property flag is forwarded to test JVMs by the root `build.gradle.kts:46-52` plumbing — verified). On failure: test reports upload as an artifact (14-day retention) and a step summary states the seed-harvesting doctrine (pin the reported seed, never re-run-and-move-on).

**Verification:** YAML validated; the flag plumbing verified in the root build; the schedule itself is only provable live — the `workflow_dispatch` trigger exists exactly so the first run can be fired manually after merge (workflow definitions for dispatch/schedule read from the default branch).

### Design-goal review
- Testing/CI-only diff. The workflow codifies the #878 doctrine's operational half; no principle touched beyond making an existing documented command (CLAUDE.md's propExplore build command) run on a cadence.

Closes #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)