### PR TITLE
privacy(pipeline): #835 — stateDescription joins every scrub/redact layer via a UiNode scrubbable-fields SSOT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,6 +308,18 @@ iterate it instead of hand-listing the fields, so a field added to the model can
 scrub site; the UNKNOWN-notification `SensitiveTextMarkers` scan and the `CustomerTextMarkers`
 backstop both also scan `actionLabels` now (#666) — a push action button label is serialized into
 the envelope the same as the text fields and was previously excluded from every scrub layer.
+**The screen-node edition of that SSOT is `UiNodeTextField` + `UiNode.scrubbableStrings()` /
+`mapScrubbableStrings()` / `allScrubbableText()` (#835):** `stateDescription` is captured (SDK ≥ R)
+and serialized as `"state"`, but every layer hand-listed `text` + `contentDescription`, so a view
+that mirrors content into it (toggles/sliders/custom controls do) would have shipped it verbatim on
+BOTH paths — latent, no fielded leak. `CompiledRedact.maskNode`, `CustomerTextMarkers`
+(text scan + `scrub`/`scrubUnknown` + the #910 id scan's already-redacted test),
+`SensitiveTextMarkers.findMarker(tree)`, and the corpus `SnapshotSecurityScanner`/`SnapshotRedactor`
+now all iterate that enumeration, so the NEXT string field added to `UiNode` cannot silently miss a
+scrub site. Recognition is deliberately untouched: `UiNode.allText` (what rules match on) still
+excludes `stateDescription` — widening a scrub layer must never be able to move a classification —
+and rule-side FIND predicates (`hasTextMatchesRegex` & co.) are likewise unchanged; #835 fixes the
+MASK side only.
 **Two #910 additions close the SPLIT-NODE class** — DoorDash renders the customer card as separate
 nodes (a `user_name_label` reading exactly `"Delivery for"` beside a BARE `user_name`), which a
 text-PREFIX scan can never own since the marker and the PII are in different nodes. (1) A **click

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -693,9 +693,9 @@ class CaptureRedactionCorpusTest {
         )
     }
 
+    /** Visit every serialized string field of every node (the #835 SSOT). */
     private fun walkText(node: UiNode, visit: (String) -> Unit) {
-        node.text?.let(visit)
-        node.contentDescription?.let(visit)
+        node.scrubbableStrings().forEach { (_, value) -> value?.let(visit) }
         node.children.forEach { walkText(it, visit) }
     }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.test.util
 
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNodeTextField
 import cloud.trotter.dashbuddy.domain.model.notification.NotifTextField
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
@@ -177,8 +178,11 @@ object SnapshotRedactor {
     private fun collectNode(o: JsonObject, repl: MutableMap<String, String>) {
         val piiById = (o["id"]?.takeIf { it is JsonPrimitive }?.jsonPrimitive?.content ?: "")
             .substringAfterLast('/') in PII_ID_SUFFIXES
-        for (k in listOf("text", "desc", "state")) {
-            val v = o[k] as? JsonPrimitive ?: continue
+        // #835: iterate the production UiNodeTextField wire-name SSOT instead of
+        // hand-listing text/desc/state, so a string field added to UiNodeDto is
+        // scrubbed on the commit path automatically.
+        for (field in UiNodeTextField.entries) {
+            val v = o[field.wire] as? JsonPrimitive ?: continue
             if (!v.isString) continue
             record(v.content, scrub(v.content, piiById), repl)
         }

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScanner.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScanner.kt
@@ -56,14 +56,17 @@ object SnapshotSecurityScanner {
         // SSOT PARITY (#590): delegate the marker/shape decision to the production
         // fail-closed backstop rather than re-implementing its keyword list. This is
         // the load-bearing guarantee `findMarker(tree)!=null ⇒ scan.isToxic`:
-        //  - it scans the whole tree's `allText` (text AND contentDescription), so a
-        //    desc-borne marker the old per-node `node.text` walk missed is caught;
+        //  - it scans the whole tree's scrubbable text (text, contentDescription AND —
+        //    since #835 — stateDescription), so a desc/state-borne marker the old
+        //    per-node `node.text` walk missed is caught;
         //  - it NFKC-normalizes both sides, so homoglyph/whitespace-mutated markers hit;
         //  - it scans the space-joined blob, so a marker split across sibling nodes rejoins;
         //  - it owns the SSN/card-PAN shapes the scanner never had.
         // A future marker addition lands here automatically — the two copies can't diverge.
         SensitiveTextMarkers.findMarker(node)?.let { marker ->
-            triggers.add(node.allText.joinToString(" ") to "sensitive-marker:$marker")
+            // Report the SAME blob the production scan read (#835), so the evidence
+            // line can't omit the field that actually tripped it.
+            triggers.add(node.allScrubbableText().joinToString(" ") to "sensitive-marker:$marker")
         }
 
         // Scanner-specific EXTRA corpus-gate shapes NOT in the production backstop
@@ -93,11 +96,12 @@ object SnapshotSecurityScanner {
      * Walk the tree for the scanner-specific EXTRA shapes (#803 pin/gate). Marker/
      * keyword parity is owned by the [SensitiveTextMarkers.findMarker] delegation in
      * [scan]; this only adds the corpus-gate shapes the production backstop doesn't
-     * carry. Scans both text and contentDescription so a shape hiding in a desc node
-     * is caught too (parity discipline extended to the extras).
+     * carry. Scans every field of the [UiNode.scrubbableStrings] SSOT (#835) — text,
+     * contentDescription and stateDescription — so a shape hiding in a desc or state
+     * node is caught too (parity discipline extended to the extras).
      */
     private fun walkAndFind(node: UiNode, results: MutableList<Pair<String, String>>) {
-        for (field in listOfNotNull(node.text, node.contentDescription)) {
+        for (field in node.scrubbableStrings().mapNotNull { it.second }) {
             SENSITIVE_SHAPES.firstOrNull { (re, _) -> re.containsMatchIn(field) }?.let { (_, label) ->
                 results.add(field to label)
             }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
@@ -138,29 +138,31 @@ object CustomerTextMarkers {
     }
 
     /**
-     * The first un-redacted customer marker anywhere in [tree] (text or
-     * contentDescription of any node), or null when clean. Cheap scan run on
-     * every recognized capture; the [scrub] copy is built only on a hit.
+     * The first un-redacted customer marker anywhere in [tree] — across EVERY
+     * serialized string field of every node ([UiNode.scrubbableStrings], #835:
+     * text, contentDescription AND stateDescription) — or null when clean. Cheap
+     * short-circuiting scan run on every recognized capture; the [scrub] copy is
+     * built only on a hit.
+     *
+     * Walks the tree itself rather than the memoized [UiNode.allText] because
+     * that list is the RECOGNITION SSOT and deliberately excludes
+     * `stateDescription` — reading it here would leave the field this scan is
+     * supposed to cover invisible.
      */
     fun firstUnredactedMarker(tree: UiNode): String? =
-        tree.allText.firstNotNullOfOrNull { unredactedMarker(it) }
+        tree.scrubbableStrings().firstNotNullOfOrNull { (_, value) -> unredactedMarker(value) }
+            ?: tree.children.firstNotNullOfOrNull { firstUnredactedMarker(it) }
 
     /**
-     * Return a copy of [tree] with every node whose `text`/`contentDescription`
-     * carries an un-redacted customer marker scrubbed to [CompiledRedact.REDACTED].
-     * Call only after [firstUnredactedMarker] returned non-null, so the tree copy
-     * never happens on the clean path.
+     * Return a copy of [tree] with every node's marker-carrying string field
+     * scrubbed to [CompiledRedact.REDACTED] — per field, across the
+     * [UiNode.scrubbableStrings] SSOT (#835). Call only after
+     * [firstUnredactedMarker] returned non-null, so the tree copy never happens
+     * on the clean path.
      */
-    fun scrub(tree: UiNode): UiNode = tree.copy(
-        text = if (unredactedMarker(tree.text) != null) CompiledRedact.REDACTED else tree.text,
-        contentDescription =
-            if (unredactedMarker(tree.contentDescription) != null) {
-                CompiledRedact.REDACTED
-            } else {
-                tree.contentDescription
-            },
-        children = tree.children.map { scrub(it) },
-    )
+    fun scrub(tree: UiNode): UiNode = tree
+        .mapScrubbableStrings { if (unredactedMarker(it) != null) CompiledRedact.REDACTED else it }
+        .copy(children = tree.children.map { scrub(it) })
 
     // --- Node-id path, UNKNOWN envelopes only (#910) --------------------------
 
@@ -175,8 +177,11 @@ object CustomerTextMarkers {
         val id = node.viewIdResourceName
         if (id.isNullOrEmpty()) return null
         val marker = ID_MARKERS.firstOrNull { id.endsWith(it, ignoreCase = true) } ?: return null
-        val carriesRaw = sequenceOf(node.text, node.contentDescription)
-            .any { !it.isNullOrEmpty() && !it.contains(REDACTED_MARK) }
+        // #835: every serialized string field counts as "still carrying raw" — a
+        // customer-PII node whose only remaining value is its `stateDescription`
+        // must still be scrubbed.
+        val carriesRaw = node.scrubbableStrings()
+            .any { (_, value) -> !value.isNullOrEmpty() && !value.contains(REDACTED_MARK) }
         return if (carriesRaw) marker else null
     }
 
@@ -197,16 +202,14 @@ object CustomerTextMarkers {
      */
     fun scrubUnknown(tree: UiNode): UiNode {
         val byId = unredactedIdMarker(tree) != null
-        return tree.copy(
-            text = if (byId || unredactedMarker(tree.text) != null) CompiledRedact.REDACTED else tree.text,
-            contentDescription =
-                if (byId || unredactedMarker(tree.contentDescription) != null) {
-                    CompiledRedact.REDACTED
-                } else {
-                    tree.contentDescription
-                },
-            children = tree.children.map { scrubUnknown(it) },
-        )
+        // An id hit scrubs the node WHOLE (every field of the
+        // [UiNode.scrubbableStrings] SSOT, #835); otherwise each field is judged
+        // on its own text marker.
+        return tree
+            .mapScrubbableStrings {
+                if (byId || unredactedMarker(it) != null) CompiledRedact.REDACTED else it
+            }
+            .copy(children = tree.children.map { scrubUnknown(it) })
     }
 
     // --- Notification path (#632) --------------------------------------------

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
@@ -219,15 +219,19 @@ object SensitiveTextMarkers {
      * Scan the tree's text for a sensitive marker. Returns the first
      * matched marker (for logging) or null when clean.
      *
-     * The whole `allText` is joined on a space and scanned as ONE normalized blob
-     * (#590): a keyword within a single node stays intact, AND a keyword split
-     * across adjacent sibling nodes ("Bank" | "Account") rejoins across the space.
-     * Uses the existing `allText` walk — no new tree traversal. FAIL-CLOSED: any
-     * throw in normalization returns the toxic sentinel (drop the capture), never
-     * null.
+     * The whole tree's scrubbable text is joined on a space and scanned as ONE
+     * normalized blob (#590): a keyword within a single node stays intact, AND a
+     * keyword split across adjacent sibling nodes ("Bank" | "Account") rejoins
+     * across the space. FAIL-CLOSED: any throw in normalization returns the toxic
+     * sentinel (drop the capture), never null.
+     *
+     * Reads [UiNode.allScrubbableText] — the PRIVACY-side collection — rather
+     * than the recognition-side `allText` (#835), so a marker riding a node's
+     * `stateDescription` drops the capture too. `allText` deliberately excludes
+     * that field because rules match on it; this scan must not.
      */
     fun findMarker(tree: UiNode): String? = try {
-        scan(normalize(tree.allText.joinToString(" ")))
+        scan(normalize(tree.allScrubbableText().joinToString(" ")))
     } catch (_: Throwable) {
         NORMALIZE_FAILED
     }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
@@ -167,8 +167,10 @@ enum class RedactNormalize {
 }
 
 /**
- * A single compiled `redact` directive (#598). When [find] matches a node, that
- * node's `text` and `contentDescription` are masked in the serialized capture
+ * A single compiled `redact` directive (#598). When [find] matches a node, ALL
+ * of that node's serialized string fields — `text`, `contentDescription` and
+ * (since #835) `stateDescription`, per the [UiNode.scrubbableStrings] SSOT — are
+ * masked in the serialized capture
  * envelope only. [keepPrefix] preserves a leading marker label so a replayed
  * redacted capture still recognizes — e.g. "Deliver to <name>" is masked to
  * "Deliver to [redacted:<4hex>]", keeping the "Deliver to " require anchor while
@@ -220,15 +222,19 @@ data class CompiledRedact(
 
     private fun maskNode(node: UiNode): UiNode {
         val match = entries.firstOrNull { it.find(node) }
-        val maskedText =
-            if (match != null) mask(node.text, match.keepPrefix, match.normalize, match.plainMask) else node.text
-        val maskedDesc =
-            if (match != null) mask(node.contentDescription, match.keepPrefix, match.normalize, match.plainMask) else node.contentDescription
-        return node.copy(
-            text = maskedText,
-            contentDescription = maskedDesc,
-            children = node.children.map { maskNode(it) },
-        )
+        // #835: mask EVERY serialized string field of the matched node via the
+        // UiNode scrubbable-fields SSOT — `stateDescription` used to be skipped
+        // here, so a matched node's `state` shipped verbatim. Each field is
+        // masked from its OWN content, so the #623 distinctness suffix, the #889
+        // short-token floor and the #795 plainMask semantics apply per field
+        // exactly as they did for text/desc.
+        val maskedSelf =
+            if (match != null) {
+                node.mapScrubbableStrings { mask(it, match.keepPrefix, match.normalize, match.plainMask) }
+            } else {
+                node
+            }
+        return maskedSelf.copy(children = node.children.map { maskNode(it) })
     }
 
     companion object {

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/StateDescriptionScrubTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/StateDescriptionScrubTest.kt
@@ -1,0 +1,303 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.core.pipeline.accessibility.TreeSnapshot
+import cloud.trotter.dashbuddy.core.pipeline.rules.CompiledRedact
+import cloud.trotter.dashbuddy.core.pipeline.rules.CompiledRedactEntry
+import cloud.trotter.dashbuddy.core.pipeline.rules.NoRedaction
+import cloud.trotter.dashbuddy.core.pipeline.rules.RuleCompiler
+import cloud.trotter.dashbuddy.core.pipeline.rules.ScreenRedactionSource
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNodeTextField
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.pipeline.UNKNOWN_TARGET
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * #835 — `stateDescription` joins every scrub/redact layer.
+ *
+ * The field is captured (SDK ≥ R, `AccessibilityNodeMapper`) and serialized as
+ * `"state"`, but every layer hand-listed `text` + `contentDescription`, so a
+ * third-party view that mirrors content into `stateDescription` (toggles,
+ * sliders and custom controls do) would ship it verbatim on BOTH the recognized
+ * (rule `redact`) and the UNKNOWN (marker backstop) paths.
+ *
+ * Latent, not fielded: no committed fixture puts PII there today. These tests
+ * are the standing proof that all four layers now read the one
+ * [UiNode.scrubbableStrings] SSOT — several iterate [UiNodeTextField.entries] so
+ * a field added to the enum without a scrub site fails HERE.
+ */
+class StateDescriptionScrubTest {
+
+    private val captureBus: CaptureBus = mock { on { isEnabled } doReturn true }
+    private val stats = PipelineStats()
+
+    private fun screenEvent(tree: UiNode) = PipelineEvent.Screen(
+        timestamp = 1_000L,
+        tree = tree,
+        snapshot = TreeSnapshot(tree = tree, packageName = "com.doordash.driverapp"),
+        packageName = "com.doordash.driverapp",
+    )
+
+    private fun obs(ruleId: String?, target: String) = Observation.Screen(
+        timestamp = 1_000L,
+        captureId = null,
+        ruleId = ruleId,
+        metadata = ReplayMetadata.EMPTY,
+        flow = null,
+        modeHint = null,
+        parsed = ParsedFields.None,
+        target = target,
+    )
+
+    private fun unknownClickObs() = Observation.Click(
+        timestamp = 1_000L,
+        captureId = null,
+        ruleId = null,
+        metadata = ReplayMetadata.EMPTY,
+        flow = null,
+        modeHint = null,
+        parsed = ParsedFields.None,
+        target = UNKNOWN_TARGET,
+    )
+
+    private fun sourceFor(forRuleId: String, redact: CompiledRedact) = object : ScreenRedactionSource {
+        override fun redactFor(ruleId: String): CompiledRedact? = redact.takeIf { ruleId == forRuleId }
+    }
+
+    private fun writer(source: ScreenRedactionSource = NoRedaction) =
+        CaptureWriter(captureBus, stats, source)
+
+    private fun capturedEnvelope(): String {
+        val cap = argumentCaptor<String>()
+        verify(captureBus).offer(any(), any(), anyOrNull(), any(), cap.capture(), anyOrNull())
+        return cap.lastValue
+    }
+
+    /**
+     * A node carrying [value] in exactly ONE field. The `when` is exhaustive on
+     * purpose: adding a [UiNodeTextField] entry breaks compilation here until the
+     * new field is given a builder, so the per-field sweeps below cannot silently
+     * skip it.
+     */
+    private fun nodeCarrying(field: UiNodeTextField, value: String, id: String? = null) = when (field) {
+        UiNodeTextField.TEXT -> UiNode(text = value, viewIdResourceName = id)
+        UiNodeTextField.CONTENT_DESCRIPTION -> UiNode(contentDescription = value, viewIdResourceName = id)
+        UiNodeTextField.STATE_DESCRIPTION -> UiNode(stateDescription = value, viewIdResourceName = id)
+    }
+
+    // =========================================================================
+    // (a) the rule-declared redact — the recognized path
+    // =========================================================================
+
+    /** A dropoff-shaped block: whatever node carries the address id is masked whole. */
+    private val addressRedact = CompiledRedact(
+        listOf(
+            CompiledRedactEntry(
+                find = RuleCompiler.compileNodePred(
+                    Json.parseToJsonElement("""{"hasIdSuffix":"address_line_1"}"""),
+                ),
+            ),
+        ),
+    )
+
+    @Test
+    fun `a redact entry masks a PII-bearing stateDescription on the matched node`() {
+        busAcceptsOffer()
+        val tree = UiNode(
+            children = listOf(
+                UiNode(
+                    viewIdResourceName = "com.doordash:id/address_line_1",
+                    text = "123 Secret St",
+                    stateDescription = "123 Secret St, Springfield ZZ 78254",
+                ),
+                UiNode(text = "Directions"),
+            ),
+        )
+
+        writer(sourceFor("doordash.screen.dropoff_navigation", addressRedact))
+            .captureScreen(obs("doordash.screen.dropoff_navigation", "dropoff_navigation"), screenEvent(tree))
+
+        val json = capturedEnvelope()
+        assertFalse("street address must not persist in text", json.contains("123 Secret St"))
+        assertFalse(
+            "street address must not persist in stateDescription (#835)",
+            json.contains("Springfield ZZ 78254"),
+        )
+        assertTrue(
+            "the state field is masked, not dropped",
+            Regex(""""state": "\[redacted(:[0-9a-f]{4})?]"""").containsMatchIn(json),
+        )
+        assertTrue("non-PII node intact", json.contains("Directions"))
+    }
+
+    @Test
+    fun `the redact mask covers every scrubbable field of a matched node`() {
+        // The tripwire: ALL fields set on one matched node, none may survive raw.
+        val matched = UiNode(
+            viewIdResourceName = "com.doordash:id/address_line_1",
+            text = "PII-IN-TEXT",
+            contentDescription = "PII-IN-DESC",
+            stateDescription = "PII-IN-STATE",
+        )
+        val masked = addressRedact.apply(matched)
+
+        for ((field, value) in masked.scrubbableStrings()) {
+            assertNotNull("$field must still be present (masked, not dropped)", value)
+            assertTrue(
+                "$field must be masked by the redact block",
+                value!!.startsWith("[redacted"),
+            )
+        }
+    }
+
+    @Test
+    fun `an unmatched node keeps every field, state included`() {
+        val untouched = UiNode(
+            viewIdResourceName = "com.doordash:id/store_name",
+            text = "SPROUTS FARMERS MARKET #118",
+            stateDescription = "Selected",
+        )
+        assertEquals(untouched.scrubbableStrings(), addressRedact.apply(untouched).scrubbableStrings())
+    }
+
+    // =========================================================================
+    // (b) the customer-marker backstop — recognized AND UNKNOWN paths
+    // =========================================================================
+
+    @Test
+    fun `the customer text-marker scan sees a marker in any scrubbable field`() {
+        for (field in UiNodeTextField.entries) {
+            val tree = UiNode(children = listOf(nodeCarrying(field, "Deliver to Jane Q. Doe")))
+            assertEquals(
+                "marker riding $field must be found",
+                "Deliver to ",
+                CustomerTextMarkers.firstUnredactedMarker(tree),
+            )
+            val scrubbed = CustomerTextMarkers.scrub(tree)
+            assertFalse(
+                "marker riding $field must be scrubbed",
+                scrubbed.allScrubbableText().any { it.contains("Jane Q. Doe") },
+            )
+        }
+    }
+
+    @Test
+    fun `an UNKNOWN screen carrying a customer marker in stateDescription is scrubbed, not shipped raw`() {
+        busAcceptsOffer()
+        val tree = UiNode(
+            children = listOf(
+                UiNode(text = "Current task"),
+                UiNode(stateDescription = "Deliver to Jane Q. Doe"),
+            ),
+        )
+
+        writer().captureScreen(obs(null, UNKNOWN_TARGET), screenEvent(tree))
+
+        val json = capturedEnvelope()
+        assertFalse("customer name must not persist", json.contains("Jane Q. Doe"))
+        assertTrue("the frame still captures for triage", json.contains("Current task"))
+        assertEquals(1L, stats.unknownCustomerScrubCount)
+    }
+
+    @Test
+    fun `the customer-PII node-id scan treats a state-only value as still raw`() {
+        for (field in UiNodeTextField.entries) {
+            val node = nodeCarrying(field, "Jane Q. Doe", id = "com.doordash:id/user_name")
+            assertEquals(
+                "a customer-PII id whose value rides $field must scrub",
+                "user_name",
+                CustomerTextMarkers.unredactedIdMarker(node),
+            )
+            val scrubbed = CustomerTextMarkers.scrubUnknown(node)
+            assertFalse(
+                "the id scrub must mask $field",
+                scrubbed.allScrubbableText().any { it.contains("Jane Q. Doe") },
+            )
+        }
+    }
+
+    @Test
+    fun `an already-masked node is not re-scrubbed regardless of which field holds the mask`() {
+        for (field in UiNodeTextField.entries) {
+            val node = nodeCarrying(field, CompiledRedact.REDACTED, id = "com.doordash:id/user_name")
+            assertNull(
+                "an all-masked node must not re-trip the id scan via $field",
+                CustomerTextMarkers.unredactedIdMarker(node),
+            )
+        }
+    }
+
+    // =========================================================================
+    // (c) the dasher-sensitive backstop — the whole capture is DROPPED
+    // =========================================================================
+
+    @Test
+    fun `a sensitive marker riding stateDescription is found by the fail-closed scan`() {
+        for (field in UiNodeTextField.entries) {
+            val tree = UiNode(children = listOf(nodeCarrying(field, "Available Balance")))
+            assertEquals(
+                "a banking marker in $field must drop the capture",
+                "Available Balance",
+                SensitiveTextMarkers.findMarker(tree),
+            )
+        }
+    }
+
+    @Test
+    fun `an UNKNOWN screen whose sensitive marker rides stateDescription is never offered to the bus`() {
+        val toxic = UiNode(children = listOf(UiNode(stateDescription = "Routing Number 021000021")))
+        writer().captureScreen(obs(null, UNKNOWN_TARGET), screenEvent(toxic))
+
+        verify(captureBus, never()).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertEquals(1L, stats.scrubbedUnknownCaptureCount)
+    }
+
+    @Test
+    fun `an UNKNOWN click whose sensitive marker rides stateDescription is never offered to the bus`() {
+        val toxic = UiNode(text = "Confirm", stateDescription = "Transfer out", isClickable = true)
+        writer().captureClick(
+            unknownClickObs(),
+            PipelineEvent.Click(timestamp = 1_000L, node = toxic, packageName = "com.doordash.driverapp"),
+            screenTarget = null,
+            screenRuleId = null,
+        )
+
+        verify(captureBus, never()).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertEquals(1L, stats.scrubbedUnknownCaptureCount)
+    }
+
+    @Test
+    fun `a benign state value still captures - the widened scan is not a blanket drop`() {
+        busAcceptsOffer()
+        val benign = UiNode(children = listOf(UiNode(text = "Dash now", stateDescription = "Not selected")))
+        writer().captureScreen(obs(null, UNKNOWN_TARGET), screenEvent(benign))
+
+        verify(captureBus, times(1)).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertEquals(0L, stats.scrubbedUnknownCaptureCount)
+        assertEquals(0L, stats.unknownCustomerScrubCount)
+        assertTrue("benign state text survives for triage", capturedEnvelope().contains("Not selected"))
+    }
+
+    private fun busAcceptsOffer() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull()))
+            .thenReturn("cap-1")
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/UiNode.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/UiNode.kt
@@ -17,6 +17,8 @@ import java.util.Locale
  *  In this file
  *    - the equals function
  *    - the hashcode function
+ *    - [UiNodeTextField] + [scrubbableStrings] / [mapScrubbableStrings], if the new
+ *      property is a STRING the capture envelope serializes (#835)
  *  In :core:database
  *  - UiNodeDto
  *  - UiNode.toDto
@@ -239,12 +241,80 @@ data class UiNode(
         get() = !viewIdResourceName.isNullOrBlank()
 
     // ========================================================================
+    //  SCRUBBABLE STRING FIELDS (#835)
+    //  The privacy-side enumeration of this node's serialized string values.
+    //  Deliberately SEPARATE from the recognition-side [allText] — see the
+    //  [UiNodeTextField] KDoc for why the two must not be merged.
+    // ========================================================================
+
+    /**
+     * This node's own scrubbable string values, paired with their field identity
+     * (#835). The SSOT every scrub/redact/scan site iterates instead of
+     * hand-listing `text` + `contentDescription` — a string field added to this
+     * class is covered by every reader the moment it joins [UiNodeTextField],
+     * rather than silently missing a scrub site (which is exactly how
+     * [stateDescription] shipped outside every layer).
+     *
+     * Values are returned RAW (nulls and blanks included) so a caller can decide
+     * its own emptiness policy; [allScrubbableText] is the non-blank tree-wide
+     * collection.
+     */
+    fun scrubbableStrings(): List<Pair<UiNodeTextField, String?>> = listOf(
+        UiNodeTextField.TEXT to text,
+        UiNodeTextField.CONTENT_DESCRIPTION to contentDescription,
+        UiNodeTextField.STATE_DESCRIPTION to stateDescription,
+    )
+
+    /**
+     * A copy of THIS node (children untouched) with every scrubbable string
+     * rewritten through [transform] (#835). The write-side twin of
+     * [scrubbableStrings] and the ONE place the fields are enumerated for
+     * writing — a masker/scrubber that uses it cannot forget a field.
+     *
+     * [transform] receives each value as-is (null included) and returns the
+     * replacement; returning the argument leaves the field untouched. Note the
+     * returned copy has no wired [parent] (as with any `copy`), which the
+     * envelope serializers ignore.
+     */
+    fun mapScrubbableStrings(transform: (String?) -> String?): UiNode = copy(
+        text = transform(text),
+        contentDescription = transform(contentDescription),
+        stateDescription = transform(stateDescription),
+    )
+
+    /**
+     * Every non-blank scrubbable string in this subtree, DFS (#835) — the
+     * privacy-side counterpart of [allText], which recognition owns.
+     *
+     * Deliberately NOT memoized: it is built once per capture envelope at the
+     * tree root, whereas [allText] is read per node per rule, so a `by lazy`
+     * field here would cost memory on every node for a value almost none of
+     * them are asked for.
+     */
+    fun allScrubbableText(): List<String> {
+        val results = mutableListOf<String>()
+        collectScrubbableText(this, results)
+        return results
+    }
+
+    private fun collectScrubbableText(node: UiNode, list: MutableList<String>) {
+        for ((_, value) in node.scrubbableStrings()) {
+            if (!value.isNullOrBlank()) list.add(value)
+        }
+        node.children.forEach { collectScrubbableText(it, list) }
+    }
+
+    // ========================================================================
     //  DATA COLLECTION (Lazy)
     // ========================================================================
 
     /**
      * Collects all text and content descriptions from the entire tree.
      * Used primarily by Screen Recognizers.
+     *
+     * RECOGNITION SSOT — deliberately EXCLUDES [stateDescription] (#835). Rules
+     * match on this list, so folding a new field in would shift classification
+     * corpus-wide; the privacy layers read [allScrubbableText] instead.
      */
     val allText: List<String> by lazy {
         val results = mutableListOf<String>()
@@ -326,6 +396,39 @@ data class UiNode(
         for (child in node.children) {
             appendNode(builder, child, indent + 1)
         }
+    }
+}
+
+/**
+ * The string fields a [UiNode] carries into a capture envelope (#835) — the
+ * screen-node analogue of `NotifTextField` (#666), and the SSOT every scrub /
+ * redact / PII-scan site enumerates via [UiNode.scrubbableStrings] /
+ * [UiNode.mapScrubbableStrings] / [UiNode.allScrubbableText].
+ *
+ * Why it exists: `stateDescription` is captured (SDK ≥ R) and serialized as
+ * `"state"`, but every scrub layer hand-listed `text` + `contentDescription`, so
+ * a third-party view that mirrors its label into `stateDescription` (toggles,
+ * sliders, custom controls do) would have shipped it verbatim on both the
+ * recognized and the UNKNOWN path. Enumerating once makes the NEXT added field a
+ * compile-visible gap instead of a silent leak channel.
+ *
+ * This is a PRIVACY enumeration, not a recognition one: [UiNode.allText] (what
+ * rules match on) is deliberately narrower and stays untouched, so widening
+ * scrub coverage can never move a classification.
+ *
+ * [wire] is the capture-envelope JSON key (`UiNodeDto`'s `@SerialName`), so
+ * JSON-level tooling (the corpus `SnapshotRedactor`) keys off this list too.
+ * Annotation arguments must be compile-time constants, so `UiNodeDto` cannot
+ * reference these directly — `UiNodeScrubbableFieldsTest` pins the two in sync.
+ */
+enum class UiNodeTextField(val wire: String) {
+    TEXT("text"),
+    CONTENT_DESCRIPTION("desc"),
+    STATE_DESCRIPTION("state"),
+    ;
+
+    companion object {
+        fun fromWire(wire: String): UiNodeTextField? = entries.firstOrNull { it.wire == wire }
     }
 }
 

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/accessibility/UiNodeScrubbableFieldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/accessibility/UiNodeScrubbableFieldsTest.kt
@@ -1,0 +1,153 @@
+package cloud.trotter.dashbuddy.domain.model.accessibility
+
+import cloud.trotter.dashbuddy.domain.capture.dto.BoundingBoxDto
+import cloud.trotter.dashbuddy.domain.capture.dto.UiNodeDto
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #835 — the [UiNodeTextField] scrubbable-fields SSOT.
+ *
+ * `stateDescription` was captured and serialized but sat outside every scrub
+ * layer because each layer hand-listed `text` + `contentDescription`. These pin
+ * the enumeration that closed it: its membership, its wire names, and the
+ * deliberate NON-membership of the recognition-side [UiNode.allText].
+ */
+class UiNodeScrubbableFieldsTest {
+
+    private fun node(
+        text: String? = null,
+        desc: String? = null,
+        state: String? = null,
+    ) = UiNode(text = text, contentDescription = desc, stateDescription = state)
+
+    /**
+     * The value a fully-populated [UiNodeDto] carries in [field]. An exhaustive
+     * `when` on purpose: a new [UiNodeTextField] entry breaks compilation here
+     * until it is wired into the DTO check below, so the wire-name pin can never
+     * silently skip a field.
+     */
+    private fun dtoSentinel(field: UiNodeTextField): String = when (field) {
+        UiNodeTextField.TEXT -> "TEXT-VALUE"
+        UiNodeTextField.CONTENT_DESCRIPTION -> "DESC-VALUE"
+        UiNodeTextField.STATE_DESCRIPTION -> "STATE-VALUE"
+    }
+
+    @Test
+    fun `scrubbableStrings enumerates every serialized string field of the node`() {
+        val n = node(text = "T", desc = "D", state = "S")
+        assertEquals(
+            listOf(
+                UiNodeTextField.TEXT to "T",
+                UiNodeTextField.CONTENT_DESCRIPTION to "D",
+                UiNodeTextField.STATE_DESCRIPTION to "S",
+            ),
+            n.scrubbableStrings(),
+        )
+    }
+
+    @Test
+    fun `scrubbableStrings reports raw values including nulls`() {
+        val n = node(text = "T")
+        assertEquals(listOf("T", null, null), n.scrubbableStrings().map { it.second })
+    }
+
+    @Test
+    fun `mapScrubbableStrings rewrites every field and leaves the rest of the node alone`() {
+        val original = UiNode(
+            text = "T",
+            contentDescription = "D",
+            stateDescription = "S",
+            viewIdResourceName = "com.app:id/thing",
+            className = "android.widget.TextView",
+            isClickable = true,
+            boundsInScreen = BoundingBox(1, 2, 3, 4),
+            children = listOf(node(text = "child")),
+        )
+
+        val masked = original.mapScrubbableStrings { if (it != null) "[x]" else null }
+
+        assertEquals(listOf("[x]", "[x]", "[x]"), masked.scrubbableStrings().map { it.second })
+        // Non-string identity fields and the children list are untouched.
+        assertEquals(original.viewIdResourceName, masked.viewIdResourceName)
+        assertEquals(original.className, masked.className)
+        assertEquals(original.isClickable, masked.isClickable)
+        assertEquals(original.boundsInScreen, masked.boundsInScreen)
+        assertEquals(original.children, masked.children)
+        // Copy semantics: the source node is never mutated.
+        assertEquals("T", original.text)
+    }
+
+    @Test
+    fun `mapScrubbableStrings sees nulls so a transform can distinguish absent from empty`() {
+        val seen = mutableListOf<String?>()
+        node(text = "T", state = "S").mapScrubbableStrings { seen.add(it); it }
+        assertEquals(listOf("T", null, "S"), seen)
+    }
+
+    @Test
+    fun `allScrubbableText collects every non-blank field across the whole tree`() {
+        val tree = UiNode(
+            text = "root",
+            stateDescription = "  ", // blank -> dropped, same policy as allText
+            children = listOf(
+                node(desc = "childDesc", state = "childState"),
+                node(text = "leaf"),
+            ),
+        )
+        assertEquals(
+            listOf("root", "childDesc", "childState", "leaf"),
+            tree.allScrubbableText(),
+        )
+    }
+
+    /**
+     * Decision 1 of the #835 plan, pinned: recognition must NOT change. `allText`
+     * is what every rule predicate matches on, so folding `stateDescription` into
+     * it would shift classification corpus-wide — the privacy layers read
+     * [UiNode.allScrubbableText] instead.
+     */
+    @Test
+    fun `allText deliberately excludes stateDescription while allScrubbableText includes it`() {
+        val tree = UiNode(
+            text = "visible",
+            contentDescription = "described",
+            stateDescription = "stateful",
+        )
+        assertEquals(listOf("visible", "described"), tree.allText)
+        assertFalse("recognition must not see state", tree.allTextLowerJoined.contains("stateful"))
+        assertTrue("the scrub layers must see state", tree.allScrubbableText().contains("stateful"))
+    }
+
+    /**
+     * [UiNodeTextField.wire] is the capture-envelope JSON key. Annotation
+     * arguments must be compile-time constants, so `UiNodeDto`'s `@SerialName`s
+     * cannot reference the enum — this is the tripwire that keeps the two copies
+     * from drifting (a JSON-level consumer, the corpus `SnapshotRedactor`, keys
+     * off the enum).
+     */
+    @Test
+    fun `wire names match the capture DTO serial names`() {
+        val dto = UiNodeDto(
+            text = dtoSentinel(UiNodeTextField.TEXT),
+            contentDescription = dtoSentinel(UiNodeTextField.CONTENT_DESCRIPTION),
+            stateDescription = dtoSentinel(UiNodeTextField.STATE_DESCRIPTION),
+            boundsInScreen = BoundingBoxDto(0, 0, 0, 0),
+        )
+        val obj = Json.parseToJsonElement(Json.encodeToString(UiNodeDto.serializer(), dto)).jsonObject
+
+        for (field in UiNodeTextField.entries) {
+            assertEquals(
+                "UiNodeDto must serialize ${field.name} under the wire key '${field.wire}'",
+                dtoSentinel(field),
+                obj[field.wire]?.jsonPrimitive?.content,
+            )
+            assertEquals(field, UiNodeTextField.fromWire(field.wire))
+        }
+    }
+}


### PR DESCRIPTION
`UiNode.stateDescription` is captured (`AccessibilityNodeMapper`, SDK ≥ R, length-capped since #850) and serialized into every capture envelope as `UiNodeDto @SerialName("state")` — but **every scrub layer hand-listed `text` + `contentDescription`**, so the field sat outside all of them: the rule-declared `redact` mask, both marker backstops, and the corpus PII scanner.

**Latent gap, not a fielded leak.** No committed fixture puts PII in `state` today (the corpus's 202 populated `"state"` values are benign UI states — `"Not selected"`, `"50%"`, `"in progress"`). But the exposure is real and structural: any third-party view that mirrors its label into `stateDescription` — toggles, sliders and custom controls routinely do — would have shipped a customer name/address verbatim to disk on **both** the recognized path (a rule's `redact` matched the node and masked only two of its three strings) and the UNKNOWN path (neither `CustomerTextMarkers` nor `SensitiveTextMarkers` could see it, so the drop/scrub never fired).

## The fix: one enumeration, not four hand-lists

New SSOT in `:domain` — `UiNodeTextField` + `UiNode.scrubbableStrings()` / `mapScrubbableStrings()` / `allScrubbableText()` — the screen-node edition of the #666 `RawNotificationData.textFields()` pattern. Every scrub/redact/scan site iterates it, so the **next** string field added to `UiNode` cannot silently miss a site (principle 5).

Converted consumers (the full `grep -rn "contentDescription"` sweep over `core/pipeline` + `app/src/test`, per plan step 3):

| Site | Layer | Change |
|---|---|---|
| `CompiledRedact.maskNode` (`:core:pipeline`) | recognized `redact` | matched node masks **all three** fields; each hashed from its OWN content, so #623 distinctness / #889 short-token floor / #795 `plainMask` semantics apply per field unchanged |
| `CustomerTextMarkers.firstUnredactedMarker` | recognized + UNKNOWN | short-circuiting tree walk over `scrubbableStrings()` (was `allText`, which structurally excludes `state`) |
| `CustomerTextMarkers.scrub` / `scrubUnknown` | recognized + UNKNOWN | `mapScrubbableStrings` — the #910 id-keyed arm scrubs the node WHOLE, state included |
| `CustomerTextMarkers.unredactedIdMarker` | UNKNOWN (#910) | `carriesRaw` counts a state-only value as still raw |
| `SensitiveTextMarkers.findMarker(tree)` | UNKNOWN drop | scans `allScrubbableText()`, so a banking marker riding `state` drops the capture |
| `SnapshotSecurityScanner` (app test util) | corpus commit gate | #803 pin/gate shape walk + the trigger-evidence blob |
| `SnapshotRedactor.collectNode` (app test util) | corpus commit gate | already handled `"state"` by hand — now keys off `UiNodeTextField.wire` so it can't drift |
| `CaptureRedactionCorpusTest.walkText` | corpus assertion | the FIX-4 bare-name leak walk now covers all three fields |

Deliberately **not** converted (not scrub walks): `CompilerHelpers.readProperty` / `PredicateCompiler` (recognition vocabulary), `UiInteractionHandler` label collection (actuation), `SnapshotScreenDiagnostics` / `UnknownScreenAnalysisTest` (X-ray triage reports).

## Scoping (plan decision 4) — MASK side only

The issue also notes that content-shape redact predicates (`hasTextMatchesRegex` & co.) find on `text` only, so a PII-bearing `stateDescription` can't be *targeted* by a shape entry. That is left alone on purpose: find-predicates are recognition-coupled (a rule's `redact` block is evaluated against the original tree with the same predicate compiler rules recognition uses), and widening them would change which nodes match. The gap this issue names is the MASK side — an entry that already matched a node leaving one of its fields raw — and the SSOT closes exactly that. A rule that needs to *target* a state-borne value can still do so by id/sibling anchors; a shape predicate over `state` would be a separate, deliberate DSL addition.

## Recognition is byte-identical (plan decision 1)

`UiNode.allText` / `allTextLowerJoined` / every rule predicate are untouched — `allText` still excludes `stateDescription` and is now KDoc'd as the RECOGNITION SSOT, with `allScrubbableText()` as its privacy-side counterpart. Widening a scrub layer must never be able to move a classification. `ParseOutputGoldenTest` and `GoldenSnapshotRegressionTest` are green **with no regen**; `approved-parse-output.json` and the corpus are untouched (`git status` clean after a full suite run).

## Tests

- `UiNodeScrubbableFieldsTest` (`:domain`, 7): membership, raw-null reporting, `mapScrubbableStrings` copy semantics, `allScrubbableText` tree collection + blank policy, the **`allText`-excludes-state / `allScrubbableText`-includes-state** invariant, and a **wire-name pin** (`UiNodeDto`'s `@SerialName`s vs the enum, via an exhaustive `when` — a new entry breaks compilation until it's covered).
- `StateDescriptionScrubTest` (`:core:pipeline`, 11): (a) a `redact` entry masks a PII-bearing `stateDescription` in the real envelope + the all-fields tripwire + an unmatched-node negative; (b) the customer text-marker scan and the #910 id scan sweep **every `UiNodeTextField.entries`** (exhaustive-`when` node builder = compile tripwire) and the already-masked skip holds per field; (c) an UNKNOWN screen and an UNKNOWN click whose *sensitive* marker rides `state` are never offered to the bus; plus a benign-`state` negative proving the widened scan is not a blanket drop.
- **Mutation-checked:** dropping `STATE_DESCRIPTION` from the SSOT turns 6 `:domain` + 7 `:core:pipeline` tests red across all four layers (verified, then reverted).

Verification run locally at CI parity: `./gradlew :app:assembleDebug`, `testDebugUnitTest :domain:test` (all modules), `:app:lintVitalRelease`, and `--tests "*AllMatchersSuite*"` — all green, working tree clean.

## Security & privacy posture

- **Trusted:** nothing new. The third-party accessibility tree remains untrusted input; this only *widens* what gets scrubbed out of it.
- **Gated:** unchanged. No new capture, no new field captured, no new network. `stateDescription` was already captured and already length-capped (#850).
- **Scrubbed:** strictly more than before — one additional serialized field at four layers, on both the recognized and UNKNOWN paths. Fail-closed direction throughout: the sensitive scan can now *drop* a capture it previously admitted, and the customer scan can now *mask* a value it previously shipped; neither can start admitting anything. Confirmed non-over-blocking on the committed corpus (`AllMatchersSuite` + `CaptureBackstopCorpusTest` green, zero reclassifications).

## Follow-up suggestion (not applied here)

Per instructions I did not touch `docs/field-testing/README.md`. Suggested checklist item for whoever owns it: *"#835 — after a dash, grep the new UNKNOWN/recognized captures for a populated `"state"` field carrying a name/address; expect `[redacted…]` or the frame absent entirely, never raw. Also confirm benign `"state"` values (`Not selected`, percentages) still survive for triage. Confirmed: 0/2."*

Closes #835

### Design-goal review

- **P5 (SSOT)** — the whole point: four hand-maintained field lists (plus two corpus-tool copies) collapse to one `UiNodeTextField` enumeration with read (`scrubbableStrings`), write (`mapScrubbableStrings`) and tree-collect (`allScrubbableText`) helpers. The one unavoidable duplicate — `UiNodeDto`'s `@SerialName` constants, which annotations cannot source from an enum — is pinned by a test rather than left to drift.
- **P6 (security & privacy first)** — closes a latent envelope-PII channel at the edge, on both frame classes, fail-closed in direction. Posture statement above. The recognized path keeps the rule's `redact` as primary control; the backstops stay backstops.
- **P3 (single responsibility)** — the enumeration lives with the model it describes; no consumer grew logic, each shed some.
- **P4 (idiomatic Kotlin)** — data-class `copy` helper, exhaustive `when` over the enum in tests as a compile-time tripwire, no new mutable state.
- **P8 (platform-agnostic core)** — touches `:domain` + `:core:pipeline`: no platform literal added or read; the change is a field enumeration, identical for every platform, and no rule/ruleset vocabulary changed.
- **P7 (logging)** — no log site added or moved. The existing `Pipeline` WARNs already name markers by log-safe id (#862) and are unaffected.
- **P1/P2, Reactive UI** — untouched (no state machine, no UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
