### PR TITLE
test: #947 — suite hardening (fuzz timing, parity hit-floor, addon-phantom pin, AllMatchersSuite membership)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/AddonPhantomReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/AddonPhantomReplayTest.kt
@@ -1,7 +1,7 @@
 package cloud.trotter.dashbuddy.replay
 
 import cloud.trotter.dashbuddy.test.util.SessionReplay
-import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
@@ -37,9 +37,23 @@ class AddonPhantomReplayTest {
     fun `the Burger King add-on offer frame is not misrecognized as a delivery summary (#564, Level A)`() {
         val obs = SessionReplay.replayRecognition(session).single()
         println("add-on frame → target=${obs.target} parsed=${obs.parsed::class.simpleName}")
-        assertNotEquals(
-            "an add-on offer frame must not classify as a delivery summary (would fabricate a \$0 completion)",
-            "delivery_summary_collapsed", obs.target,
+        // #947: pin the EXPECTED intent instead of only excluding the old bug's misfire.
+        // As of #888 this fixture is Shape B of `doordash.screen.offer_accepting` — the
+        // rule's own comment names this exact fixture
+        // (snapshots/sessions/addon_phantom_2026_06_21) as the frame it was written to catch.
+        // Verified correct by reading the rule (matchers/rules/doordash/offer.json5): Shape B's
+        // `require` demands `accept_decline_fragment_container` + `secondary_action_button_dash_plus`
+        // + a non-empty `display_name` that isn't "Customer dropoff"/"Business handoff" — i.e. the
+        // offer chrome is still on screen with the Accept footer torn down and a real store leg
+        // present, exactly the post-accept teardown frame this fixture captures. The rule is
+        // RECOGNIZE-ONLY (no `state.flow`/parse/bind), so classifying here cannot drive any
+        // lifecycle edge — recognition merely graduates the frame out of UNKNOWN, which is the
+        // guard this test exists to pin. NOTE: #935 may re-anchor `delivery_summary_collapsed`'s
+        // `require`, which could shift what this fixture classifies as — revisit this pin then.
+        assertEquals(
+            "the add-on offer teardown frame's classification drifted; it must never be " +
+                "delivery_summary_collapsed (would fabricate a \$0 completion)",
+            "offer_accepting", obs.target,
         )
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/ClassifyGateCaptureFuzzTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/ClassifyGateCaptureFuzzTest.kt
@@ -22,7 +22,6 @@ import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.checkAll
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -36,10 +35,16 @@ import org.mockito.kotlin.mock
  * [ObservationClassifier] wired to the PRODUCTION rules ([TestRulesetFactory]) and then
  * the real [CaptureWriter] fail-closed backstop. Asserts:
  *  - classify + capture never throw (no crash on hostile input);
- *  - each frame classifies + captures within a wall-clock budget (bounded time);
  *  - the fail-closed invariant: an UNKNOWN frame that reaches the capture bus NEVER
  *    carried a [SensitiveTextMarkers] hit — a toxic UNKNOWN is always dropped
  *    (post the #590 evasion hardening, homoglyph markers are caught too).
+ *
+ * **No wall-clock assertion (#947).** An earlier version asserted `elapsedMs < 2_000`
+ * inside this 200-sample property — exactly the CI-runner-jitter flake shape the #878
+ * seeding doctrine exists to kill (a slow CI host, not a real regression, would redden a
+ * *reproducible-looking* seeded property, defeating the point of seeding). The functional
+ * assertions above carry the test; a genuine hang is caught by the test-runner's own
+ * timeout, not a per-sample stopwatch.
  *
  * Pipeline-service stages (the accessibility gate/dedup) need Android services and are
  * out of scope; this exercises the classify + capture-scrub path directly, mirroring
@@ -48,8 +53,6 @@ import org.mockito.kotlin.mock
  * **Determinism (#878).** The seed below pins PR CI, so a failure is a reproducible
  * finding rather than a dice roll; bump it **deliberately** to explore new samples.
  * Unseeded breadth lives on the `-Ddashbuddy.propExplore=true` path ([PropSeeds]).
- * NOTE the wall-clock budget in this property is machine-dependent by nature — the
- * seed pins the INPUT trees, not the timing.
  */
 class ClassifyGateCaptureFuzzTest {
 
@@ -138,17 +141,13 @@ class ClassifyGateCaptureFuzzTest {
     )
 
     @Test
-    fun `property - adversarial trees never crash classify or capture, stay time-bounded, and never leak an UNKNOWN sensitive frame`() = runTest {
+    fun `property - adversarial trees never crash classify or capture, and never leak an UNKNOWN sensitive frame`() = runTest {
         checkAll(PropSeeds.samples(200), PropSeeds.config(SEED), treeArb) { tree ->
             val bus = RecordingBus()
             val writer = CaptureWriter(bus, PipelineStats(), noRedaction)
 
-            val start = System.nanoTime()
             val obs = classifier.classify(event(tree)) // must not throw
             writer.captureScreen(obs, event(tree))      // must not throw
-            val elapsedMs = (System.nanoTime() - start) / 1_000_000
-
-            assertTrue("classify+capture took ${elapsedMs}ms — not time-bounded", elapsedMs < 2_000)
 
             // Fail-closed invariant: a toxic UNKNOWN frame is always dropped before the bus.
             if (obs.target == UNKNOWN_TARGET && bus.offered) {

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatchersSuite.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatchersSuite.kt
@@ -1,14 +1,17 @@
 package cloud.trotter.dashbuddy.test.suites
 
 import cloud.trotter.dashbuddy.core.pipeline.CaptureBackstopCorpusTest
+import cloud.trotter.dashbuddy.core.pipeline.RuleIdLogSafetyTest
 import cloud.trotter.dashbuddy.core.pipeline.SensitiveMarkerAssetCoverageTest
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.view.clicked.ClickClassifierTest
 import cloud.trotter.dashbuddy.core.pipeline.notification.NotificationClassifierTest
 import cloud.trotter.dashbuddy.core.pipeline.recognition.matchers.GoldenSnapshotRegressionTest
 import cloud.trotter.dashbuddy.core.pipeline.recognition.matchers.OfferPipelineTest
+import cloud.trotter.dashbuddy.core.pipeline.recognition.matchers.PickupNoCustomerIdentityTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.CaptureRedactionCorpusTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.ClickRulesetTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.DefaultRulesIntegrationTest
+import cloud.trotter.dashbuddy.core.pipeline.rules.GoPuffRecognitionTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.NotificationRulesetTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.ParseOutputGoldenTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.ScreenRulesetTest
@@ -17,6 +20,7 @@ import cloud.trotter.dashbuddy.core.pipeline.rules.UberDeclineClickRuleTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.UberHomeDashboardOfflineEvidenceTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.UberIdleMapOfflineEvidenceTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.UberOfferExpiryOverlayTest
+import cloud.trotter.dashbuddy.core.pipeline.rules.UberOfferKindAndStackStoreTest
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
 
@@ -78,6 +82,41 @@ import org.junit.runners.Suite
  *   resulting `OfferEvaluation` — proves the recognition→parse→evaluate wiring, not just the
  *   evaluator math (Layer 1, `:domain`'s `OfferEvaluatorTest`). Pure/side-effect-free like the rest
  *   of this suite (no state machine, DB, or UI).
+ * - [PickupNoCustomerIdentityTest] — #548: source-scans every generated rule for the structural
+ *   invariant that a PICKUP surface never parses a customer identity (the #526 D6a
+ *   `customerNameHash` exception is node-pinned and separately asserted).
+ * - [RuleIdLogSafetyTest] — #862 review LOW-2: every reachable (non-sensitive) rule id is
+ *   [cloud.trotter.dashbuddy.core.pipeline.SensitiveTextMarkers]-clean, so a rule id can never
+ *   self-scrub the recognized-frame backstop WARN that interpolates it.
+ * - [GoPuffRecognitionTest] — #501: the GoPuff (DoorDash Drive) warehouse batch-pickup branches
+ *   (bin-scan arrival anchor, wait-survey/barcode-failure/multi-order-confirm recognize-only,
+ *   the hand-built zone-arrival CTA fixtures) against the real production ruleset.
+ * - [UberOfferKindAndStackStoreTest] — #881/#882: the Uber stacked-card `Delivery (N)` chip wins
+ *   the top-level display store but NOT the `orders[]`/`presentationKey` read (chip-anchored
+ *   identity, immune to the card cycling which store it shows), plus `offerKind: match|direct`
+ *   parsing from the CTA — against the fielded corpus.
+ *
+ * ### Deliberately excluded (#947 membership reconciliation)
+ *
+ * These also compile the production ruleset via `TestRulesetFactory` but are NOT suite members:
+ *  - [cloud.trotter.dashbuddy.core.pipeline.recognition.matchers.InboxProcessorTest] /
+ *    [cloud.trotter.dashbuddy.core.pipeline.recognition.matchers.UnknownScreenAnalysisTest] —
+ *    corpus-*mutating* intake tools (see above); this suite is pure verification.
+ *  - [cloud.trotter.dashbuddy.core.pipeline.notification.NotificationPipelineSensitiveOrderingTest]
+ *    — a `RobolectricTestRunner` pipeline-ORDERING integration test (the sensitive gate must run
+ *    before `CaptureWriter`), not a ruleset/corpus regression; every other suite member is a plain
+ *    JVM test, and pulling in Robolectric's Android shadow runtime here would cost every pre-PR run
+ *    the startup it exists to avoid.
+ *  - [cloud.trotter.dashbuddy.state.effects.ActuationBindingResolutionTest] — validates the
+ *    EFFECTS-layer actuation target-binding resolution (`ClickCandidateRanker` /
+ *    `UiInteractionHandler` mirror, #734), which happens to replay a rule-bound target but is
+ *    testing the app's click-actuation logic, not screen/intent recognition; out of this suite's
+ *    stated scope ("WITHOUT touching the rest of the unit suite").
+ *  - [cloud.trotter.dashbuddy.replay.ClassifyGateCaptureFuzzTest] — a `PropSeeds`/`checkAll`
+ *    kotest PROPERTY test (200 adversarial-tree samples) in the #590/#878 security-fuzz family,
+ *    which is its own documented command (`-Ddashbuddy.propExplore=true`, see the root CLAUDE.md)
+ *    with its own seed-exploration doctrine — deliberately kept separate from this suite's
+ *    deterministic single-pass corpus/fixture checks.
  */
 @RunWith(Suite::class)
 @Suite.SuiteClasses(
@@ -98,5 +137,9 @@ import org.junit.runners.Suite
     CaptureRedactionCorpusTest::class,
     CaptureBackstopCorpusTest::class,
     SensitiveMarkerAssetCoverageTest::class,
+    PickupNoCustomerIdentityTest::class,
+    RuleIdLogSafetyTest::class,
+    GoPuffRecognitionTest::class,
+    UberOfferKindAndStackStoreTest::class,
 )
 class AllMatchersSuite

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScannerParityTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScannerParityTest.kt
@@ -117,9 +117,16 @@ class SnapshotSecurityScannerParityTest {
 
     @Test
     fun `property - scanner catches everything the production backstop catches`() = runTest {
+        // #947: the property only asserted INSIDE `if (markerHit != null)`, so it would go
+        // silently vacuous (pass without checking anything) if the generators ever drifted
+        // to stop producing marker-bearing trees — e.g. a `toxicTokens`/`mutations` edit that
+        // accidentally neuters every sample. Count hits across the run and floor them so a
+        // drift like that fails loud instead of passing green.
+        var markerHits = 0
         checkAll(PropSeeds.samples(600), PropSeeds.config(SEED), treeArb) { tree ->
             val markerHit = SensitiveTextMarkers.findMarker(tree)
             if (markerHit != null) {
+                markerHits++
                 assertTrue(
                     "SSOT PARITY VIOLATION: findMarker hit <$markerHit> on\n$tree\n" +
                         "but SnapshotSecurityScanner.scan reported CLEAN — a toxic screen the " +
@@ -128,6 +135,17 @@ class SnapshotSecurityScannerParityTest {
                 )
             }
         }
+        // Observed 600/600 samples hit a marker under the pinned SEED (every generated tree
+        // embeds a `toxicTokens` entry, so this should ~always be the full 600) — floor at
+        // ~half so the assertion stays meaningful without being brittle to a legitimate,
+        // deliberate generator change. Per the #878 doctrine, don't bump SEED to dodge this;
+        // if a real generator change lowers the count, re-run and reset the floor deliberately.
+        assertTrue(
+            "SSOT PARITY VIOLATION: only $markerHits/600 samples hit a marker (observed 600/600 " +
+                "at authorship) — the generators may have drifted away from marker-bearing " +
+                "samples, which would make the assertion above conditionally vacuous.",
+            markerHits >= 300,
+        )
     }
 
     // ---- Crisp named cases (each isolates one pre-fix gap for the red-first log) ----


### PR DESCRIPTION
## Summary

Four small test-suite hardenings from the 2026-07-30 adversarial review (#947, spot-validated §4.4 item 6):

1. **`ClassifyGateCaptureFuzzTest`** — removed the wall-clock `elapsedMs < 2_000` assertion from inside the 200-sample kotest property. That was exactly the CI-runner-jitter flake shape the #878 seeding doctrine exists to kill: a slow CI host (not a real regression) would redden a *reproducible-looking* seeded property. Left a comment explaining the removal; no new timing mechanism added. The functional assertions (no throw, fail-closed UNKNOWN/sensitive invariant) carry the test; a genuine hang is caught by the test-runner's own timeout.

2. **`SnapshotSecurityScannerParityTest`** — the property previously asserted only inside `if (markerHit != null)`, so it could go silently vacuous if the generators ever drifted away from marker-bearing samples. Added a hit counter across the 600-sample run and asserted a floor. Ran the suite first to observe the actual count under the pinned seed: **600/600 samples hit a marker**. Set the floor at 300 (~half), with a comment naming the observed count and the #878 seed doctrine (don't bump SEED to dodge a legitimate drop — reset the floor deliberately if the generators change).

3. **`AddonPhantomReplayTest`** — replaced the weak `!= delivery_summary_collapsed` guard with a pinned EXPECTED intent. Ran the replay to discover the fixture's current classification: `offer_accepting` (rule `doordash.screen.offer_accepting`, Shape B). Verified correctness by reading `matchers/rules/doordash/offer.json5`: the rule's own comment explicitly names this exact fixture (`snapshots/sessions/addon_phantom_2026_06_21`) as the frame it was written to catch, and Shape B's `require` (fragment container + `secondary_action_button_dash_plus` + a non-empty, non-"Customer dropoff"/"Business handoff" `display_name`) matches the fixture's shape — a post-accept teardown frame with the offer chrome still rendered and the Accept footer torn down. The rule is RECOGNIZE-ONLY (no `state.flow`/parse/bind), so classifying here cannot drive any lifecycle edge. Added a note that #935 may re-anchor `delivery_summary_collapsed`'s `require`, which could shift this fixture's classification again.

4. **`AllMatchersSuite` membership** — compared every test that compiles production rulesets via `TestRulesetFactory` against the suite's `@SuiteClasses`. Found 4 recognition tests outside the suite, undocumented, and 3 outside for legitimate reasons (previously undocumented):
   - **Added**: `PickupNoCustomerIdentityTest` (#548 structural invariant), `RuleIdLogSafetyTest` (#862 rule-id log-safety scan), `GoPuffRecognitionTest` (#501 GoPuff batch-pickup branches), `UberOfferKindAndStackStoreTest` (#881/#882 stacked-card store/kind parsing) — all plain-JVM, side-effect-free, corpus/fixture-driven, matching the suite's existing membership pattern.
   - **Documented as deliberately excluded** (new KDoc section): `NotificationPipelineSensitiveOrderingTest` (Robolectric-dependent pipeline-ORDERING integration test — every other suite member is plain JVM), `ActuationBindingResolutionTest` (effects-layer actuation-binding resolution, not screen/intent recognition), `ClassifyGateCaptureFuzzTest` (the #590/#878 property-fuzz family, with its own `-Ddashbuddy.propExplore=true` exploration path — deliberately kept separate from this suite's deterministic single-pass checks). The pre-existing `InboxProcessorTest`/`UnknownScreenAnalysisTest` exclusion (corpus-mutating) was already documented and is unchanged.
   - Did **not** add any corpus-mutating test to the suite.

## Design-goal review

- **Principle 3 (single responsibility)**: no file grew unboundedly; `AllMatchersSuite`'s KDoc grew but stays a pure membership/rationale document, matching its existing style.
- **Principle 5 (SSOT)**: the parity floor's rationale points back at the single seeded run that produced it rather than re-deriving a number; the suite-membership doc is the one place that now explains inclusion/exclusion for every `TestRulesetFactory` consumer, so a future audit has one place to check instead of re-deriving it from scratch.
- **Principle 6 (security & privacy)**: no security coverage was weakened — `ClassifyGateCaptureFuzzTest` keeps every functional/fail-closed assertion (crash-safety, the UNKNOWN-sensitive-marker backstop invariant) and only drops a non-functional wall-clock check; `SnapshotSecurityScannerParityTest` gets *stronger* (a hit-floor closes a conditional-vacuity gap in a #590 SSOT-parity security gate); the `AddonPhantomReplayTest` pin makes a #564 ledger-corruption regression guard tighter, not looser.
- **Principle 8 (platform-agnostic core)**: N/A to this diff — test-only changes, no `:core:state`/`:core:pipeline`/`:domain`/rule-JSON edits; the newly-added suite members span both DoorDash (`PickupNoCustomerIdentityTest`, `RuleIdLogSafetyTest`, `GoPuffRecognitionTest`) and Uber (`UberOfferKindAndStackStoreTest`) rules already, so no new platform-specific asymmetry is introduced by the membership change itself.

## Test plan

- [x] `ClassifyGateCaptureFuzzTest` green individually
- [x] `SnapshotSecurityScannerParityTest` green individually (observed 600/600 marker hits under the pinned seed before setting the floor at 300)
- [x] `AddonPhantomReplayTest` green individually
- [x] `AllMatchersSuite` compiles and passes with the 4 additions
- [x] `./gradlew :core:pipeline:testDebugUnitTest :app:testDebugUnitTest :domain:test` green

Closes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)
