### PR TITLE
fix(offer-engine): #936 — null-distance offers get NO verdict instead of a fabricated 1-mile trip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,6 +408,28 @@ enumeration, every capability lands *undecided* until the user opts in via the c
 Handlers: `OdometerEffectHandler`, `ScreenShotHandler`, `TipEffectHandler`, `TtsEffectHandler`,
 `UiInteractionHandler` (package-scoped, label-verified `RuleAction` taps — the only path that ever
 clicks a third-party app, #425), `OfferActionReceiver` (notification Accept/Decline actions).
+**The evaluator fails CLOSED on a missing input (#936).** Its two parse fallbacks were asymmetric:
+pay `?: 0.0` scores 0 → DECLINE, but distance `?: 1.0` invented a favourable **one-mile trip** —
+near-zero operating cost, near-zero drive time, an inflated `$/hr` — biasing the verdict toward
+ACCEPT precisely where the input was least trustworthy (the #827 class of seam). Distance is now
+the `0.0` "no distance" sentinel, and an offer that would otherwise be *scored* without one
+returns the existing no-verdict shape instead — `OfferAction.NOTHING` / score 0 /
+`OfferQuality.UNKNOWN`, mirroring the no-scoring-rules return. The three **distance-independent**
+verdicts stay in front of it (shopping opt-out #762 D12, protect-stats, merchant BLOCK). The
+returned economics are the honest subset: real gross pay and the economy's own
+`operatingCostPerMile` (a profile constant the projector freezes as the session cpm — zeroing it
+would make the session's deliveries look cost-free), with every distance-derived figure an
+explicit `0.0` placeholder and `netPayAmount` == gross (no cost deducted ≠ a one-mile cost).
+**`OfferEvaluation.hasDistanceMetrics` is the one predicate consumers branch on** so those
+placeholders are never rendered as measurements — `FlowCardSnapshot.Offer.from` (bubble card +
+heads-up custom views get null → their existing `—` / hidden gauge), `toNotificationSummary`,
+`TtsEffectHandler` (a no-verdict utterance, not "zero dollars an hour"),
+`JobAcceptFlow.acceptInputsFromPending` + `FlowCardMapper`'s #460 co-hero, and
+`RecordFolds.foldOffer` (null frozen estimates, so `AVG(score)`/`AVG(estDollarsPerHour)` aren't
+dragged toward a fabricated 0). The #659 fuel/non-fuel split was already guarded at the fold
+(`distanceMiles > 0.0` → null split → 3-step waterfall), so no NaN can reach a frozen economics
+column, and no `PROJECTOR_VERSION` bump was needed (historical evaluations were frozen carrying
+the fabricated 1.0 mile, so a refold reproduces them byte-identically).
 **Dedupe granularity is the rule's to declare (#859).** The durable `effects_fired` row is
 "at most once per 48h"; a rule effect that declares its own `throttleMs` opts OUT of it and
 into that declared window (the engine's wall-clock throttle, keyed by the same `effectKey`) —

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
@@ -173,6 +173,18 @@ class TtsEffectHandler @Inject constructor(
                 else -> R.string.tts_verdict_offer
             }
         )
+        // #936: an offer whose distance never parsed carries 0.0 placeholders in every rate field,
+        // so the scored template would speak "zero dollars an hour net … zero miles, score zero"
+        // — a fabricated verdict read aloud to a driving dasher. Speak the parsed pay and say
+        // there's no verdict instead.
+        if (!eval.hasDistanceMetrics) {
+            return localized.getString(
+                R.string.tts_offer_no_verdict_template,
+                verdict,
+                eval.merchantName.trim(),
+                Formats.decimal(eval.payAmount, 2),
+            )
+        }
         return localized.getString(
             R.string.tts_offer_evaluation_template,
             verdict,

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -13,6 +13,8 @@
     <string name="tts_verdict_offer">Oferta</string>
     <!-- %1$s verdict word, %2$s merchant name, %3$s $/hr, %4$s net pay, %5$s miles, %6$s score. -->
     <string name="tts_offer_evaluation_template">%1$s. %2$s. %3$s dólares por hora netos. Neto %4$s, %5$s millas, puntuación %6$s.</string>
+    <!-- %1$s verdict word, %2$s merchant name, %3$s gross pay (#936). -->
+    <string name="tts_offer_no_verdict_template">%1$s. %2$s. Pago %3$s. Sin veredicto: no se pudo leer la distancia.</string>
 
     <!-- #907 — folded from values-es-rUS; defaults live in app/src/main/res/values/strings.xml. -->
     <string name="app_name">DashBuddy</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -480,6 +480,10 @@
          Translations MUST keep the same six positional args (a translated %-mismatch is the #719
          HIGH-1 crash class). The merchant name and the numbers are runtime args — never translated. -->
     <string name="tts_offer_evaluation_template">%1$s. %2$s. %3$s dollars an hour net. Net %4$s, %5$s miles, score %6$s.</string>
+    <!-- #936 — spoken when the offer's distance never parsed, so every rate would be fabricated.
+         %1$s verdict word, %2$s merchant name, %3$s gross pay. Translations MUST keep the same
+         three positional args (the #719 HIGH-1 crash class). -->
+    <string name="tts_offer_no_verdict_template">%1$s. %2$s. Pay %3$s. No verdict — the distance didn\'t parse.</string>
 
     <!-- state/effects/TipEffectHandler.kt -->
     <!-- %1$s tip amount, %2$s store name -->

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/JobAcceptFlow.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/JobAcceptFlow.kt
@@ -65,15 +65,21 @@ internal data class AcceptInputs(
 internal fun PlatformRegionStepper.acceptInputsFromPending(pending: PendingOffer?, acceptedAt: Long?): AcceptInputs {
     val parsedOffer = pending?.offerFields?.parsedOffer
     val eval = pending?.evaluation
+    // #936: an evaluation of a distance-less offer carries 0.0 PLACEHOLDERS in its rate-bearing
+    // fields (it scored nothing), so those are read only from an evaluation that actually had a
+    // distance — otherwise the parse wins, and a null distance is preferable to a 0.0 that would
+    // masquerade as a measurement in the accepted job's economics. `payAmount` (real gross) and
+    // `estMinutes` (the handling floor) are not rates and read from the evaluation either way.
+    val scoredEval = eval?.takeIf { it.hasDistanceMetrics }
     val storeHints = parsedOffer?.orders?.map { it.storeName } ?: emptyList()
     return AcceptInputs(
         offerHash = pending?.offerHash,
         economics = AcceptedOfferEconomics(
             offerHash = pending?.offerHash,
             payAmount = eval?.payAmount ?: parsedOffer?.payAmount,
-            netPay = eval?.netPayAmount,
+            netPay = scoredEval?.netPayAmount,
             estMinutes = eval?.estimatedTimeMinutes ?: parsedOffer?.timeToCompleteMinutes?.toDouble(),
-            distanceMiles = eval?.distanceMiles ?: parsedOffer?.distanceMiles,
+            distanceMiles = scoredEval?.distanceMiles ?: parsedOffer?.distanceMiles,
             // #823 Phase 1: capture the offer's quoted UNITS count when it was units-denominated, so
             // the pickup-confirmed shop-rate site can pair it with the ground-truth items shopped and
             // learn the items:units ratio. Null for an items-denominated / non-shop offer.

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -494,6 +494,14 @@ object RecordFolds {
         val evalDist = eval?.distanceMiles
         val fuelPerMile = if (eval != null && evalDist != null && evalDist > 0.0) eval.fuelCostEstimate / evalDist else null
         val nonFuelPerMile = if (eval != null && evalDist != null && evalDist > 0.0) eval.nonFuelCostEstimate / evalDist else null
+        // #936: an offer whose distance never parsed gets NO verdict — its evaluation carries 0.0
+        // PLACEHOLDERS in every rate field and a placeholder score, because nothing was scored. The
+        // frozen estimate columns are nullable precisely so the Decisions-tab aggregates
+        // (`AVG(score)`, `AVG(estDollarsPerHour)`, `Σ estNetPay`) can yield null instead of a
+        // fabricated 0 (see [OfferScoreOutcomeRow]) — so hand them null. The honest facts still
+        // record: `action`/`quality` (NOTHING/UNKNOWN), the parsed pay + null distance, and the
+        // economy's own `operatingCostPerMile`, which is not distance-derived.
+        val scoredEval = eval?.takeIf { it.hasDistanceMetrics }
         val offer = OfferFold(
             eventSequenceId = event.sequenceId,
             sessionId = sid,
@@ -509,13 +517,13 @@ object RecordFolds {
             // evaluator uses, so an un-evaluated offer records the store the dasher saw rather
             // than the identity-bearing first order (the Uber stack card's type chip).
             merchantName = eval?.merchantName ?: parsed.displayStoreText.takeIf { it.isNotBlank() },
-            score = eval?.score,
+            score = scoredEval?.score,
             action = eval?.action?.name,
             quality = eval?.qualityLevel?.name,
-            estNetPay = eval?.netPayAmount,
-            estDollarsPerHour = eval?.dollarsPerHour,
-            estDollarsPerMile = eval?.dollarsPerMile,
-            estTimeMinutes = eval?.estimatedTimeMinutes,
+            estNetPay = scoredEval?.netPayAmount,
+            estDollarsPerHour = scoredEval?.dollarsPerHour,
+            estDollarsPerMile = scoredEval?.dollarsPerMile,
+            estTimeMinutes = scoredEval?.estimatedTimeMinutes,
             estOperatingCostPerMile = eval?.operatingCostPerMile,
             estFuelPerMile = fuelPerMile,
             estNonFuelPerMile = nonFuelPerMile,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluation.kt
@@ -43,4 +43,17 @@ data class OfferEvaluation(
      * Shown to the user when configuring rules so they understand why offers are being declined.
      */
     val warnings: List<String> = emptyList(),
-)
+) {
+    /**
+     * True when this evaluation was computed against a real, positive parsed distance — i.e.
+     * [distanceMiles], [dollarsPerMile], [dollarsPerHour] and the cost fields are real numbers.
+     *
+     * False when the offer's distance never parsed (#936). Those fields are then `0.0`
+     * PLACEHOLDERS meaning *unknown*, not measurements: [netPayAmount] is gross (no cost was
+     * deducted) and the verdict is [OfferQuality.UNKNOWN]/[OfferAction.NOTHING]. Any surface that
+     * renders or speaks a per-mile / per-hour / distance figure must check this first and show its
+     * "unknown" affordance instead — printing the zeros would quote a rate we never computed.
+     * ([operatingCostPerMile] is exempt: it is the economy profile's own rate, not distance-derived.)
+     */
+    val hasDistanceMetrics: Boolean get() = distanceMiles > 0.0
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
@@ -9,7 +9,17 @@ class OfferEvaluator() {
 
         val economy = config.userEconomy
         val grossPay = offer.payAmount ?: 0.0
-        val dist = offer.distanceMiles ?: 1.0
+        // #936: distance is the denominator of every cost and rate metric below, so the old
+        // `?: 1.0` fallback fabricated a favorable one-mile trip for an offer whose distance
+        // never parsed — near-zero operating cost, near-zero drive time, an inflated $/hr — i.e.
+        // it biased the verdict toward ACCEPT precisely when its input was least trustworthy.
+        // That was the one fail-toward-ACCEPT default in a codebase whose pay fallback (`?: 0.0`,
+        // above) correctly fails toward DECLINE. The sentinel is now 0.0 ("no distance"), so
+        // nothing is invented: [hasDistance] gates the rate metrics, and an offer that would
+        // otherwise be SCORED without a distance returns the no-verdict evaluation below instead.
+        // A parsed 0.0 is treated identically — per-mile and per-hour are undefined either way.
+        val dist = offer.distanceMiles?.takeIf { it > 0.0 } ?: 0.0
+        val hasDistance = dist > 0.0
         val items = offer.itemCount.toDouble()
 
         // Operating cost — full breakdown (fuel + tires + oil + brakes + fluids +
@@ -48,8 +58,12 @@ class OfferEvaluator() {
 
         // Metrics operate on net pay (same NetProfit SSOT; 0.0 when the
         // denominator is undefined, preserving the prior scoring behavior).
+        // #936: with no distance, [dist] is 0.0 so `perMile` is already undefined → 0.0, but
+        // `estTimeHours` still carries the handling term — dividing by it would quote an hourly
+        // rate off a route whose drive leg is unknown. Gate it, so both rates read as the 0.0
+        // "unknown" placeholder that [OfferEvaluation.hasDistanceMetrics] tells consumers about.
         val dpm = NetProfit.perMile(netPay, dist) ?: 0.0
-        val activeHourly = NetProfit.perHour(netPay, estTimeHours) ?: 0.0
+        val activeHourly = if (hasDistance) NetProfit.perHour(netPay, estTimeHours) ?: 0.0 else 0.0
 
         // #882: the ONE display-store SSOT ([ParsedOffer.displayStoreText]) — the joined order
         // stores exactly as before, except that a card whose rule parsed its own headline store
@@ -162,6 +176,44 @@ class OfferEvaluator() {
             )
         }
 
+        // --- 3b. No distance ⇒ NO VERDICT (#936) ---
+        // Every metric from here on is a rate over distance, so scoring an unparsed-distance offer
+        // would score a fabricated trip. The three verdicts ABOVE this point are deliberately left
+        // in front of it because they are distance-INDEPENDENT decisions that must stay true in
+        // every mode: the shopping opt-out is a capability constraint (#762 D12), protect-stats
+        // accepts everything, and a BLOCK-listed merchant is a hard decline. This mirrors the
+        // no-scoring-rules return above — action NOTHING, score 0, quality UNKNOWN — and carries
+        // only the HONEST economics: real gross pay, and the real per-mile operating rate (a
+        // profile constant, not distance-derived, and load-bearing downstream — the analytics
+        // projector freezes it as the session cpm, so zeroing it would make a delivery in this
+        // session look cost-free). Every distance-derived figure is the explicit 0.0 "unknown"
+        // placeholder — no cost is deducted, so `netPayAmount` is gross, NOT a 1-mile net — and
+        // consumers branch on [OfferEvaluation.hasDistanceMetrics] instead of rendering the zeros.
+        // `estimatedTimeMinutes` is the one field kept as computed: it is the HANDLING term only
+        // (the drive leg is 0 with no distance), which is a real, if incomplete, floor and is the
+        // fallback `JobAcceptFlow` reads for an accepted job's ETA. It is not a rate, so it cannot
+        // flatter a verdict; the analytics fold records it as null alongside the other estimates.
+        if (!hasDistance) {
+            return OfferEvaluation(
+                action = OfferAction.NOTHING,
+                score = 0.0,
+                qualityLevel = OfferQuality.UNKNOWN,
+                payAmount = grossPay,
+                fuelCostEstimate = 0.0,
+                nonFuelCostEstimate = 0.0,
+                totalOperatingCost = 0.0,
+                operatingCostPerMile = economy.operatingCostPerMile,
+                netPayAmount = grossPay,
+                distanceMiles = 0.0,
+                dollarsPerMile = 0.0,
+                dollarsPerHour = 0.0,
+                estimatedTimeMinutes = estTimeMinutes,
+                itemCount = items,
+                merchantName = merchants,
+                isUsingDefaults = economy.isUsingDefaults,
+            )
+        }
+
         // MANUAL_REVIEW: flag for later action override
         val requiresManualReview = activeMerchantRules.any { rule ->
             rule.action == MerchantAction.MANUAL_REVIEW &&
@@ -257,23 +309,30 @@ class OfferEvaluator() {
         }.coerceIn(0.0, 1.0)
     }
 
+    /**
+     * Caveats for rule targets so high that they would auto-decline nearly everything.
+     *
+     * P8 (#936): the copy names no platform and quotes no per-platform pay norms — this is the
+     * platform-agnostic core, and "most DoorDash offers pay $0.80–$1.50/mi" was both a platform
+     * literal in `:domain` and a market-specific claim we don't measure. The thresholds stay; the
+     * wording says only that the target is above what offers typically pay.
+     */
     private fun buildCaveatWarnings(rules: List<ScoringRule.MetricRule>): List<String> =
         rules.mapNotNull { rule ->
             val target = rule.targetValue.toDouble()
+            val consequence =
+                "Setting this high will result in most offers being auto-declined."
             when (rule.metricType) {
                 MetricType.DOLLAR_PER_MILE -> if (target > REALISTIC_MAX_DPM)
-                    "Your \$/mile target of ${Formats.money(target)} is above what most DoorDash offers pay. " +
-                    "Most offers are \$0.80–\$1.50/mi. Setting this high will result in most offers being auto-declined."
+                    "Your per-mile target of ${Formats.money(target)} is above what most offers pay. $consequence"
                 else null
 
                 MetricType.ACTIVE_HOURLY -> if (target > REALISTIC_MAX_HOURLY)
-                    "Your hourly target of ${Formats.money(target)}/hr is above typical DoorDash earnings. " +
-                    "Most dashers earn \$15–\$25/hr active. Setting this high will result in most offers being auto-declined."
+                    "Your hourly target of ${Formats.money(target)} is above typical active earnings. $consequence"
                 else null
 
                 MetricType.PAYOUT -> if (target > REALISTIC_MAX_PAYOUT)
-                    "Your minimum payout of ${Formats.money(target)} is above what most single orders pay. " +
-                    "Most DoorDash orders are under \$10. Setting this high will result in most offers being auto-declined."
+                    "Your minimum payout of ${Formats.money(target)} is above what most single orders pay. $consequence"
                 else null
 
                 else -> null

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
@@ -97,34 +97,38 @@ sealed class FlowCardSnapshot {
                 expiresAt: Long? = null,
                 countdownSeconds: Int? = null,
                 outcome: AppEventType? = null,
-            ): Offer = Offer(
-                phaseStartedAt = phaseStartedAt,
-                phaseEndedAt = phaseEndedAt,
-                offerHash = offerHash,
-                payAmount = parsedOffer.payAmount,
-                distanceMiles = parsedOffer.distanceMiles,
-                itemCount = parsedOffer.itemCount,
-                // #882: the display-store SSOT, not the raw per-order names — on an Uber
-                // multi-order card the per-order name is the type chip ("Delivery (2)") held
-                // there for #830 identity, and this card is a human surface.
-                storeNames = parsedOffer.displayStores,
+            ): Offer {
                 // #936: an evaluation with no parsed distance carries 0.0 PLACEHOLDERS, not
                 // measurements, in every distance-derived field (and a placeholder score, since
                 // no scoring ran). This card's metric fields are already nullable and every
                 // renderer — the bubble offer card and the heads-up notification's custom views —
                 // already draws the "—" affordance / hides the score gauge for a null, so the
-                // honest value to hand them is null. `payAmount` (real, parsed) still shows.
-                evaluationScore = evaluation?.takeIf { it.hasDistanceMetrics }?.score,
-                evaluationAction = evaluation?.action?.name,
-                netPayAmount = evaluation?.takeIf { it.hasDistanceMetrics }?.netPayAmount,
-                dollarsPerMile = evaluation?.takeIf { it.hasDistanceMetrics }?.dollarsPerMile,
-                dollarsPerHour = evaluation?.takeIf { it.hasDistanceMetrics }?.dollarsPerHour,
-                qualityLevel = evaluation?.qualityLevel,
-                badges = badgesOf(parsedOffer),
-                expiresAt = expiresAt,
-                countdownSeconds = countdownSeconds,
-                outcome = outcome,
-            )
+                // honest value to hand them is null. `payAmount` (real, parsed) still shows, as do
+                // the action and the UNKNOWN quality chip ("No verdict").
+                val scored = evaluation?.takeIf { it.hasDistanceMetrics }
+                return Offer(
+                    phaseStartedAt = phaseStartedAt,
+                    phaseEndedAt = phaseEndedAt,
+                    offerHash = offerHash,
+                    payAmount = parsedOffer.payAmount,
+                    distanceMiles = parsedOffer.distanceMiles,
+                    itemCount = parsedOffer.itemCount,
+                    // #882: the display-store SSOT, not the raw per-order names — on an Uber
+                    // multi-order card the per-order name is the type chip ("Delivery (2)") held
+                    // there for #830 identity, and this card is a human surface.
+                    storeNames = parsedOffer.displayStores,
+                    evaluationScore = scored?.score,
+                    evaluationAction = evaluation?.action?.name,
+                    netPayAmount = scored?.netPayAmount,
+                    dollarsPerMile = scored?.dollarsPerMile,
+                    dollarsPerHour = scored?.dollarsPerHour,
+                    qualityLevel = evaluation?.qualityLevel,
+                    badges = badgesOf(parsedOffer),
+                    expiresAt = expiresAt,
+                    countdownSeconds = countdownSeconds,
+                    outcome = outcome,
+                )
+            }
 
             /**
              * The offer + order badge enum names for the pill row, plus a

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
@@ -108,11 +108,17 @@ sealed class FlowCardSnapshot {
                 // multi-order card the per-order name is the type chip ("Delivery (2)") held
                 // there for #830 identity, and this card is a human surface.
                 storeNames = parsedOffer.displayStores,
-                evaluationScore = evaluation?.score,
+                // #936: an evaluation with no parsed distance carries 0.0 PLACEHOLDERS, not
+                // measurements, in every distance-derived field (and a placeholder score, since
+                // no scoring ran). This card's metric fields are already nullable and every
+                // renderer — the bubble offer card and the heads-up notification's custom views —
+                // already draws the "—" affordance / hides the score gauge for a null, so the
+                // honest value to hand them is null. `payAmount` (real, parsed) still shows.
+                evaluationScore = evaluation?.takeIf { it.hasDistanceMetrics }?.score,
                 evaluationAction = evaluation?.action?.name,
-                netPayAmount = evaluation?.netPayAmount,
-                dollarsPerMile = evaluation?.dollarsPerMile,
-                dollarsPerHour = evaluation?.dollarsPerHour,
+                netPayAmount = evaluation?.takeIf { it.hasDistanceMetrics }?.netPayAmount,
+                dollarsPerMile = evaluation?.takeIf { it.hasDistanceMetrics }?.dollarsPerMile,
+                dollarsPerHour = evaluation?.takeIf { it.hasDistanceMetrics }?.dollarsPerHour,
                 qualityLevel = evaluation?.qualityLevel,
                 badges = badgesOf(parsedOffer),
                 expiresAt = expiresAt,

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -364,11 +364,26 @@ class RecordFoldsTest {
         assertNull(offer.estNonFuelPerMile)
         assertEquals(0.30, offer.estOperatingCostPerMile!!, 1e-9)
 
+        // #936: the same row's other frozen ESTIMATES are placeholders too (a distance-less
+        // evaluation scores nothing), so they record as null rather than dragging the Decisions-tab
+        // `AVG(score)` / `AVG(estDollarsPerHour)` / `Σ estNetPay` aggregates toward a fabricated 0.
+        assertNull(offer.score)
+        assertNull(offer.estNetPay)
+        assertNull(offer.estDollarsPerHour)
+        assertNull(offer.estDollarsPerMile)
+        assertNull(offer.estTimeMinutes)
+        // The honest facts still record.
+        assertEquals(OfferAction.ACCEPT.name, offer.action)
+        assertEquals(OfferQuality.GOOD.name, offer.quality)
+
         val d = outcomes[2].delivery!!
         assertEquals(CostBasis.OFFER_FROZEN, d.costBasis)
         assertEquals(0.30, d.frozenCostPerMile!!, 1e-9)
         assertNull("no split on a distance-0 offer", d.frozenFuelPerMile)
         assertNull(d.frozenNonFuelPerMile)
+        // The money-critical half: no NaN/Infinity can reach a frozen economics column.
+        assertTrue(d.netProfit!!.isFinite())
+        assertTrue(d.frozenCostPerMile.isFinite())
     }
 
     @Test

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluatorTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluatorTest.kt
@@ -5,6 +5,7 @@ import cloud.trotter.dashbuddy.domain.model.order.OrderType
 import cloud.trotter.dashbuddy.domain.model.order.ParsedOrder
 import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -480,12 +481,134 @@ class OfferEvaluatorTest {
         assertEquals(100.0, result.score, 0.0001)
     }
 
+    // -------------------------------------------------------------------------
+    // Unparsed distance ⇒ NO VERDICT (#936)
+    //
+    // The predecessor of this section pinned the bug: `distance null defaults to 1 - prevents
+    // divide-by-zero in dpm` asserted score 100 (a full ACCEPT) for a $2.00 offer of unknown
+    // length, because `?: 1.0` fabricated a one-mile trip. Distance is the denominator of every
+    // cost and rate metric, so the fail-SAFE direction is no verdict at all.
+    // -------------------------------------------------------------------------
+
     @Test
-    fun `distance null defaults to 1 - prevents divide-by-zero in dpm`() {
+    fun `null distance - is NOT scored as a 1-mile trip (the #936 regression)`() {
         val cfg = config(metricRule(MetricType.DOLLAR_PER_MILE, 2.0f))
         val result = evaluator.evaluate(offer(pay = 2.0, dist = null), cfg)
-        // dist defaults to 1.0 → dpm = 2.0/1.0 = 2.0 → score 100
+        // Was: dist ?: 1.0 → dpm = 2.0/1.0 = 2.0 → score 100 → ACCEPT.
+        assertEquals(OfferQuality.UNKNOWN, result.qualityLevel)
+        assertEquals(OfferAction.NOTHING, result.action)
+        assertEquals(0.0, result.score, 0.0001)
+    }
+
+    @Test
+    fun `null distance - fabricates no per-mile, per-hour or cost figure`() {
+        // A real (costly) economy: if any distance-derived field were computed off a fabricated
+        // mile, these would be non-zero.
+        val cfg = EvaluationConfig(
+            rules = listOf(metricRule(MetricType.PAYOUT, 7.0f)),
+            userEconomy = fuelOnlyEconomy(vehicleMpg = 20.0, gasPricePerGallon = 4.0),
+        )
+        val result = evaluator.evaluate(offer(pay = 12.5, dist = null), cfg)
+
+        assertEquals(OfferQuality.UNKNOWN, result.qualityLevel)
+        assertEquals(0.0, result.distanceMiles, 0.0)
+        assertEquals(0.0, result.dollarsPerMile, 0.0)
+        assertEquals(0.0, result.dollarsPerHour, 0.0)
+        assertEquals(0.0, result.fuelCostEstimate, 0.0)
+        assertEquals(0.0, result.nonFuelCostEstimate, 0.0)
+        assertEquals(0.0, result.totalOperatingCost, 0.0)
+        // Gross pay is real (it parsed); net is gross because NO cost was deducted — an unknown
+        // cost, not a fabricated one-mile cost.
+        assertEquals(12.5, result.payAmount, 0.0001)
+        assertEquals(12.5, result.netPayAmount, 0.0001)
+        // The economy's own per-mile rate is NOT distance-derived and stays real — the analytics
+        // projector freezes it as the session cost-per-mile.
+        assertEquals(cfg.userEconomy.operatingCostPerMile, result.operatingCostPerMile, 1e-9)
+        // The consumer-facing contract: renderers must treat those zeros as "unknown".
+        assertFalse(result.hasDistanceMetrics)
+    }
+
+    @Test
+    fun `zero distance - is unscoreable for the same reason as a null one`() {
+        val cfg = config(metricRule(MetricType.DOLLAR_PER_MILE, 2.0f))
+        val result = evaluator.evaluate(offer(pay = 2.0, dist = 0.0), cfg)
+        assertEquals(OfferQuality.UNKNOWN, result.qualityLevel)
+        assertFalse(result.hasDistanceMetrics)
+    }
+
+    @Test
+    fun `null distance - a MAX_DISTANCE rule cannot score it as within the limit`() {
+        // The sharpest fail-open shape: `1.0 - (dist / target)` gave a fabricated mile nearly full
+        // marks on a distance limit it was never measured against.
+        val cfg = config(metricRule(MetricType.MAX_DISTANCE, 10.0f))
+        val result = evaluator.evaluate(offer(pay = 20.0, dist = null), cfg)
+        assertEquals(OfferAction.NOTHING, result.action)
+        assertEquals(0.0, result.score, 0.0001)
+    }
+
+    @Test
+    fun `null distance - the shopping opt-out still hard-declines first`() {
+        // #762 D12's promise ("if off, Red Card orders are auto-declined") is a capability
+        // constraint, not an economic verdict — it must stay true even with no distance.
+        val cfg = EvaluationConfig(
+            rules = listOf(metricRule(MetricType.PAYOUT, 7.0f)),
+            userEconomy = noCostEconomy,
+            allowShopping = false,
+        )
+        val result = evaluator.evaluate(
+            offer(pay = 20.0, dist = null, orderType = OrderType.SHOP_FOR_ITEMS), cfg,
+        )
+        assertEquals(OfferAction.DECLINE, result.action)
+        assertEquals(OfferQuality.SHOP_DECLINED, result.qualityLevel)
+        // …but it still invents no mileage economics.
+        assertEquals(0.0, result.distanceMiles, 0.0)
+        assertEquals(0.0, result.dollarsPerHour, 0.0)
+    }
+
+    @Test
+    fun `null distance - a BLOCK-listed merchant still hard-declines first`() {
+        val cfg = config(metricRule(MetricType.PAYOUT, 7.0f), blockRule("Taco Bell"))
+        val result = evaluator.evaluate(offer(pay = 20.0, dist = null, storeName = "Taco Bell"), cfg)
+        assertEquals(OfferAction.DECLINE, result.action)
+        assertEquals(OfferQuality.BLOCKED, result.qualityLevel)
+    }
+
+    @Test
+    fun `null PAY (distance present) still fails toward DECLINE - unchanged asymmetry`() {
+        // Pinned so the asymmetry is deliberate and visible: an unparsed PAY is scoreable (it
+        // scores as $0 and declines), an unparsed DISTANCE is not scoreable at all.
+        val cfg = config(metricRule(MetricType.PAYOUT, 7.0f))
+        val result = evaluator.evaluate(offer(pay = null, dist = 3.0), cfg)
+        assertEquals(OfferAction.DECLINE, result.action)
+        assertEquals(0.0, result.score, 0.0001)
+        assertEquals(0.0, result.payAmount, 0.0)
+        assertTrue(result.hasDistanceMetrics)
+    }
+
+    @Test
+    fun `fully-populated offer - evaluation is unchanged by the #936 guard`() {
+        // Regression pin: the normal path must be byte-identical to pre-#936 behavior.
+        val cfg = EvaluationConfig(
+            rules = listOf(metricRule(MetricType.PAYOUT, 7.0f)),
+            userEconomy = fuelOnlyEconomy(vehicleMpg = 25.0, gasPricePerGallon = 3.0),
+        )
+        val result = evaluator.evaluate(offer(pay = 10.0, dist = 5.0), cfg)
+        val fuel = 5.0 * (3.0 / 25.0)
+
+        assertTrue(result.hasDistanceMetrics)
+        assertEquals(5.0, result.distanceMiles, 0.0)
+        assertEquals(10.0, result.payAmount, 0.0001)
+        assertEquals(fuel, result.fuelCostEstimate, 1e-9)
+        assertEquals(10.0 - fuel, result.netPayAmount, 1e-9)
+        assertEquals((10.0 - fuel) / 5.0, result.dollarsPerMile, 1e-9)
         assertEquals(100.0, result.score, 0.0001)
+        assertEquals(OfferAction.ACCEPT, result.action)
+        // $/hr is the real route rate (drive + handling), not a gated zero.
+        assertEquals(
+            (10.0 - fuel) / (result.estimatedTimeMinutes / 60.0),
+            result.dollarsPerHour,
+            1e-9,
+        )
     }
 
     // -------------------------------------------------------------------------

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/FlowCardMapper.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/FlowCardMapper.kt
@@ -102,9 +102,13 @@ object FlowCardMapper {
                     // On accept, capture the offer's economics for the upcoming
                     // task cards' live $/hr co-hero (#460).
                     if (payload.outcome == AppEventType.OFFER_ACCEPTED) {
-                        acceptedNetPay = payload.evaluation?.netPayAmount
+                        // #936: the co-hero is a live rate, so it reads only an evaluation that
+                        // actually had a distance — a distance-less one carries 0.0 placeholders
+                        // and would render a fabricated $0.00/hr on every task card of the job.
+                        val scored = payload.evaluation?.takeIf { it.hasDistanceMetrics }
+                        acceptedNetPay = scored?.netPayAmount
                         acceptedEstMin = payload.evaluation?.estimatedTimeMinutes
-                        acceptedDistanceMiles = payload.evaluation?.distanceMiles ?: payload.parsedOffer.distanceMiles
+                        acceptedDistanceMiles = scored?.distanceMiles ?: payload.parsedOffer.distanceMiles
                     }
                     // Re-open Awaiting if the dasher returned to the
                     // waiting-for-offer state (declined / timeout). Accept

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/formatters/OfferFormatters.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/formatters/OfferFormatters.kt
@@ -87,6 +87,14 @@ fun OfferEvaluation.notificationPersona(): ChatPersona = when (action) {
  * Net $22.48 · 12.9 mi · $1.74/mi · Score 74 · H-E-B
  * ```
  *
+ * When the offer's distance never parsed (#936) every rate here would be a `0.0` placeholder, so
+ * the summary states the gross pay and says there is no verdict instead of quoting `$0/hr net`:
+ *
+ * ```
+ * OFFER · no verdict
+ * Pay $12.50 · distance didn't parse · H-E-B
+ * ```
+ *
  * Note: bold + size are reliable across devices; foreground color in a MessagingStyle notification
  * is device/version dependent (the system may re-theme it), so the line still reads cleanly without
  * it. `toString()` yields the plain text used for chat storage.
@@ -94,6 +102,7 @@ fun OfferEvaluation.notificationPersona(): ChatPersona = when (action) {
 fun OfferEvaluation.toNotificationSummary(): CharSequence {
     val verdict = offerVerdictLabel(action)
     val verdictColor = offerVerdictArgb(action)
+    val scored = hasDistanceMetrics
 
     return SpannableStringBuilder().apply {
         val start = length
@@ -102,17 +111,22 @@ fun OfferEvaluation.toNotificationSummary(): CharSequence {
         setSpan(RelativeSizeSpan(1.2f), start, length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
 
         append(" · ")
-        append("${Formats.money0(dollarsPerHour)}/hr net")
+        append(if (scored) "${Formats.money0(dollarsPerHour)}/hr net" else "no verdict")
         // Whole headline (verdict + rate) bold.
         setSpan(StyleSpan(Typeface.BOLD), start, length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
 
         append("\n")
         append(
-            "Net ${Formats.money(netPayAmount)} · " +
-                "${Formats.decimal(distanceMiles)} mi · " +
-                "${Formats.money(dollarsPerMile)}/mi · " +
-                "Score ${score.toInt()} · " +
-                merchantName,
+            if (scored) {
+                "Net ${Formats.money(netPayAmount)} · " +
+                    "${Formats.decimal(distanceMiles)} mi · " +
+                    "${Formats.money(dollarsPerMile)}/mi · " +
+                    "Score ${score.toInt()} · " +
+                    merchantName
+            } else {
+                // Gross pay is real (parsed); every other figure would be invented.
+                "Pay ${Formats.money(payAmount)} · distance didn't parse · $merchantName"
+            },
         )
     }
 }


### PR DESCRIPTION
Closes #936.

`OfferEvaluator.evaluate` opened with:

```kotlin
val grossPay = offer.payAmount ?: 0.0    // fails toward DECLINE ✅
val dist = offer.distanceMiles ?: 1.0    // fabricated a favorable 1-mile trip ❌
```

Distance is the denominator of every cost and rate metric, so an offer whose distance never
parsed was **scored as a one-mile trip**: near-zero operating cost, near-zero drive time, an
inflated `$/hr` — the verdict and the spoken headline biased toward ACCEPT precisely when the
input was least trustworthy. It was the one fail-toward-ACCEPT default in a fail-closed
codebase, and #827's Uber time/miles swap is the same class of seam.

### Fail-direction table

| Unparsed input | Before | After |
|---|---|---|
| `payAmount` | `0.0` → scores 0 → **DECLINE** (fail-safe) | unchanged (pinned by a new test) |
| `distanceMiles` | `1.0` → tiny cost, tiny time → **biased ACCEPT** | **no verdict** (`NOTHING` / score 0 / `UNKNOWN`) |

### The change

`dist` is now the `0.0` "no distance" sentinel, and an offer that would otherwise be **scored**
without a distance returns the existing no-verdict shape instead — `action = NOTHING`,
`score = 0.0`, `qualityLevel = UNKNOWN`, mirroring the no-scoring-rules return at the top of the
rules section. A parsed `0.0` is treated identically (per-mile and per-hour are undefined either
way).

The three **distance-independent** verdicts stay in front of the new guard, deliberately:
the shopping opt-out (#762 D12 — a capability constraint whose Settings promise must be literally
true in every mode), protect-stats, and a BLOCK-listed merchant. Two new tests pin that ordering.

Economics carried on the no-verdict return are the **honest subset**:

* real gross pay (`payAmount`), and the economy's own `operatingCostPerMile` — a profile
  constant, *not* distance-derived, and load-bearing downstream: the analytics projector freezes
  it as the session cpm, so zeroing it would make every delivery in that session look cost-free;
* every distance-derived figure an explicit `0.0` placeholder, and `netPayAmount` = gross,
  because **no cost was deducted** — an unknown cost, not a fabricated one-mile cost;
* `estimatedTimeMinutes` is the one field kept as computed — it is the handling term only (the
  drive leg is 0), a real if incomplete floor, it is the fallback `JobAcceptFlow` reads for an
  accepted job's ETA, and it is not a rate so it cannot flatter a verdict.

### Consumer verification (plan step 3)

None of the render surfaces special-cased `UNKNOWN` — today's no-rules `UNKNOWN` renders *real*
numbers (its distance parsed), so the case was invisible. With a null distance they would all
have printed the placeholders as measurements. Findings and fixes:

| Surface | Before this PR | After |
|---|---|---|
| **TTS** (`TtsEffectHandler.formatEvaluation`) | would speak *"Offer. H-E-B. **zero** dollars an hour net. Net 12.50, **zero** miles, score **zero**."* to a driving dasher | new `tts_offer_no_verdict_template` (en + es): *"Offer. H-E-B. Pay $12.50. No verdict — the distance didn't parse."* |
| **Heads-up summary** (`OfferFormatters.toNotificationSummary`) | `OFFER · $0/hr net` / `Net $12.50 · 0.0 mi · $0.00/mi · Score 0 · H-E-B` | `OFFER · no verdict` / `Pay $12.50 · distance didn't parse · H-E-B` |
| **Heads-up custom views** (`BubbleManager.buildOfferCardView`) | `$0/hr`, `0.0 mi`, a red **0** score gauge | already draws `—` for a null metric and hides the gauge for a null score — fixed at the source (below), no view code touched |
| **Bubble offer card** (`FlowCardItem`) | `$0/hr` hero, `0.0 mi · $0.00/mi` | already `?.let`s every metric — same source fix; the hero falls back to the real gross pay |
| **Accepted-job economics** (`JobAcceptFlow.acceptInputsFromPending`, `:core:state`) | `netPay` became gross and `distanceMiles` became `0.0` — which even beat the parsed `null` through the `?:` | both read from a scored evaluation; distance falls back to the parse (null) |
| **Task-card `$/hr` co-hero** (`FlowCardMapper`, #460) | every task card of the job would render a live rate off a fabricated net/distance pair | same gate; a null net simply hides the co-hero |
| **`FakeOfferCard`** (settings preview) | n/a — the simulator's distance slider is `0.5f..20f`, so it can never produce an unscoreable offer | unaffected |

`payAmount` (real gross) and `estMinutes` (the handling floor — not a rate) still read from the
evaluation everywhere.

The single seam for the two card surfaces is `FlowCardSnapshot.Offer.from`, whose metric fields
are *already nullable with existing "unknown" affordances downstream* — so the honest value to
hand them is `null`, gated on the new predicate. `distanceMiles` there already came from
`parsedOffer` (null when unparsed).

`OfferEvaluation.hasDistanceMetrics` (`distanceMiles > 0.0`) is the one SSOT predicate every
consumer branches on, documented at the declaration as "these are placeholders, not
measurements".

### Fold-hazard analysis (plan step 2 — money-critical) — **already guarded**

An `UNKNOWN`-verdict offer can still be accepted manually, and its frozen `OfferEvaluation` feeds
the #659 fuel/non-fuel split at projection. **The division was already guarded** and needed no
change:

`RecordFolds.foldOffer` (`domain/.../analytics/RecordFolds.kt:494-496`)

```kotlin
val evalDist = eval?.distanceMiles
val fuelPerMile = if (eval != null && evalDist != null && evalDist > 0.0) eval.fuelCostEstimate / evalDist else null
val nonFuelPerMile = if (eval != null && evalDist != null && evalDist > 0.0) eval.nonFuelCostEstimate / evalDist else null
```

→ null split → `DeliveryFolds` writes `frozenFuelPerMile`/`frozenNonFuelPerMile` as null → the
waterfall falls back to 3-step. The context capture is also keep-prior (`fuelPerMile ?: it.last…`)
so a distance-0 offer cannot wipe a good split, and `lastEvaluatedCostPerMile` still takes the
real cpm. **No NaN/Infinity can reach a frozen economics column.** An existing test already pinned
it (`RecordFoldsTest`: *a distance-0 offer eval captures cpm but null fuel-non-fuel split (guarded
division)*); this PR extends that test with explicit `isFinite()` assertions on `netProfit` /
`frozenCostPerMile` plus the new #936 column assertions.

One related fold change **was** made, in the same spirit: the offer row's other frozen estimates
(`score`, `estNetPay`, `estDollarsPerHour`, `estDollarsPerMile`, `estTimeMinutes`) now record
`null` for a distance-less evaluation rather than the placeholder `0.0`. `AnalyticsTotals` already
documents that those aggregates must "yield null, never a fabricated 0", and `AVG(score)` /
`AVG(estDollarsPerHour)` / `Σ estNetPay` on the Decisions tab would otherwise be dragged down by an
offer nothing ever scored. `action`, `quality`, the parsed pay/distance and `estOperatingCostPerMile`
still record — those are honest facts.

**No `PROJECTOR_VERSION` bump.** Every historical evaluation in the log was frozen by the old
evaluator, which stamped `distanceMiles = 1.0` for an unparsed distance — so `hasDistanceMetrics`
is true for all of it and a from-zero refold reproduces existing rows byte-identically.
(Incremental ≡ refold is unaffected either way: both run the same fold code.)

### Also folded in — the issue's P8 cosmetic

`buildCaveatWarnings` in `:domain` named DoorDash and quoted market pay norms ("Most offers are
$0.80–$1.50/mi", "Most dashers earn $15–$25/hr", "Most DoorDash orders are under $10") — a
platform literal in the platform-agnostic core, and a market-specific claim we don't measure. The
copy is now platform-neutral ("above what most offers pay", "above typical active earnings"); the
`REALISTIC_MAX_*` thresholds are unchanged, and no `Platform` branch was introduced.

### Tests

`:domain` (pure JVM), 8 new/rewritten cases in `OfferEvaluatorTest`:

* the bug-pinning test `distance null defaults to 1 - prevents divide-by-zero in dpm` (which
  literally asserted **score 100** for a $2.00 offer of unknown length) is replaced by
  `null distance - is NOT scored as a 1-mile trip (the #936 regression)`;
* no fabricated per-mile / per-hour / cost figure, against a *costly* economy, plus the real
  `operatingCostPerMile` and net == gross;
* a parsed `0.0` is unscoreable for the same reason;
* a `MAX_DISTANCE` rule can no longer score a fabricated mile as within a limit it was never
  measured against (the sharpest fail-open shape);
* the shopping opt-out and a BLOCK-listed merchant still hard-decline first;
* **null pay (distance present) still fails toward DECLINE** — the asymmetry pinned deliberately;
* a fully-populated offer is byte-identical to pre-#936 behaviour (regression pin).

Plus the extended `RecordFoldsTest` fold-guard case above.

Verification: `./gradlew :domain:test testDebugUnitTest` — **2854 tests, 0 failures**;
`./gradlew :app:lintVitalRelease` green (new string resources). `AllMatchersSuite` /
`ParseOutputGoldenTest` untouched — the evaluator is not part of recognition.

### Suggested field-test checklist item (not added here — this PR must not touch `docs/field-testing/README.md`)

> **#936 — an offer with an unreadable distance says so instead of guessing.** If a card's mileage
> ever fails to parse, the HUD/notification should show `no verdict` + `distance didn't parse` (no
> `$0/hr`, no score gauge) and the voice should say *"No verdict — the distance didn't parse"*.
> Rare in the field; the desk check is `offer_records` rows with `quality = 'UNKNOWN'` and a null
> `distanceMiles` — their `score`/`estDollarsPerHour` columns must be **null**, never `0`.
> Confirmed: 0/2

### Design-goal review

* **P1 (UDF).** The evaluator stays a pure function of `(ParsedOffer, EvaluationConfig)`; the new
  branch is a return value, not a side effect. `FlowCardSnapshot.Offer.from` remains the pure
  assembly SSOT both the live builder and the event-log fold call.
* **P3 (single responsibility).** No new type or file: the guard reuses the existing
  `OfferQuality.UNKNOWN` no-verdict shape, and one derived predicate replaces what would otherwise
  be four copies of `distanceMiles > 0.0` at the render sites.
* **P4 (Kotlin).** `?.takeIf { it > 0.0 } ?: 0.0` over a nullable-arithmetic special case;
  `hasDistanceMetrics` is a computed property on the `@Serializable` data class, so it adds no
  serialized field and cannot drift from `distanceMiles`.
* **P5 (SSOT).** `hasDistanceMetrics` is the single definition of "these numbers are real",
  consumed by the card assembly, the notification summary, the TTS handler and the analytics fold —
  no surface re-derives it. `NetProfit` remains the cost-math SSOT (the guard sits around its
  already-null-returning denominators, it does not re-implement them).
* **P6 (security/privacy).** No recognition, capture, network or effect-gate change. The new TTS
  branch speaks the merchant name exactly as the existing template does; the INFO log line is
  unchanged (`"speaking (%d chars)"` — a length, no raw text), so the shareable-log posture is
  untouched.
* **P7 (logging).** No log sites added or moved.
* **P8 (platform-agnostic core).** Mandatory here (`:domain` + `:core:state`-adjacent). No
  `Platform` branch, literal, package name or wire string is introduced; the guard keys purely on
  the parsed value. The diff **removes** three platform literals from `:domain` (the DoorDash
  caveat copy). Adding a platform still needs zero edits to this file.
* **Reactive UI.** The touched render paths are data-in renderers of an immutable snapshot; nothing
  time-derived was frozen, and the null metrics flow through the existing recomposition path.

### Adversarial review

_(to be filled in by the pre-merge `/code-review` + `/security-review` pass — not run by the
builder.)_
