### PR TITLE
cleanup(ui): #942 — UI-edge SSOT batch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,8 @@ Hilt/`:core:data`/`:core:state`.) **Remaining Phase-6 extractions: none — Phas
 - **`:domain`** — Pure Kotlin library. Domain models, state regions, evaluation logic,
   pipeline/provider contracts, the capture contracts (`CaptureBus`, `EnvelopeBuilder`,
   capture schemas/DTOs), the `PlatformPreferences` read interface (#355), and the
-  number/money/duration formatting SSOT (`format.Formats` money/decimal + `format.TimeFormats`
+  number/money/duration formatting SSOT (`format.Formats` money/decimal/**percent** — #942 pulled
+  the `(x * 100).roundToInt()` shape down off four UI call sites — + `format.TimeFormats`
   `formatDuration`/`formatCountdown` — the locale policy, #358/#456/#467; lives here so both the
   UI and the state layer route through one definition; the Compose time helpers
   `rememberNow`/`rememberTimeFormatter` stay in `:core:designsystem`). No Android
@@ -209,7 +210,11 @@ Hilt/`:core:data`/`:core:state`.) **Remaining Phase-6 extractions: none — Phas
   `AppGaugeRing`, `AppSegmented`, `AppSlider`, `AppBarChart`, `AppAccordion`). The design-system
   brand vocabulary is `App*`, not `Dash*` (#468) — no platform-flavoured names. No M3 dynamic
   color. Feature-specific composables stay with their feature (Package by Feature); only generic,
-  data-in/lambdas-out components live here.
+  data-in/lambdas-out components live here. It also owns the shared **display vocabulary** two
+  modules would otherwise copy: the Compose time helpers (`time.TimeKit` — `rememberNow`,
+  `rememberTimeFormatter`) and the em-dash no-value placeholder (`text.EMPTY_VALUE`, #942 — the
+  `:app` analytics hub and `:feature:dashboard` each held a copy, and a feature module can never
+  reach an `:app` owner).
 - **`:app`** — UI (Compose + overlays), side effect handlers (SideEffectEngine, odometer, screenshots,
   TTS, tips), Hilt DI wiring, and the `DashBuddyApplication` entry point.
 - **`matchers/`** — the recognition **ruleset** source, as a self-contained **included Gradle build**

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -34,6 +34,7 @@ import cloud.trotter.dashbuddy.feature.bubble.formatters.offerVerdictLabel
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+import cloud.trotter.dashbuddy.domain.model.offer.joinDisplayStores
 import android.os.SystemClock
 import android.view.View
 import android.widget.RemoteViews
@@ -531,7 +532,7 @@ class BubbleManager @Inject constructor(
                     rv.setViewVisibility(slot, View.GONE)
                 }
             }
-            val stores = offer.storeNames.joinToString(" + ")
+            val stores = offer.storeNames.joinDisplayStores()
             val items = if (offer.itemCount > 1) {
                 context.getString(R.string.bubble_offer_card_items_suffix, offer.itemCount)
             } else ""

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
@@ -16,6 +16,7 @@ import cloud.trotter.dashbuddy.domain.model.vehicle.FuelType
 import cloud.trotter.dashbuddy.domain.state.AppState
 import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.focusedPlatform
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.feature.bubble.cards.BubbleCards
@@ -27,6 +28,7 @@ import cloud.trotter.dashbuddy.feature.bubble.session.BubbleSessionResolver
 import cloud.trotter.dashbuddy.feature.bubble.session.LiveSession
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -89,11 +91,8 @@ class BubbleViewModel @Inject constructor(
     private val _selectedPlatform = MutableStateFlow<Platform?>(null)
 
     /** The platform whose frame we last recognized — the base the presentation follows. */
-    private val followPlatform = stateManager.state
-        .map { state ->
-            state.regions.flow.activePlatform
-                ?: state.regions.crossPlatform.mostRecentActivityPlatform
-        }
+    private val followPlatform: Flow<Platform?> = stateManager.state
+        .map { it.focusedPlatform() }
         .distinctUntilChanged()
 
     /** Every platform currently dashing (`PlatformRegion.session != null`), oldest dash first. */

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
@@ -15,11 +15,12 @@ import cloud.trotter.dashbuddy.domain.analytics.StoreReportCard
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 
 /**
- * The placeholder shown for a stat with no measurable value yet — the em-dash. ONE owner across every
- * analytics-hub tab (Money / Decisions / Time / Patterns / SessionDetail), Principle 5: a per-file copy
- * is a divergence bug waiting to fire.
+ * Below this a money figure is effectively zero — no callout, no cash-tip line (it avoids flagging
+ * a "$0.00"). ONE owner for the analytics hub (#942): the Money tab and the per-dash drill-down
+ * each kept their own `private const` copy of the same 0.005, which is a threshold that can only
+ * ever drift apart.
  */
-internal const val EMPTY_VALUE = "—"
+internal const val UNATTRIBUTED_EPSILON = 0.005
 
 /**
  * The Analytics hub tabs (#315). [Money], [Decisions] (H3), [Time] (H4), and [Patterns] (H5) all

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/DecisionsTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/DecisionsTab.kt
@@ -21,10 +21,10 @@ import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.component.AppLegend
 import cloud.trotter.dashbuddy.core.designsystem.component.AppSegment
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStackBar
+import cloud.trotter.dashbuddy.core.designsystem.text.EMPTY_VALUE
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.format.Formats
-import kotlin.math.roundToInt
 
 
 /**
@@ -62,7 +62,7 @@ private fun OfferFunnelCard(decisions: DecisionEconomics) {
             return@AppCard
         }
 
-        val rate = decisions.acceptanceRate?.let { "${(it * 100).roundToInt()}%" } ?: EMPTY_VALUE
+        val rate = decisions.acceptanceRate?.let { Formats.percent(it) } ?: EMPTY_VALUE
         Text(text = rate, style = AppTheme.num.heroNum, color = c.text)
         Spacer(Modifier.height(2.dp))
         Text(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -32,6 +32,7 @@ import cloud.trotter.dashbuddy.core.designsystem.component.AppCallout
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
+import cloud.trotter.dashbuddy.core.designsystem.text.EMPTY_VALUE
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferGroup
@@ -43,9 +44,6 @@ import cloud.trotter.dashbuddy.domain.format.formatShortDate
 import java.time.format.TextStyle
 import java.util.Locale
 
-
-/** Below this the unattributed pay is effectively zero — no callout (avoids a "$0.00" flag). */
-private const val UNATTRIBUTED_EPSILON = 0.005
 
 /**
  * Money tab v1 (#315 H1): the frozen-net earnings review for the selected period, top→bottom —

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/NoSessionAssignDialogs.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/NoSessionAssignDialogs.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.designsystem.text.EMPTY_VALUE
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/OrphanOfferAttestDialog.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/OrphanOfferAttestDialog.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.designsystem.text.EMPTY_VALUE
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferCandidate
 import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferGroup

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
+import cloud.trotter.dashbuddy.core.designsystem.text.EMPTY_VALUE
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppColors
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
@@ -44,6 +44,7 @@ import cloud.trotter.dashbuddy.core.designsystem.component.AppCallout
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
+import cloud.trotter.dashbuddy.core.designsystem.text.EMPTY_VALUE
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
 import cloud.trotter.dashbuddy.domain.analytics.PayBasis
@@ -53,10 +54,6 @@ import cloud.trotter.dashbuddy.domain.format.formatClockTime
 import cloud.trotter.dashbuddy.domain.format.formatDuration
 import cloud.trotter.dashbuddy.domain.format.formatShortDate
 import kotlin.math.roundToInt
-
-/** Below this the unattributed pay is effectively zero — no callout (avoids a "$0.00" flag). */
-private const val UNATTRIBUTED_EPSILON = 0.005
-
 
 /**
  * The read-only per-dash drill-down (#650 PR A): one dash expanded top→bottom — a header card

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
@@ -20,6 +20,7 @@ import cloud.trotter.dashbuddy.core.designsystem.component.AppLegend
 import cloud.trotter.dashbuddy.core.designsystem.component.AppSegment
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStackBar
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
+import cloud.trotter.dashbuddy.core.designsystem.text.EMPTY_VALUE
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.core.data.analytics.PeriodBounds
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
@@ -29,7 +30,6 @@ import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.format.formatDuration
 import java.time.Instant
 import java.time.ZoneId
-import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 
 
@@ -129,8 +129,8 @@ private fun DeadheadCard(time: TimeEconomics) {
             return@AppCard
         }
 
-        val deadheadPct = (time.unattributedMiles / time.miles * 100.0).roundToInt()
-        Text(text = "$deadheadPct%", style = AppTheme.num.heroNum, color = c.text)
+        val deadheadPct = Formats.percent(time.unattributedMiles / time.miles)
+        Text(text = deadheadPct, style = AppTheme.num.heroNum, color = c.text)
         Spacer(Modifier.height(2.dp))
         Text(
             text = stringResource(R.string.time_tab_deadhead_caption),
@@ -167,7 +167,7 @@ private fun OnTimeCard(time: TimeEconomics) {
 
         AppGaugeRing(
             progress = rate.toFloat(),
-            value = "${(rate * 100.0).roundToInt()}%",
+            value = Formats.percent(rate),
             label = stringResource(R.string.time_tab_gauge_on_time_label),
             color = c.good,
         )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
@@ -12,6 +12,7 @@ import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.focusedPlatform
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
 import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -89,11 +90,8 @@ class DashboardViewModel @Inject constructor(
     }
 
     /** The platform the home status attributes to — registry-resolved, not a literal. */
-    private fun focusedRegion(state: AppState): PlatformRegion? {
-        val platform: Platform? = state.regions.flow.activePlatform
-            ?: state.regions.crossPlatform.mostRecentActivityPlatform
-        return platform?.let { state.regions.platforms[it] }
-    }
+    private fun focusedRegion(state: AppState): PlatformRegion? =
+        state.focusedPlatform()?.let { state.regions.platforms[it] }
 
     @StringRes
     private fun statusText(flow: Flow, mode: Mode?): Int {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/ratings/RatingsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/ratings/RatingsViewModel.kt
@@ -3,8 +3,7 @@ package cloud.trotter.dashbuddy.ui.main.ratings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
-import cloud.trotter.dashbuddy.domain.state.AppState
-import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.focusedPlatform
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -27,13 +26,9 @@ class RatingsViewModel @Inject constructor(
 
     val uiState: StateFlow<RatingsUiState> = stateManager.state
         .map { state ->
-            val platform = focusedPlatform(state)
+            val platform = state.focusedPlatform()
             val snapshot = platform?.let { state.regions.platforms[it]?.ratings }
             RatingsUiState.from(platform, snapshot)
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), RatingsUiState.EMPTY)
-
-    private fun focusedPlatform(state: AppState): Platform? =
-        state.regions.flow.activePlatform
-            ?: state.regions.crossPlatform.mostRecentActivityPlatform
 }

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/text/AppText.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/text/AppText.kt
@@ -1,0 +1,15 @@
+package cloud.trotter.dashbuddy.core.designsystem.text
+
+/**
+ * The placeholder shown for a stat with no measurable value yet — the em-dash.
+ *
+ * ONE owner (#942, principle 5) for every surface that renders a nullable number: the analytics-hub
+ * tabs (Money / Decisions / Time / Patterns / SessionDetail, `:app`) AND the home glance's
+ * `PeriodReview` (`:feature:dashboard`). The `:app` copy's own KDoc already forbade per-file copies,
+ * but a feature module can never depend on `:app`, so the copy was the only way to reach it — the
+ * fix is to own it where both can: the design system, which is where display vocabulary belongs.
+ *
+ * Not a string resource: it is a typographic token, identical in every locale, and several call
+ * sites are non-Composable `?:` fallbacks.
+ */
+const val EMPTY_VALUE = "—"

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/format/Formats.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/format/Formats.kt
@@ -44,4 +44,14 @@ object Formats {
 
     /** "12,500" — grouped integer. */
     fun commaInt(value: Int): String = String.format(locale, "%,d", value)
+
+    /**
+     * "67%" — a 0..1 [fraction] rendered as a percentage with [decimals] places
+     * (#942). Callers pass the fraction, NOT the pre-multiplied value: the `* 100`
+     * belongs to the formatter, and hand-rolling it at the call site is how the
+     * bubble's acceptance rate (integer-truncated) and the Decisions tab's
+     * (rounded) came to disagree by a point on the same metric.
+     */
+    fun percent(fraction: Double, decimals: Int = 0): String =
+        String.format(locale, "%.${decimals}f%%", fraction * 100.0)
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
@@ -78,6 +78,15 @@ sealed class FlowCardSnapshot {
 
         companion object {
             /**
+             * The synthetic Shop & Deliver badge marker (#461) — not an
+             * [cloud.trotter.dashbuddy.domain.model.offer.OfferBadge] /
+             * [cloud.trotter.dashbuddy.domain.model.order.OrderBadge] constant, so it needs its own
+             * owner (#942). Minted by [badgesOf] and recognized by the renderer; the literal
+             * `"SHOP"` used to live at both ends.
+             */
+            const val SHOP_BADGE = "SHOP"
+
+            /**
              * Single owner (SSOT) for assembling an [Offer] card from a
              * [ParsedOffer] + its [OfferEvaluation]. Both the live builder
              * (from `AppState`) and the event-log fold call this so the
@@ -130,7 +139,7 @@ sealed class FlowCardSnapshot {
                 (parsedOffer.badges.map { it.name } +
                     parsedOffer.orders.flatMap { it.badges }.map { it.name } +
                     if (parsedOffer.orders.any { it.orderType == OrderType.SHOP_FOR_ITEMS }) {
-                        listOf("SHOP")
+                        listOf(SHOP_BADGE)
                     } else {
                         emptyList()
                     }).distinct()

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/offer/ParsedOffer.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/offer/ParsedOffer.kt
@@ -138,5 +138,16 @@ data class ParsedOffer(
         }
 
     /** [displayStores] as one human string — the form TTS speaks and the ledger records. */
-    val displayStoreText: String get() = displayStores.joinToString(separator = " & ")
+    val displayStoreText: String get() = displayStores.joinDisplayStores()
 }
+
+/**
+ * The ONE way a list of display store names becomes one human string (#942).
+ *
+ * [ParsedOffer.displayStoreText] is the primary read, but two surfaces hold only the already-derived
+ * `List<String>` (the bubble HUD's `FlowCardSnapshot.Offer.storeNames` and the heads-up
+ * notification's offer payload) and each re-implemented the join — with different separators, so a
+ * stacked offer read "A & B" on the card and "A + B" in the notification for the same offer.
+ * Separator lives here, not at either call site.
+ */
+fun List<String>.joinDisplayStores(): String = joinToString(separator = " & ")

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/order/OrderBadge.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/order/OrderBadge.kt
@@ -9,17 +9,23 @@ package cloud.trotter.dashbuddy.domain.model.order
  * so the enum is a stable set of serialized keys (persisted by name via `DataTypeConverters`). The
  * old Kotlin text-matching machinery (`findAllBadgesInOrderBlock`/`findBadgesInText` and the
  * `badgeText` column) was superseded by the rules and removed.
+ *
+ * Each constant carries a human-readable [displayName] — the ONE label owner for the badge
+ * (#942), mirroring [cloud.trotter.dashbuddy.domain.model.offer.OfferBadge]. The bubble's badge
+ * pill row used to keep its own per-badge label map, which drifted and silently missed branches.
  */
-enum class OrderBadge {
+enum class OrderBadge(
+    val displayName: String,
+) {
     /** Indicates that a Red Card is required for this specific order (e.g., for payment at the store). */
-    RED_CARD,
+    RED_CARD(displayName = "Red Card"),
 
     /** Indicates this specific order is a large catering order, often requiring more space or different handling. */
-    LARGE_ORDER,
+    LARGE_ORDER(displayName = "Large Order"),
 
     /** Indicates a pizza bag is required for this specific order. */
-    PIZZA_BAG,
+    PIZZA_BAG(displayName = "Pizza Bag"),
 
     /** Indicates this specific order contains alcohol and may require ID check at pickup or dropoff for this leg. */
-    ALCOHOL,
+    ALCOHOL(displayName = "Alcohol"),
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/AppState.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/AppState.kt
@@ -50,3 +50,21 @@ fun AppState.activeSessionId(): String? {
         ?.let { regions.platforms[it]?.session?.sessionId }
     return active ?: regions.platforms.values.firstNotNullOfOrNull { it.session?.sessionId }
 }
+
+/**
+ * THE platform the UI focuses on (#942) — the flow region's screen-authoritative
+ * active platform, else the cross-platform region's most recent activity so a
+ * neutral/home screen keeps showing the dash the dasher was just on.
+ *
+ * Derived, never a second copy (principle 5): four surfaces — the home dashboard,
+ * the ratings screen, the bubble's follow-platform base, and the live card builder —
+ * hand-rolled this same `activePlatform ?: mostRecentActivityPlatform` expression in
+ * three different modules, which is exactly how the #356 family started. Lives beside
+ * [activeSessionId] because it is the same "which dash is the UI talking about"
+ * question, one step earlier.
+ *
+ * Platform-agnostic by construction: both inputs are registry-resolved [Platform]
+ * values, so no surface can grow a literal.
+ */
+fun AppState.focusedPlatform(): Platform? =
+    regions.flow.activePlatform ?: regions.crossPlatform.mostRecentActivityPlatform

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/format/FormatsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/format/FormatsTest.kt
@@ -40,4 +40,35 @@ class FormatsTest {
         assertEquals("$7,50", Formats.money(7.5))
         assertEquals("12.500", Formats.commaInt(12_500))
     }
+
+    /**
+     * #942: [Formats.percent] replaced four hand-rolled `(x * 100).roundToInt()` sites, so its
+     * whole-number output must be byte-identical to what those rendered.
+     */
+    @Test
+    fun `percent matches the hand-rolled roundToInt shape it replaced`() {
+        Locale.setDefault(Locale.US)
+        assertEquals("0%", Formats.percent(0.0))
+        assertEquals("100%", Formats.percent(1.0))
+        assertEquals("67%", Formats.percent(2.0 / 3.0))
+        assertEquals("33%", Formats.percent(1.0 / 3.0))
+        // .5 rounds up, exactly as roundToInt() does for a non-negative value.
+        assertEquals("13%", Formats.percent(0.125))
+        assertEquals("74%", Formats.percent(0.7351))
+    }
+
+    @Test
+    fun `percent takes the fraction, never the pre-multiplied value`() {
+        Locale.setDefault(Locale.US)
+        assertEquals("8%", Formats.percent(0.08))
+        assertEquals("800%", Formats.percent(8.0))
+    }
+
+    @Test
+    fun `percent honors a decimals request and the device locale`() {
+        Locale.setDefault(Locale.US)
+        assertEquals("66.7%", Formats.percent(2.0 / 3.0, decimals = 1))
+        Locale.setDefault(Locale.GERMANY)
+        assertEquals("66,7%", Formats.percent(2.0 / 3.0, decimals = 1))
+    }
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/offer/BadgeDisplayNameTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/offer/BadgeDisplayNameTest.kt
@@ -1,0 +1,47 @@
+package cloud.trotter.dashbuddy.domain.model.offer
+
+import cloud.trotter.dashbuddy.domain.model.order.OrderBadge
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #942: `displayName` is now the ONE badge-label owner — the bubble HUD's pill row reads it instead
+ * of a second, drifted map that silently missed ≥8 branches and rendered them as a lowercased enum
+ * name. That only holds if every constant actually carries a human label, so a badge added later
+ * cannot reintroduce the mangle.
+ */
+class BadgeDisplayNameTest {
+
+    @Test
+    fun `every OfferBadge carries a human displayName`() {
+        OfferBadge.entries.forEach { badge ->
+            assertTrue("${badge.name} has a blank displayName", badge.displayName.isNotBlank())
+            assertTrue(
+                "${badge.name} renders its raw enum name — that IS the mangle #942 removed",
+                badge.displayName != badge.name,
+            )
+        }
+    }
+
+    @Test
+    fun `every OrderBadge carries a human displayName`() {
+        OrderBadge.entries.forEach { badge ->
+            assertTrue("${badge.name} has a blank displayName", badge.displayName.isNotBlank())
+            assertTrue(
+                "${badge.name} renders its raw enum name — that IS the mangle #942 removed",
+                badge.displayName != badge.name,
+            )
+        }
+    }
+
+    /**
+     * The renderer resolves a wire name by scanning both enums, so a name shared between them would
+     * make the lookup order (offer first) silently decide the color.
+     */
+    @Test
+    fun `the two badge enums share no constant name`() {
+        val offerNames = OfferBadge.entries.map { it.name }.toSet()
+        val collisions = OrderBadge.entries.map { it.name }.filter { it in offerNames }
+        assertTrue("OfferBadge/OrderBadge name collision: $collisions", collisions.isEmpty())
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/offer/OfferDisplayStoreTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/offer/OfferDisplayStoreTest.kt
@@ -89,6 +89,20 @@ class OfferDisplayStoreTest {
         assertEquals("", offer(null).displayStoreText)
     }
 
+    /**
+     * #942: the two surfaces that hold only the derived list (the HUD offer card and the heads-up
+     * notification) join through this, not through their own separator — they used to disagree
+     * (" & " vs " + ") about the same offer.
+     */
+    @Test
+    fun `joinDisplayStores is the separator SSOT displayStoreText itself uses`() {
+        assertEquals("A & B", listOf("A", "B").joinDisplayStores())
+        assertEquals("A", listOf("A").joinDisplayStores())
+        assertEquals("", emptyList<String>().joinDisplayStores())
+        val stacked = offer(null, "Tarka Indian Kitchen", "Torchy's Tacos")
+        assertEquals(stacked.displayStoreText, stacked.displayStores.joinDisplayStores())
+    }
+
     // ---------------------------------------------------------------------------------------
     // The evaluator (the SSOT's one consumer) — merchantName is what TTS speaks
     // ---------------------------------------------------------------------------------------

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/FocusedPlatformTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/FocusedPlatformTest.kt
@@ -1,0 +1,40 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #942: [focusedPlatform] is the one owner of "which dash is the UI talking about", extracted from
+ * four hand-rolled copies (home dashboard, ratings screen, bubble follow-platform, live card
+ * builder) in three modules. These pin the exact precedence those copies had, so the extraction is
+ * provably behavior-preserving.
+ */
+class FocusedPlatformTest {
+
+    @Test
+    fun `the flow region's active platform wins`() {
+        val state = AppState(
+            regions = Regions(
+                flow = FlowRegion(activePlatform = Platform.Uber),
+                crossPlatform = CrossPlatformRegion(mostRecentActivityPlatform = Platform.DoorDash),
+            ),
+        )
+        assertEquals(Platform.Uber, state.focusedPlatform())
+    }
+
+    @Test
+    fun `falls back to most-recent activity on a neutral screen`() {
+        val state = AppState(
+            regions = Regions(
+                crossPlatform = CrossPlatformRegion(mostRecentActivityPlatform = Platform.DoorDash),
+            ),
+        )
+        assertEquals(Platform.DoorDash, state.focusedPlatform())
+    }
+
+    @Test
+    fun `null when nothing has been recognized yet`() {
+        assertNull(AppState().focusedPlatform())
+    }
+}

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/ChatViews.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/ChatViews.kt
@@ -1,7 +1,6 @@
 package cloud.trotter.dashbuddy.feature.bubble
 
 import android.text.Html
-import android.text.format.DateFormat
 import android.widget.TextView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -28,24 +27,22 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import cloud.trotter.dashbuddy.core.designsystem.time.rememberTimeFormatter
 import cloud.trotter.dashbuddy.feature.bubble.R
 import cloud.trotter.dashbuddy.domain.model.chat.ChatMessage
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.feature.bubble.formatters.getIconResId
-import java.util.Date
 
 // ---------------------------------------------------------------------------
 // Chat header title
@@ -165,8 +162,6 @@ fun FullChatView(messages: List<ChatMessage>) {
 
 @Composable
 fun ChatBubble(message: ChatMessage) {
-    val context = LocalContext.current
-
     val isSystem =
         message.persona is ChatPersona.Dispatcher || message.persona is ChatPersona.System
 
@@ -176,9 +171,11 @@ fun ChatBubble(message: ChatMessage) {
         MaterialTheme.colorScheme.primary
     }
 
-    val timeString = remember(message.timestamp) {
-        DateFormat.getTimeFormat(context).format(Date(message.timestamp))
-    }
+    // #942: the designsystem TimeKit formatter, not a second private wall-clock formatter — it is
+    // keyed on the device's 12/24-hour setting, so flipping that setting now re-renders the chat
+    // timestamps instead of freezing them until the next recomposition of this message.
+    val formatTime = rememberTimeFormatter()
+    val timeString = formatTime(message.timestamp)
 
     Row(
         modifier = Modifier.fillMaxWidth(),

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/ModeCards.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/ModeCards.kt
@@ -139,10 +139,13 @@ private fun LastSessionSummary(session: SessionRecord, focusedPlatform: Platform
         }
 
         if (session.offersReceived > 0) {
-            val pct = session.offersAccepted * 100 / session.offersReceived
             ModeRow(
                 label = stringResource(R.string.bubble_mode_idle_acceptance_label),
-                value = "$pct%",
+                // #942: the Formats.percent SSOT — this used to truncate via integer division while
+                // the Decisions tab rounded, so the same acceptance rate could differ by a point.
+                value = Formats.percent(
+                    session.offersAccepted.toDouble() / session.offersReceived,
+                ),
             )
         }
 

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/FlowCardItem.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/FlowCardItem.kt
@@ -53,7 +53,11 @@ import androidx.compose.ui.draw.clip
 import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
 import cloud.trotter.dashbuddy.core.designsystem.component.AppGaugeRing
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppColors
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+import cloud.trotter.dashbuddy.domain.model.offer.OfferBadge
+import cloud.trotter.dashbuddy.domain.model.offer.joinDisplayStores
+import cloud.trotter.dashbuddy.domain.model.order.OrderBadge
 import cloud.trotter.dashbuddy.domain.model.cards.TaskEconomics
 import cloud.trotter.dashbuddy.domain.state.PickupActivity
 import cloud.trotter.dashbuddy.domain.state.flowPhase
@@ -63,8 +67,11 @@ import cloud.trotter.dashbuddy.domain.model.pay.displayLabel
 import cloud.trotter.dashbuddy.feature.bubble.formatters.color
 import cloud.trotter.dashbuddy.feature.bubble.formatters.displayLabel
 import cloud.trotter.dashbuddy.feature.bubble.formatters.offerBadgeIcon
+import cloud.trotter.dashbuddy.feature.bubble.formatters.offerScoreColor
+import cloud.trotter.dashbuddy.feature.bubble.formatters.offerVerdictColor
+import cloud.trotter.dashbuddy.feature.bubble.formatters.offerVerdictContainer
+import cloud.trotter.dashbuddy.feature.bubble.formatters.offerVerdictLabel
 import cloud.trotter.dashbuddy.feature.bubble.formatters.phaseBg
-import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluator
 import cloud.trotter.dashbuddy.domain.state.customerLabel
 
 /**
@@ -353,12 +360,9 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             snap.evaluationScore?.let { score ->
-                // Ring colors track the evaluator's REAL decision boundaries (#400).
-                val sc = when {
-                    score >= OfferEvaluator.ACCEPT_THRESHOLD -> c.good
-                    score <= OfferEvaluator.DECLINE_THRESHOLD -> c.bad
-                    else -> c.warn
-                }
+                // Ring colors track the evaluator's REAL decision boundaries (#400) — via the
+                // [offerScoreColor] SSOT the notification gauge shares (#942).
+                val sc = offerScoreColor(score, c)
                 AppGaugeRing(
                     progress = (score / 100.0).toFloat(),
                     value = score.toInt().toString(),
@@ -398,21 +402,17 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
             // (#461: the item count now rides the [cart N] shop badge below, not the hero tier.)
         }
 
-        // Verdict banner — action word + reason + quality chip, tinted by the action.
-        snap.evaluationAction?.let { action ->
-            val vColor = when (action) {
-                "ACCEPT" -> c.good
-                "DECLINE" -> c.bad
-                else -> c.warn
-            }
-            val vBg = when (action) {
-                "ACCEPT" -> c.goodBg
-                "DECLINE" -> c.badBg
-                else -> c.warnBg
-            }
+        // Verdict banner — action word + reason + quality chip, tinted by the action. The word and
+        // its two tints come from the [offerVerdictLabel]/[offerVerdictColor] SSOT the heads-up
+        // notification shares (#942); this used to be three independent `when`s over the raw enum
+        // NAME (the #283 stringly-typed shape), which is how "REVIEW" here became "MANUAL REVIEW".
+        snap.evaluationAction?.let { name ->
+            val action = runCatching { OfferAction.valueOf(name) }.getOrNull()
+            val vColor = offerVerdictColor(action, c)
+            val vBg = offerVerdictContainer(action, c)
             val vIcon = when (action) {
-                "ACCEPT" -> Icons.Default.Check
-                "DECLINE" -> Icons.Default.Close
+                OfferAction.ACCEPT -> Icons.Default.Check
+                OfferAction.DECLINE -> Icons.Default.Close
                 else -> Icons.Default.Info
             }
             Surface(shape = MaterialTheme.shapes.small, color = vBg) {
@@ -424,7 +424,7 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
                     Icon(vIcon, contentDescription = null, tint = vColor, modifier = Modifier.size(18.dp))
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
-                            action.replace('_', ' '),
+                            offerVerdictLabel(action),
                             style = MaterialTheme.typography.labelLarge,
                             fontWeight = FontWeight.ExtraBold,
                             color = vColor,
@@ -446,7 +446,7 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
                 snap.badges.forEach { b ->
                     val (label, col) = badgeMeta(b, c)
                     when {
-                        b == "SHOP" -> BadgeIcon(
+                        b == FlowCardSnapshot.Offer.SHOP_BADGE -> BadgeIcon(
                             iconRes = R.drawable.ic_chat_shopping_cart,
                             label = snap.itemCount.takeIf { it > 0 }?.toString(),
                             color = col,
@@ -459,8 +459,9 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
             }
         }
 
-        // Footer: stores. (Item count moved up to the hero tier, #461.)
-        val storeText = snap.storeNames.joinToString(" & ").ifBlank { null }
+        // Footer: stores, joined by the :domain display SSOT (#942 — the heads-up notification
+        // used to say "A + B" for the same offer this card called "A & B").
+        val storeText = snap.storeNames.joinDisplayStores().ifBlank { null }
         if (storeText != null) Caption(storeText)
     }
 }
@@ -514,20 +515,41 @@ private fun BadgeIcon(
     }
 }
 
-/** Maps a badge enum name to a short label + brand color for the pill row. */
+/**
+ * Maps a badge wire name to its label + brand color for the pill row.
+ *
+ * The **label** is not this function's to own (#942): every badge is an
+ * [OfferBadge]/[OrderBadge] constant carrying a `displayName`, and this map used to keep a second,
+ * drifted set of labels that silently missed ≥8 branches — those fell to a lowercased-enum mangle
+ * ("Age restricted 21 plus"). Only the synthetic
+ * [SHOP_BADGE][FlowCardSnapshot.Offer.SHOP_BADGE] marker, which is no enum constant, keeps a
+ * string-resource label of its own.
+ *
+ * The **color** is the one thing this owns — and it is keyed on the typed enums, not on raw name
+ * strings (the #283 stringly-typed shape).
+ */
 @Composable
-private fun badgeMeta(name: String, c: AppColors): Pair<String, Color> = when (name) {
-    "SHOP" -> stringResource(R.string.flow_card_badge_shop_and_deliver) to c.stPickup
-    "HIGH_PAYING" -> stringResource(R.string.flow_card_badge_high_pay) to c.good
-    "PRIORITY_ACCESS" -> stringResource(R.string.flow_card_badge_priority) to c.stOffer
-    "RED_CARD" -> stringResource(R.string.flow_card_badge_red_card) to c.bad
-    "ALCOHOL" -> stringResource(R.string.flow_card_badge_alcohol) to c.warn
-    "LARGE_ORDER" -> stringResource(R.string.flow_card_badge_large_order) to c.neutral
-    "PIZZA_BAG" -> stringResource(R.string.flow_card_badge_pizza_bag) to c.neutral
-    "ALL_ORDERS_SAME_STORE" -> stringResource(R.string.flow_card_badge_same_store) to c.neutral
-    "BOTH_ORDERS_SAME_CUSTOMER" -> stringResource(R.string.flow_card_badge_same_customer) to c.neutral
-    "ITEMS_CAN_BE_ADDED" -> stringResource(R.string.flow_card_badge_add_ons_ok) to c.neutral
-    else -> name.lowercase().replace('_', ' ').replaceFirstChar { it.uppercase() } to c.neutral
+private fun badgeMeta(name: String, c: AppColors): Pair<String, Color> {
+    if (name == FlowCardSnapshot.Offer.SHOP_BADGE) {
+        return stringResource(R.string.flow_card_badge_shop_and_deliver) to c.stPickup
+    }
+    OfferBadge.entries.firstOrNull { it.name == name }?.let { badge ->
+        return badge.displayName to when (badge) {
+            OfferBadge.HIGH_PAYING -> c.good
+            OfferBadge.PRIORITY_ACCESS -> c.stOffer
+            else -> c.neutral
+        }
+    }
+    OrderBadge.entries.firstOrNull { it.name == name }?.let { badge ->
+        return badge.displayName to when (badge) {
+            OrderBadge.RED_CARD -> c.bad
+            OrderBadge.ALCOHOL -> c.warn
+            OrderBadge.LARGE_ORDER, OrderBadge.PIZZA_BAG -> c.neutral
+        }
+    }
+    // Unreachable today — the snapshot's badge list is minted from the two enums plus SHOP — but a
+    // future marker renders as itself rather than vanishing.
+    return name to c.neutral
 }
 
 /** Pickup body — the #324/#460 task-card vocabulary (co-hero pair). */

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/LiveCardBuilder.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/LiveCardBuilder.kt
@@ -7,6 +7,7 @@ import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import cloud.trotter.dashbuddy.domain.state.UNKNOWN_STORE
+import cloud.trotter.dashbuddy.domain.state.focusedPlatform
 
 /**
  * Constructs the live (active) flow card from the current [AppState].
@@ -20,9 +21,7 @@ import cloud.trotter.dashbuddy.domain.state.UNKNOWN_STORE
 object LiveCardBuilder {
 
     fun build(state: AppState): FlowCardSnapshot? {
-        val platform = state.regions.flow.activePlatform
-            ?: state.regions.crossPlatform.mostRecentActivityPlatform
-            ?: return null
+        val platform = state.focusedPlatform() ?: return null
         val region = state.regions.platforms[platform] ?: return null
         val flow = state.regions.flow.flow
         val now = state.timestamp

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/formatters/OfferFormatters.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/formatters/OfferFormatters.kt
@@ -6,8 +6,10 @@ import android.text.SpannableStringBuilder
 import android.text.style.ForegroundColorSpan
 import android.text.style.RelativeSizeSpan
 import android.text.style.StyleSpan
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import cloud.trotter.dashbuddy.feature.bubble.R
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppColors
 import cloud.trotter.dashbuddy.core.designsystem.theme.darkAppColors
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
@@ -28,28 +30,42 @@ fun offerVerdictLabel(action: OfferAction?): String = when (action) {
     else -> "OFFER"
 }
 
+/**
+ * Verdict foreground color — the companion of [offerVerdictLabel], so the word and its tint can't
+ * drift (#942). The bubble offer card's verdict banner re-implemented this keyed on the raw enum
+ * NAME (`"ACCEPT" -> c.good`), the #283 stringly-typed shape.
+ */
+fun offerVerdictColor(action: OfferAction?, c: AppColors): Color = when (action) {
+    OfferAction.ACCEPT -> c.good
+    OfferAction.DECLINE -> c.bad
+    else -> c.warn
+}
+
+/** The [offerVerdictColor] container tint for a filled verdict surface (#942). */
+fun offerVerdictContainer(action: OfferAction?, c: AppColors): Color = when (action) {
+    OfferAction.ACCEPT -> c.goodBg
+    OfferAction.DECLINE -> c.badBg
+    else -> c.warnBg
+}
+
 /** Verdict color as an ARGB int (RemoteViews can't use Compose Color / theme attrs). */
-fun offerVerdictArgb(action: OfferAction?): Int = darkAppColors().let { c ->
-    when (action) {
-        OfferAction.ACCEPT -> c.good
-        OfferAction.DECLINE -> c.bad
-        OfferAction.MANUAL_REVIEW -> c.warn
-        else -> c.warn
-    }
-}.toArgb()
+fun offerVerdictArgb(action: OfferAction?): Int =
+    offerVerdictColor(action, darkAppColors()).toArgb()
 
 /**
- * Score-band color as an ARGB int for the notification gauge ring (#583) — mirrors the bubble offer
- * card's ring color (`OfferBody`): the evaluator's real decision boundaries (#400). good ≥ ACCEPT,
- * bad ≤ DECLINE, warn in between.
+ * Score-band color: the evaluator's REAL decision boundaries (#400) — good ≥ ACCEPT, bad ≤ DECLINE,
+ * warn in between. One owner (#942) for the bubble offer card's gauge ring and the notification
+ * gauge ring (#583), which held a verbatim copy of this `when`.
  */
-fun offerScoreArgb(score: Double): Int = darkAppColors().let { c ->
-    when {
-        score >= OfferEvaluator.ACCEPT_THRESHOLD -> c.good
-        score <= OfferEvaluator.DECLINE_THRESHOLD -> c.bad
-        else -> c.warn
-    }
-}.toArgb()
+fun offerScoreColor(score: Double, c: AppColors): Color = when {
+    score >= OfferEvaluator.ACCEPT_THRESHOLD -> c.good
+    score <= OfferEvaluator.DECLINE_THRESHOLD -> c.bad
+    else -> c.warn
+}
+
+/** [offerScoreColor] as an ARGB int for the notification gauge ring (#583). */
+fun offerScoreArgb(score: Double): Int =
+    offerScoreColor(score, darkAppColors()).toArgb()
 
 /**
  * SSOT (#461/#578) badge enum name → `ic_badge_*` drawable, shared by the bubble offer card and the

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/session/BubbleSessionResolver.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/session/BubbleSessionResolver.kt
@@ -80,8 +80,8 @@ object BubbleSessionResolver {
     /**
      * @param mode the dev-settings experiment switch.
      * @param selection the switcher's current pick (null ⇒ never picked / released by the caller).
-     * @param followPlatform `flow.activePlatform ?: crossPlatform.mostRecentActivityPlatform` —
-     *   the platform of the last recognized frame.
+     * @param followPlatform [cloud.trotter.dashbuddy.domain.state.focusedPlatform] — the platform of
+     *   the last recognized frame.
      * @param liveSessions every platform with a live session, caller-ordered (oldest dash first).
      * @param fallbackSessionId the durable most-recent session from the event log (#459) — what to
      *   show when nothing is live.

--- a/feature/bubble/src/main/res/values/strings.xml
+++ b/feature/bubble/src/main/res/values/strings.xml
@@ -48,15 +48,6 @@
     <string name="flow_card_distance_secondary_format" translatable="false">%1$s mi</string>
     <string name="flow_card_per_mile_secondary_format" translatable="false">%1$s/mi</string>
     <string name="flow_card_badge_shop_and_deliver">Shop &amp; Deliver</string>
-    <string name="flow_card_badge_high_pay">High pay</string>
-    <string name="flow_card_badge_priority">Priority</string>
-    <string name="flow_card_badge_red_card">Red Card</string>
-    <string name="flow_card_badge_alcohol">Alcohol</string>
-    <string name="flow_card_badge_large_order">Large order</string>
-    <string name="flow_card_badge_pizza_bag">Pizza bag</string>
-    <string name="flow_card_badge_same_store">Same store</string>
-    <string name="flow_card_badge_same_customer">Same customer</string>
-    <string name="flow_card_badge_add_ons_ok">Add-ons OK</string>
     <string name="flow_card_timer_dwell_label">Dwell</string>
     <string name="flow_card_timer_at_door_sub">at door</string>
     <string name="flow_card_timer_at_store_sub">at store</string>

--- a/feature/dashboard/src/main/java/cloud/trotter/dashbuddy/feature/dashboard/components/PeriodReview.kt
+++ b/feature/dashboard/src/main/java/cloud/trotter/dashbuddy/feature/dashboard/components/PeriodReview.kt
@@ -12,14 +12,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
+import cloud.trotter.dashbuddy.core.designsystem.text.EMPTY_VALUE
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.feature.dashboard.R
-
-/** Placeholder shown for a rate figure that has no measurable denominator yet. */
-private const val EMPTY_VALUE = "—"
 
 /** The review windows offered by the period selector, in display order. */
 private data class PeriodOption(val period: AnalyticsPeriod, val label: String)


### PR DESCRIPTION
Nine display-edge duplications from the 2026-07-30 adversarial review (§4.7). The core layers are
SSOT-clean; drift had re-accumulated at the UI edge — the early state of the #356-family disease,
cheap to cure as one batch while small. Each site is pointed at its existing owner; a new owner is
minted only where none existed.

`Closes #942.` Coordinate: **#943 (FlowCardItem split) is blocked-by this** — `FlowCardItem.kt` is
edited in place here, never split.

## Per item

| # | Site(s) | Before | After |
|---|---|---|---|
| 1 | `FlowCardItem.kt` footer + `BubbleManager.kt:534` | `joinToString(" & ")` / `joinToString(" + ")` — same offer, two separators | both → new `List<String>.joinDisplayStores()` in `:domain`, which `ParsedOffer.displayStoreText` now also reads |
| 2 | `MoneyTab.kt` + `SessionDetailScreen.kt` | two `private const val UNATTRIBUTED_EPSILON = 0.005` | one `internal const` in `AnalyticsUiState.kt` (the analytics package's shared file) |
| 3 | `AnalyticsUiState.kt` (`:app`) + `PeriodReview.kt` (`:feature:dashboard`) | `EMPTY_VALUE = "—"` twice; the `:app` KDoc forbade copies but a feature module can't reach `:app` | one `core:designsystem` `text.EMPTY_VALUE`; both modules already depend on designsystem (no new module edge) |
| 4 | `RatingsViewModel:38`, `BubbleViewModel:95`, `DashboardViewModel:94`, `LiveCardBuilder:24` | `flow.activePlatform ?: crossPlatform.mostRecentActivityPlatform` hand-rolled ×4 in 3 modules | `AppState.focusedPlatform()` in `:domain`, beside `activeSessionId()`; `BubbleSessionResolver`'s KDoc now links it |
| 5 | `FlowCardItem.badgeMeta(name: String)` | a second, drifted label map missing ≥8 branches → lowercased-enum mangle; keyed on raw enum-name strings | labels come from `OfferBadge.displayName` / new `OrderBadge.displayName`; `badgeMeta` keeps only the icon/color mapping, keyed on the **typed** enums (#283). 9 orphaned `flow_card_badge_*` string resources deleted |
| 6 | `FlowCardItem.kt:357` + `OfferFormatters.offerScoreArgb` | verbatim duplicate score→band `when` | one `offerScoreColor(score, c)`; `offerScoreArgb` delegates to it |
| 7 | `FlowCardItem.kt:403–417` (3 `when`s over the enum NAME) vs `offerVerdictLabel`/`offerVerdictArgb` | card said `MANUAL REVIEW`, notification said `REVIEW`; colors duplicated | card reads `offerVerdictLabel` + new `offerVerdictColor`/`offerVerdictContainer`; `offerVerdictArgb` delegates |
| 8 | `DecisionsTab:65`, `TimeTab:132`, `TimeTab:170`, `ModeCards:142` | four hand-rolled `(x * 100).roundToInt()` / integer-truncating percents | `Formats.percent(fraction, decimals = 0)` in `:domain` (the locale-policy SSOT) |
| 9 | `ChatViews.kt:179` | a second private wall-clock formatter (`DateFormat.getTimeFormat`) frozen behind `remember(timestamp)` | `core:designsystem` `rememberTimeFormatter()` — the same helper `FlowCardItem` already uses |

## User-visible string changes (all of them)

**Named in the plan (deliberate):**

1. **Heads-up offer notification, stacked offer:** `"Store A + Store B"` → `"Store A & Store B"`.
   The bubble card already said `&`; the notification is the one moving onto the domain SSOT.
2. **Bubble chat timestamps:** now re-render when the device's 12/24-hour setting flips (they used
   to stay in the old format until the message recomposed). Format text is unchanged in practice
   for the fielded locale (`getTimeFormat` short-time vs TimeKit's `h:mm a` / `HH:mm`).

**Drifted duplicate resolving to its SSOT (the "SSOT wins" rule):**

3. Offer verdict banner on the bubble card: `MANUAL REVIEW` → `REVIEW`; `NOTHING` → `OFFER`
   (the words the heads-up notification has always used). `ACCEPT` / `DECLINE` unchanged.
4. Badge pills — labels now come from the enum `displayName`:

   | badge | before | after | visible as |
   |---|---|---|---|
   | `HIGH_PAYING` | High pay | High Paying | icon pill (label unshown) |
   | `PRIORITY_ACCESS` | Priority | Priority Access | icon pill (label unshown) |
   | `RED_CARD` | Red Card | Red Card | icon pill |
   | `ALCOHOL` | Alcohol | Alcohol | icon pill |
   | `LARGE_ORDER` | Large order | Large Order | icon pill |
   | `PIZZA_BAG` | Pizza bag | Pizza Bag | icon pill |
   | `ALL_ORDERS_SAME_STORE` | Same store | **All Orders Same Store** | **text pill** |
   | `BOTH_ORDERS_SAME_CUSTOMER` | Same customer | **Both Orders Same Customer** | **text pill** |
   | `ITEMS_CAN_BE_ADDED` | Add-ons OK | **Items Can Be Added** | **text pill** |
   | `SHARPIE_RECOMMENDED` | Sharpie recommended *(mangle)* | Sharpie Recommended | text pill |
   | `MAY_NEED_RETURNS` | May need returns *(mangle)* | May Need Returns | text pill |
   | `CONTAINS_RESTRICTED_ITEMS` / `AGE_RESTRICTED_18_PLUS` / `AGE_RESTRICTED_21_PLUS` / `CHECK_RECIPIENT_ID` / `COLLECT_CASH` / `INCLUDES_ALCOHOL` | lowercased-enum mangle ("Age restricted 21 plus") | proper `displayName` ("Age Restricted 21+") | icon pill except `INCLUDES_ALCOHOL` (text) |

   Only the bolded text-pill rows change what a dasher actually reads on the HUD; the icon-pill
   badges render an icon and never showed their label. `SHOP` keeps its string resource (it is a
   synthetic marker, not an enum constant). **If the dev prefers the shorter HUD copy, the fix is
   to shorten the enum `displayName` — one owner, one edit — not to reintroduce the second map.**
5. Bubble ModeCard acceptance rate: was integer-truncated (`accepted * 100 / received`), now
   rounded like the Decisions tab's identical metric. Same input could read 66% on the HUD and
   67% in analytics; ≤1pp shift on the HUD.

## New SSOT locations + module-dependency changes

- `domain/format/Formats.kt` — `percent(fraction, decimals = 0)`.
- `domain/state/AppState.kt` — `AppState.focusedPlatform()`.
- `domain/model/offer/ParsedOffer.kt` — `List<String>.joinDisplayStores()` (top-level extension).
- `domain/model/order/OrderBadge.kt` — gains `displayName`, mirroring `OfferBadge`. Enum **names**
  are unchanged, so the by-name `DataTypeConverters` persistence is untouched.
- `domain/model/cards/FlowCardSnapshot.kt` — `Offer.SHOP_BADGE` (the `"SHOP"` literal was minted in
  `:domain` and compared in `:feature:bubble`).
- `core/designsystem/text/AppText.kt` — **new file**, `EMPTY_VALUE`.
- `feature/bubble/formatters/OfferFormatters.kt` — `offerScoreColor`, `offerVerdictColor`,
  `offerVerdictContainer`; the two `*Argb` functions now delegate.

**No module-dependency changes.** Every consumer already declared every dep it now imports
(`:feature:dashboard` and `:feature:bubble` both already carry `:core:designsystem`) — the
honest-deps doctrine holds with no new edges.

## Verification

- `./gradlew testDebugUnitTest :domain:test` — **BUILD SUCCESSFUL** (full sweep, all modules).
- `./gradlew :app:lintVitalRelease` — **BUILD SUCCESSFUL** (gates the release variant + the #907
  locale allowlist; 9 string resources were deleted).
- New `:domain` tests: `FocusedPlatformTest` (pins the exact precedence of the four deleted copies),
  `FormatsTest` ×3 (percent is byte-identical to the `roundToInt` shape it replaced, takes the
  fraction not the pre-multiplied value, honors decimals + device locale), `OfferDisplayStoreTest`
  (`joinDisplayStores` is the separator SSOT `displayStoreText` itself uses).
- No golden/recognition impact — the diff is display-only; `AllMatchersSuite` and
  `ParseOutputGoldenTest` are green with no regeneration.

## Known residuals (deliberately out of scope)

- `feature/settings/components/FakeOfferCard.kt` (`OfferAction`→color) and
  `feature/settings/OfferRecommendation.kt` (`OfferAction`→"Recommended: X") could not join the
  `:feature:bubble` verdict SSOT: **a feature module never depends on another feature module**, and
  `:core:designsystem` has no `:domain` dep, so there is no legal shared home. Their `else` arms
  also genuinely differ (`surfaceVariant`/`neutral`, not `warn`). Left as-is rather than forcing a
  module edge.
- `core/designsystem/component/AppCharts.kt:144` hand-rolls a percent — `:core:designsystem` has no
  project deps by design, so it cannot reach `Formats`. Left as-is.

## Design-goal review

- **5 — SSOT (the subject of this PR).** Nine duplicated definitions collapse to one owner each; new
  owners are minted in the lowest layer that both consumers can legally reach (`:domain` for pure
  values, `:core:designsystem` for display vocabulary), never by adding a module edge. Two residuals
  are recorded above rather than left silent.
- **3 — Single responsibility.** `badgeMeta` sheds the labels it should never have owned and keeps
  only icon/color. `FlowCardItem.kt` is edited in place and does **not** grow — the split is #943,
  which is blocked-by this PR by design.
- **4 — Kotlin/Android practices (#283).** `badgeMeta`'s raw-name `when` and the verdict banner's
  three `"ACCEPT"`/`"DECLINE"` string `when`s become exhaustive `when`s over the typed
  `OfferBadge`/`OrderBadge`/`OfferAction` enums. The snapshot's `badges: List<String>` /
  `evaluationAction: String?` wire shape is unchanged (it is a serialized model), so the parse is
  `runCatching { OfferAction.valueOf(...) }` at the one UI edge.
- **8 — Platform-agnostic core.** `focusedPlatform()` composes two already registry-resolved
  `Platform` values; no literal, no `when (platform)`. Nothing else in `:domain`/`:core:state`
  changes semantically. `OrderBadge`/`OfferBadge` gain display copy only — no new recognition
  vocabulary, no `StateMachineContract` touch, no rule JSON.
- **1 — UDF.** Display-only. No reducer, stepper, or effect touched; `AppState.focusedPlatform()` is
  a pure derived read, not new state.
- **Reactive UI (rules 1 & 5).** Item 9 is a direct fix: the chat timestamp was computed once behind
  `remember(timestamp)` from a context-captured formatter, so a 12/24-hour setting flip left it
  stale on the HUD — the strictest-reactivity surface. It now routes through
  `rememberTimeFormatter()`, which is keyed on `is24HourFormat` and recomposes on the flip. No other
  reactivity behavior changes.
- **6 — Security & privacy.** No recognition, capture, network, or effect path touched. No new log
  sites. `joinDisplayStores` moves **merchant** names only (driver-owned, already rendered at both
  call sites) — no customer PII, no new persistence, no new INFO+ line.
- **7 — Semantic logging.** No log sites added, moved, or re-levelled.

## Suggested field-test checklist additions (for the merging agent)

_Not added here — this PR deliberately does not touch `docs/field-testing/README.md`._

- **#942 store-join parity.** On a stacked offer, the heads-up notification and the bubble card
  should name the stores identically (`Store A & Store B`) — the notification used to say `+`.
  Confirmed: 0/2
- **#942 verdict word.** A manual-review verdict reads `REVIEW` on the bubble offer card (was
  `MANUAL REVIEW`), matching the notification. Confirmed: 0/2
- **#942 badge pills.** Text badges on an offer card read their full names (`All Orders Same Store`,
  `Items Can Be Added`) — check they don't overflow / truncate badly in the HUD's pill row; if they
  do, shorten the enum `displayName` (one owner). Confirmed: 0/2
- **#942 chat clock.** Flip the phone's 24-hour setting with the bubble chat open; existing
  timestamps should re-render in the new format without reopening. Confirmed: 0/2
