### PR TITLE
privacy(pipeline): #938 — detect + document the English-locale boundary of recognition and the marker layers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,24 @@ upstream is supervised — a crash logs + counts a restart and resubscribes with
 silencing all sensing (#430) — and `PipelineStats` counts every gate decision, mapping failure,
 and restart (periodic summary log line).
 
+**The whole recognition + text-scrub layer assumes an ENGLISH device (#938).** Rule anchors and
+BOTH text-marker SSOTs (`SensitiveTextMarkers.KEYWORDS`, `CustomerTextMarkers.MARKERS`) are literal
+English strings, so on a non-`en` device recognition drops toward zero (survivable — everything
+falls to UNKNOWN, and release binds `NoOpCaptureBus`) **but the Pledge layers thin**: the
+sensitive-screen backstop, the UNKNOWN-capture PII scrub, and the shareable-log scrub all weaken.
+`CustomerTextMarkers.ID_MARKERS` (#910) is the one **locale-immune** defence — view ids don't
+localize — and is the pattern any future translation work should prefer. #938 makes the boundary
+*loud, not fixed*: `RecognitionLocale` (`:domain`, pure) decides, and the `:app`
+`LocaleBoundaryNotifier` (bound to the `:domain` `LocaleBoundaryReporter` contract that
+`AccessibilityListener.onServiceConnected` calls — recognition's own go-live edge, fail-OPEN)
+emits one WARN per sensor start (ISO-639 code only, principle 7) plus a **once-per-install**
+dasher-visible notice on its own `app_notice_channel`, remembered by the `app_state` DataStore flag
+`locale_boundary_notice_shown`. **Translating anchors/markers is deliberately NOT done** — it needs
+a non-English corpus, and until that exists a non-`en` device is a documented degraded mode, not a
+supported one. (Distinct from #428, which bounds the app's OWN copy/TTS to en/es/fr — a different
+assumption; the #938 notice copy itself IS translated into `values-es` since a Spanish dasher is
+exactly its audience.)
+
 ### 2. JSON Rule Engine (`core/pipeline/.../rules/` + generated `assets/rules/`)
 
 Recognition is **data, not code**. The rule SOURCE is per-platform **JSON5** under `matchers/rules/`

--- a/app/src/main/java/cloud/trotter/dashbuddy/di/AppModule.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/di/AppModule.kt
@@ -8,6 +8,8 @@ import cloud.trotter.dashbuddy.core.data.log.LogScrubber
 import cloud.trotter.dashbuddy.core.pipeline.SensitiveTextMarkers
 import cloud.trotter.dashbuddy.core.state.EffectExecutor
 import cloud.trotter.dashbuddy.core.state.MetadataProvider
+import cloud.trotter.dashbuddy.domain.pipeline.LocaleBoundaryReporter
+import cloud.trotter.dashbuddy.locale.LocaleBoundaryNotifier
 import cloud.trotter.dashbuddy.state.effects.SideEffectEngine
 import dagger.Binds
 import dagger.Module
@@ -24,6 +26,14 @@ abstract class AppBindingsModule {
 
     @Binds
     abstract fun bindEffectExecutor(impl: SideEffectEngine): EffectExecutor
+
+    /**
+     * #938: the sensor layer (`:core:pipeline`) reports its English-locale boundary through a
+     * `:domain` contract; `:app` supplies the implementation because the notice needs the
+     * DataStore flag and a notification, neither of which `:core:pipeline` may reach.
+     */
+    @Binds
+    abstract fun bindLocaleBoundaryReporter(impl: LocaleBoundaryNotifier): LocaleBoundaryReporter
 }
 
 @Module

--- a/app/src/main/java/cloud/trotter/dashbuddy/locale/LocaleBoundaryNotifier.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/locale/LocaleBoundaryNotifier.kt
@@ -1,0 +1,151 @@
+package cloud.trotter.dashbuddy.locale
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.ui.main.MainActivity
+import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
+import cloud.trotter.dashbuddy.domain.di.ApplicationScope
+import cloud.trotter.dashbuddy.domain.pipeline.LocaleBoundaryCheck
+import cloud.trotter.dashbuddy.domain.pipeline.LocaleBoundaryReporter
+import cloud.trotter.dashbuddy.domain.pipeline.RecognitionLocale
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The side-effecting half of the #938 English-locale boundary detection: one WARN per sensor
+ * start plus a **once-per-install** dasher-visible notice when the device language is outside
+ * the recognition/marker vocabulary.
+ *
+ * The decision itself is pure and lives in `:domain` ([RecognitionLocale]); this class owns only
+ * the edges — the current locale, the DataStore flag, the log line, and the notification — so the
+ * behaviour under test is the pure half plus three thin branches here.
+ *
+ * **Fail-open by construction.** [onSensorServiceConnected] returns immediately (the flag read is
+ * a suspend DataStore call, so the work is dispatched onto the app scope) and every step is
+ * wrapped: a locale diagnostic must never be able to stop sensing from starting, and a
+ * notification the OS refuses (POST_NOTIFICATIONS not granted) degrades to the WARN alone.
+ *
+ * **PII posture:** the only device-derived value that reaches a log line or the notification is an
+ * ISO-639 language code — principle 7's INFO+ contract holds trivially.
+ */
+@Singleton
+class LocaleBoundaryNotifier @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val notificationManager: NotificationManager,
+    private val appStateRepository: AppStateRepository,
+    @param:ApplicationScope private val scope: CoroutineScope,
+) : LocaleBoundaryReporter {
+
+    override fun onSensorServiceConnected() {
+        // Dispatched, never inline: the flag read is a suspend DataStore call and this runs on the
+        // service's connected callback (main thread).
+        scope.launch { report(Locale.getDefault()) }
+    }
+
+    /**
+     * The whole decision + side effects for one sensor start. Takes the locale as a parameter
+     * (rather than reading the JVM default here) so the test drives it without mutating global
+     * state — the same shape `TimeFormats`/`Formats` use for their locale policy.
+     */
+    internal suspend fun report(locale: Locale) {
+        val outcome = try {
+            RecognitionLocale.check(
+                locale = locale,
+                alreadyNotified = appStateRepository.localeBoundaryNoticeShown.first(),
+            )
+        } catch (e: CancellationException) {
+            throw e // structured concurrency — never swallowed by the fail-open catch (#909)
+        } catch (t: Throwable) {
+            // Fail-open: a flag/locale read failure must not surface as anything but a log line.
+            Timber.tag(TAG).e(t, "Locale boundary check failed — skipping (#938)")
+            return
+        }
+
+        if (outcome !is LocaleBoundaryCheck.Unsupported) return
+
+        Timber.tag(TAG).w(
+            "Device language '%s' is not '%s': recognition anchors and the text-marker privacy " +
+                "scrubs are English-only today (#938), so recognition thins toward UNKNOWN and " +
+                "the marker-based scrubs weaken. The id-based scrub layer is locale-immune.",
+            outcome.language,
+            RecognitionLocale.SUPPORTED_LANGUAGE,
+        )
+
+        if (!outcome.notifyUser) return
+
+        try {
+            postNotice()
+            appStateRepository.setLocaleBoundaryNoticeShown()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            // Leave the flag unset so a later start retries the notice.
+            Timber.tag(TAG).e(t, "Locale boundary notice could not be posted (#938)")
+        }
+    }
+
+    private fun postNotice() {
+        // Created lazily: a channel the dasher never needs shouldn't clutter their notification
+        // settings. A dedicated channel rather than a reused one — a channel name IS the user's
+        // mute control, so filing this under "Offer Alerts" or "Odometer Active" would both
+        // mislabel it and let an unrelated mute silence a Pledge-honesty disclosure.
+        notificationManager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.locale_notice_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply {
+                description = context.getString(R.string.locale_notice_channel_description)
+            },
+        )
+
+        val contentIntent = PendingIntent.getActivity(
+            context,
+            REQUEST_CODE,
+            Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val text = context.getString(R.string.locale_notice_text)
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.bag_red_idle)
+            .setContentTitle(context.getString(R.string.locale_notice_title))
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setContentIntent(contentIntent)
+            .setAutoCancel(true)
+            .build()
+
+        notificationManager.notify(NOTIFICATION_ID, notification)
+    }
+
+    companion object {
+        private const val TAG = "LocaleBoundary"
+
+        /** Own channel — see [postNotice] for why this is not one of the existing three. */
+        const val CHANNEL_ID = "app_notice_channel"
+
+        /**
+         * Fixed id in the small-constant range the bubble (1), offer fallback (2) and odometer
+         * (101) already occupy; `BubbleManager.offerNotificationId` deliberately folds per-offer
+         * ids into the disjoint `[2^30, 2^31)` namespace, so a fixed small id cannot collide.
+         */
+        const val NOTIFICATION_ID = 102
+
+        private const val REQUEST_CODE = 938
+    }
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -92,4 +92,13 @@
 
     <string name="wizard_title_mpg">Eficiencia del Vehículo</string>
     <string name="wizard_desc_mpg">¿Cuál es el MPG (millas por galón) promedio de tu auto? Usamos esto para calcular tu ganancia real después de los gastos de gasolina.</string>
+
+    <!-- locale/LocaleBoundaryNotifier.kt — el aviso del límite de idioma (#938). Translated here
+         even though values-es is otherwise incomplete: this notice exists FOR a dasher whose phone
+         is not in English, so an untranslated copy would be the one string that fails its own
+         audience. -->
+    <string name="locale_notice_channel_name">Avisos de la aplicación</string>
+    <string name="locale_notice_channel_description">Avisos puntuales sobre cómo funciona DashBuddy en este teléfono</string>
+    <string name="locale_notice_title">DashBuddy solo lee pantallas en inglés</string>
+    <string name="locale_notice_text">Tu teléfono está configurado en un idioma distinto del inglés. DashBuddy reconoce las pantallas de reparto por su texto en inglés, así que se le escaparán casi todas las ofertas y entregas — y los filtros de privacidad que ocultan los datos del cliente funcionan con ese mismo texto en inglés, por lo que también cubren menos. Cambiar el teléfono a inglés restablece ambas cosas.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -485,6 +485,15 @@
     <!-- %1$s tip amount, %2$s store name -->
     <string name="tip_effect_chat_message">Nice! %1$s tip from %2$s</string>
 
+    <!-- locale/LocaleBoundaryNotifier.kt — the #938 English-locale boundary notice.
+         Deliberately does NOT name a specific language: the string is device-independent, and the
+         only device-derived value the feature ever handles is an ISO-639 code (kept out of the
+         copy so nothing device-specific rides a user-visible surface). -->
+    <string name="locale_notice_channel_name">App notices</string>
+    <string name="locale_notice_channel_description">One-off notices about how DashBuddy is working on this device</string>
+    <string name="locale_notice_title">DashBuddy reads English screens only</string>
+    <string name="locale_notice_text">Your phone is set to a language other than English. DashBuddy recognises delivery screens by their English wording, so it will miss most offers and deliveries — and the privacy filters that hide customer details work by the same English wording, so they cover less too. Switching the phone to English restores both.</string>
+
     <!-- ui/bubble/BubbleManager.kt -->
     <string name="bubble_channel_stream_name">DashBuddy Stream</string>
     <string name="bubble_channel_stream_description">Live updates from your session</string>

--- a/app/src/test/java/cloud/trotter/dashbuddy/locale/LocaleBoundaryNotifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/locale/LocaleBoundaryNotifierTest.kt
@@ -1,0 +1,154 @@
+package cloud.trotter.dashbuddy.locale
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.util.Log
+import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
+import cloud.trotter.dashbuddy.test.util.RecordingTree
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import timber.log.Timber
+import java.util.Locale
+
+/**
+ * The side-effecting half of #938: WARN every non-English sensor start, interrupt the dasher
+ * exactly once.
+ *
+ * Robolectric supplies a real `Context` (the notice needs `getString`); the `NotificationManager`
+ * and `AppStateRepository` are mocks so the flag write and the post are directly observable.
+ */
+@RunWith(RobolectricTestRunner::class)
+class LocaleBoundaryNotifierTest {
+
+    private lateinit var tree: RecordingTree
+    private lateinit var notificationManager: NotificationManager
+    private lateinit var appState: AppStateRepository
+
+    @Before
+    fun setUp() {
+        tree = RecordingTree()
+        Timber.plant(tree)
+        notificationManager = mock()
+        appState = mock()
+    }
+
+    @After
+    fun tearDown() {
+        Timber.uproot(tree)
+    }
+
+    /** The WARN lines this component emitted, in order. */
+    private fun warnings(): List<String> =
+        tree.records.filter { it.priority == Log.WARN }.map { it.message }
+
+    private fun notifier(alreadyNotified: Boolean): LocaleBoundaryNotifier {
+        whenever(appState.localeBoundaryNoticeShown).thenReturn(MutableStateFlow(alreadyNotified))
+        return LocaleBoundaryNotifier(
+            context = RuntimeEnvironment.getApplication(),
+            notificationManager = notificationManager,
+            appStateRepository = appState,
+            scope = TestScope(),
+        )
+    }
+
+    // =========================================================================
+    // The happy (English) path is silent
+    // =========================================================================
+
+    @Test
+    fun `an english device neither warns nor notifies`() = runTest {
+        notifier(alreadyNotified = false).report(Locale.US)
+
+        verify(notificationManager, never()).notify(any<Int>(), any<Notification>())
+        verify(appState, never()).setLocaleBoundaryNoticeShown()
+        assertTrue(
+            "an English device must produce no locale WARN, ${warnings()}",
+            warnings().isEmpty(),
+        )
+    }
+
+    // =========================================================================
+    // First non-English start: warn + notify + remember
+    // =========================================================================
+
+    @Test
+    fun `a first non-english start warns, posts the notice and records it`() = runTest {
+        notifier(alreadyNotified = false).report(Locale.forLanguageTag("es-MX"))
+
+        verify(notificationManager).createNotificationChannel(any())
+        verify(notificationManager).notify(eq(LocaleBoundaryNotifier.NOTIFICATION_ID), any<Notification>())
+        verify(appState).setLocaleBoundaryNoticeShown()
+        assertEquals(1, warnings().size)
+    }
+
+    @Test
+    fun `the WARN carries only the iso-639 language code - principle 7`() = runTest {
+        notifier(alreadyNotified = false).report(Locale.forLanguageTag("es-MX"))
+
+        val warn = warnings().single()
+        assertTrue("expected the language code in $warn", warn.contains("'es'"))
+        // The region is device-identifying detail the log has no use for.
+        assertTrue("the WARN must not carry the region: $warn", !warn.contains("MX"))
+        assertTrue("expected the issue reference in $warn", warn.contains("#938"))
+    }
+
+    // =========================================================================
+    // Repeat starts: still warn, never interrupt twice
+    // =========================================================================
+
+    @Test
+    fun `a repeat non-english start warns again but does not re-notify`() = runTest {
+        notifier(alreadyNotified = true).report(Locale.forLanguageTag("fr"))
+
+        assertEquals(1, warnings().size)
+        verify(notificationManager, never()).notify(any<Int>(), any<Notification>())
+        verify(appState, never()).setLocaleBoundaryNoticeShown()
+    }
+
+    // =========================================================================
+    // Fail-open
+    // =========================================================================
+
+    @Test
+    fun `a flag read failure is swallowed - sensing is never blocked`() = runTest {
+        whenever(appState.localeBoundaryNoticeShown)
+            .thenReturn(flow { throw IllegalStateException("datastore is unhappy") })
+        val subject = LocaleBoundaryNotifier(
+            context = RuntimeEnvironment.getApplication(),
+            notificationManager = notificationManager,
+            appStateRepository = appState,
+            scope = TestScope(),
+        )
+
+        subject.report(Locale.forLanguageTag("es")) // must not throw
+
+        verify(notificationManager, never()).notify(any<Int>(), any<Notification>())
+    }
+
+    @Test
+    fun `a failed post leaves the flag unset so a later start retries`() = runTest {
+        doThrow(SecurityException("POST_NOTIFICATIONS not granted"))
+            .whenever(notificationManager).notify(any<Int>(), any<Notification>())
+
+        notifier(alreadyNotified = false).report(Locale.forLanguageTag("es")) // must not throw
+
+        verify(appState, never()).setLocaleBoundaryNoticeShown()
+    }
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/state/AppStateRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/state/AppStateRepository.kt
@@ -12,8 +12,15 @@ class AppStateRepository @Inject constructor(
 ) {
     val isFirstRun: Flow<Boolean> = dataSource.isFirstRun
 
+    /** False until the #938 English-locale boundary notice has been posted once. */
+    val localeBoundaryNoticeShown: Flow<Boolean> = dataSource.localeBoundaryNoticeShown
+
     suspend fun setFirstRunComplete() {
         dataSource.setFirstRunComplete()
+    }
+
+    suspend fun setLocaleBoundaryNoticeShown() {
+        dataSource.setLocaleBoundaryNoticeShown()
     }
 
     suspend fun clearPreferences() {

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/appstate/AppStateDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/appstate/AppStateDataSource.kt
@@ -15,16 +15,30 @@ class AppStateDataSource @Inject constructor(
     @param:AppStatePreferences private val ds: DataStore<Preferences>
 ) {
     private object Keys {
-        // The only key this DataSource actually needs!
         val IS_FIRST_RUN = booleanPreferencesKey("is_first_run")
+
+        /**
+         * Whether the dasher has already been shown the "recognition is English-only"
+         * notice (#938). App-lifecycle state, not a setting — it belongs here rather than
+         * in app prefs (a user-editable value) or dev settings (developer-only).
+         */
+        val LOCALE_BOUNDARY_NOTICE_SHOWN = booleanPreferencesKey("locale_boundary_notice_shown")
     }
 
     // Default to true if the key doesn't exist yet
     val isFirstRun: Flow<Boolean> = ds.data.map { it[Keys.IS_FIRST_RUN] ?: true }
 
+    /** False until the #938 English-locale notice has been posted once on this install. */
+    val localeBoundaryNoticeShown: Flow<Boolean> =
+        ds.data.map { it[Keys.LOCALE_BOUNDARY_NOTICE_SHOWN] ?: false }
+
     // Safely encapsulated write action
     suspend fun setFirstRunComplete() {
         ds.edit { it[Keys.IS_FIRST_RUN] = false }
+    }
+
+    suspend fun setLocaleBoundaryNoticeShown() {
+        ds.edit { it[Keys.LOCALE_BOUNDARY_NOTICE_SHOWN] = true }
     }
 
     suspend fun clear() {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilityListener.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilityListener.kt
@@ -4,6 +4,7 @@ import android.accessibilityservice.AccessibilityService
 import android.accessibilityservice.AccessibilityServiceInfo
 import android.view.accessibility.AccessibilityEvent
 import cloud.trotter.dashbuddy.core.pipeline.BuildConfig
+import cloud.trotter.dashbuddy.domain.pipeline.LocaleBoundaryReporter
 import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import cloud.trotter.dashbuddy.domain.state.Platform
 import dagger.hilt.android.AndroidEntryPoint
@@ -18,6 +19,14 @@ class AccessibilityListener : AccessibilityService() {
 
     @Inject
     lateinit var platformPreferences: PlatformPreferences
+
+    /**
+     * #938 — reports the English-locale boundary of recognition + the marker privacy scrubs.
+     * Injected as a `:domain` contract (the [PlatformPreferences] pattern) because the notice
+     * itself needs `:app`-owned pieces this module must not depend on.
+     */
+    @Inject
+    lateinit var localeBoundaryReporter: LocaleBoundaryReporter
 
 
 
@@ -78,6 +87,14 @@ class AccessibilityListener : AccessibilityService() {
         // Register with the source
         accessibilitySource.registerService(this)
 
+        // #938: this is the moment recognition actually goes live on this device, so it is where
+        // the English-only assumption of the anchors + marker scrubs is worth reporting. Fail-OPEN
+        // — a diagnostic must never be able to stop sensing from starting.
+        try {
+            localeBoundaryReporter.onSensorServiceConnected()
+        } catch (t: Throwable) {
+            Timber.tag("Pipeline").e(t, "Locale boundary report failed (#938) — sensing unaffected")
+        }
     }
 
     companion object {

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/LocaleBoundaryReporter.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/LocaleBoundaryReporter.kt
@@ -1,0 +1,19 @@
+package cloud.trotter.dashbuddy.domain.pipeline
+
+/**
+ * Reports the [RecognitionLocale] boundary when a sensor service goes live (#938).
+ *
+ * The contract lives in `:domain` so `:core:pipeline` can call it while keeping its
+ * `:domain`-only dependency (the `PlatformPreferences` read-interface pattern, #355); the
+ * implementation lives in `:app`, which owns the DataStore-backed once-per-install flag and
+ * the dasher-visible notification.
+ */
+fun interface LocaleBoundaryReporter {
+
+    /**
+     * Called from the sensor service's connected callback. **Fail-open:** the implementation
+     * must neither throw nor block — a locale diagnostic must never be able to stop sensing
+     * from starting.
+     */
+    fun onSensorServiceConnected()
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/RecognitionLocale.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/RecognitionLocale.kt
@@ -1,0 +1,87 @@
+package cloud.trotter.dashbuddy.domain.pipeline
+
+import java.util.Locale
+
+/**
+ * The recognition layer's **English-locale boundary** (#938).
+ *
+ * Rule anchors (the `matchers/rules` JSON5 source) and BOTH text-marker privacy SSOTs
+ * (`SensitiveTextMarkers.KEYWORDS`, `CustomerTextMarkers.MARKERS`) are literal
+ * English strings. On a device whose platform apps render in another language:
+ *
+ * - **recognition** drops toward zero — every frame falls to UNKNOWN (survivable:
+ *   release builds bind `NoOpCaptureBus`, so nothing is written), and
+ * - the **Pledge layers thin** — the sensitive-screen text backstop, the UNKNOWN-capture
+ *   customer-PII scrub, and the shareable-log scrub all weaken **silently**, which is the
+ *   part that is not survivable without a signal.
+ *
+ * The id-based layer (`CustomerTextMarkers.ID_MARKERS`, #910) is the one **locale-immune**
+ * defence — Android view ids do not localize — and is the pattern a future translation
+ * effort should prefer.
+ *
+ * This object is the pure decision half of the detection: no Android, no I/O, no clock.
+ * The side-effecting half (WARN + the one-time dasher-visible notice) lives behind
+ * [LocaleBoundaryReporter].
+ *
+ * **Scope note:** this is *detection and documentation only*. Translating anchors/markers
+ * needs a non-English corpus and is deliberately out of scope (#938). Separately, #428
+ * bounds the app's OWN copy/TTS to en/es/fr — a different assumption from this one.
+ */
+object RecognitionLocale {
+
+    /** The one language the anchors and marker SSOTs are written in. */
+    const val SUPPORTED_LANGUAGE: String = "en"
+
+    /**
+     * The device language as a lowercase ISO-639 code, or `""` when the platform reports
+     * no language at all. `Locale.ROOT` keeps the case fold machine-stable (principle 4).
+     */
+    fun languageOf(locale: Locale): String = locale.language.lowercase(Locale.ROOT)
+
+    /**
+     * Whether recognition's English assumption holds for [locale].
+     *
+     * A **blank** language (undetermined — effectively unreachable on Android, which always
+     * reports at least `en`) counts as supported: a blank tag is not evidence of a
+     * non-English device, and a false "your language isn't supported" notice costs the
+     * dasher's trust while changing no behaviour. The bias is deliberate — this signal is
+     * informational, so the safe side is *no false positive*, not *warn on doubt*.
+     */
+    fun isSupported(locale: Locale): Boolean {
+        val language = languageOf(locale)
+        return language.isBlank() || language == SUPPORTED_LANGUAGE
+    }
+
+    /**
+     * The full decision for one sensor-service start: whether to warn at all, and — when the
+     * dasher has already been told once ([alreadyNotified]) — whether to repeat the
+     * user-visible notice. The WARN is not suppressed by [alreadyNotified]: it is a per-connect
+     * diagnostic in the log (rare — a service connects at boot / on enable), whereas the notice
+     * is a once-per-install interruption.
+     */
+    fun check(locale: Locale, alreadyNotified: Boolean): LocaleBoundaryCheck =
+        if (isSupported(locale)) {
+            LocaleBoundaryCheck.Supported
+        } else {
+            LocaleBoundaryCheck.Unsupported(
+                language = languageOf(locale),
+                notifyUser = !alreadyNotified,
+            )
+        }
+}
+
+/** Outcome of [RecognitionLocale.check]. */
+sealed interface LocaleBoundaryCheck {
+
+    /** The device language is (or is indistinguishable from) English — nothing to report. */
+    data object Supported : LocaleBoundaryCheck
+
+    /**
+     * The device language is outside the recognition/marker vocabulary.
+     *
+     * @param language the lowercase ISO-639 code — PII-safe by construction (principle 7),
+     *   the only device-derived value any INFO+ line here may carry.
+     * @param notifyUser true only for the first such start on this install.
+     */
+    data class Unsupported(val language: String, val notifyUser: Boolean) : LocaleBoundaryCheck
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/pipeline/RecognitionLocaleTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/pipeline/RecognitionLocaleTest.kt
@@ -1,0 +1,106 @@
+package cloud.trotter.dashbuddy.domain.pipeline
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * The pure half of the #938 English-locale boundary detection.
+ *
+ * Every case constructs its own [Locale] — the JVM-wide default is never read or mutated, so this
+ * is order-independent and safe to run in parallel with the locale-pinning format tests.
+ */
+class RecognitionLocaleTest {
+
+    // =========================================================================
+    // isSupported
+    // =========================================================================
+
+    @Test
+    fun `plain english is supported`() {
+        assertTrue(RecognitionLocale.isSupported(Locale.ENGLISH))
+    }
+
+    @Test
+    fun `english regional variants are supported - the boundary is language-level`() {
+        // The anchors are English WORDS; a region only changes formatting, never the vocabulary.
+        assertTrue(RecognitionLocale.isSupported(Locale.US))
+        assertTrue(RecognitionLocale.isSupported(Locale.UK))
+        assertTrue(RecognitionLocale.isSupported(Locale.forLanguageTag("en-CA")))
+    }
+
+    @Test
+    fun `non-english languages are not supported`() {
+        assertFalse(RecognitionLocale.isSupported(Locale.forLanguageTag("es")))
+        assertFalse(RecognitionLocale.isSupported(Locale.forLanguageTag("es-MX")))
+        assertFalse(RecognitionLocale.isSupported(Locale.FRENCH))
+        assertFalse(RecognitionLocale.isSupported(Locale.forLanguageTag("zh-Hans-CN")))
+    }
+
+    @Test
+    fun `an undetermined language is treated as supported - no false positive`() {
+        // Effectively unreachable on Android, but the bias is documented and pinned: a blank tag
+        // is not evidence of a non-English device, so it must not fire a user-visible notice.
+        assertTrue(RecognitionLocale.isSupported(Locale.ROOT))
+    }
+
+    // =========================================================================
+    // languageOf — the only device-derived value any log line may carry
+    // =========================================================================
+
+    @Test
+    fun `languageOf is a lowercase iso-639 code, region and script stripped`() {
+        assertEquals("es", RecognitionLocale.languageOf(Locale.forLanguageTag("es-MX")))
+        assertEquals("zh", RecognitionLocale.languageOf(Locale.forLanguageTag("zh-Hans-CN")))
+        assertEquals("en", RecognitionLocale.languageOf(Locale.US))
+        assertEquals("", RecognitionLocale.languageOf(Locale.ROOT))
+    }
+
+    // =========================================================================
+    // check — warn always, notify once
+    // =========================================================================
+
+    @Test
+    fun `english yields Supported regardless of the notified flag`() {
+        assertEquals(
+            LocaleBoundaryCheck.Supported,
+            RecognitionLocale.check(Locale.US, alreadyNotified = false),
+        )
+        assertEquals(
+            LocaleBoundaryCheck.Supported,
+            RecognitionLocale.check(Locale.US, alreadyNotified = true),
+        )
+    }
+
+    @Test
+    fun `a first non-english start warns and notifies`() {
+        val outcome = RecognitionLocale.check(Locale.forLanguageTag("es-MX"), alreadyNotified = false)
+
+        assertEquals(LocaleBoundaryCheck.Unsupported(language = "es", notifyUser = true), outcome)
+    }
+
+    @Test
+    fun `a repeat non-english start still warns but does not notify again`() {
+        val outcome = RecognitionLocale.check(Locale.forLanguageTag("es-MX"), alreadyNotified = true)
+
+        // Still Unsupported — the WARN is a per-connect diagnostic; only the interruption is
+        // once-per-install.
+        assertEquals(LocaleBoundaryCheck.Unsupported(language = "es", notifyUser = false), outcome)
+    }
+
+    @Test
+    fun `a second, different non-english language does not re-notify`() {
+        // es -> fr on an install that already showed the notice: the copy is language-independent,
+        // so there is nothing new to tell the dasher.
+        val outcome = RecognitionLocale.check(Locale.FRENCH, alreadyNotified = true)
+
+        assertEquals(LocaleBoundaryCheck.Unsupported(language = "fr", notifyUser = false), outcome)
+    }
+
+    @Test
+    fun `the supported language constant is the one the markers are written in`() {
+        assertEquals("en", RecognitionLocale.SUPPORTED_LANGUAGE)
+    }
+}

--- a/matchers/README.md
+++ b/matchers/README.md
@@ -46,6 +46,35 @@ Full JSON-Schema validation against `docs/rules.schema.json` is deferred to the 
 (ADR-0009); `verifyMatchersCanonical` does a cheap schema-aware structural check (required top-level
 keys, read from the schema) plus the idempotency fixed-point assertion.
 
+## Locale scope: this ruleset is English-only (#938)
+
+Every anchor in `rules/` is a **literal English string** — `require` text predicates, `matchesRegex`
+shapes, the `keepPrefix` markers a `redact` entry preserves, the tap-label allowlists a `RuleAction`
+verifies against. So is the app-side privacy backstop these rules sit behind: both marker SSOTs
+(`SensitiveTextMarkers.KEYWORDS`, `CustomerTextMarkers.MARKERS`) are English literals too.
+
+**Consequence on a non-English device.** Recognition drops toward zero — every frame falls to
+UNKNOWN, which is survivable (release builds bind `NoOpCaptureBus`, so nothing is written). What is
+*not* survivable silently is that the **Pledge layers thin**: the sensitive-screen text backstop,
+the UNKNOWN-capture customer-PII scrub, and the shareable-log scrub all weaken, because all three
+match on English wording. `CustomerTextMarkers.ID_MARKERS` (#910 — view-id suffixes like
+`customer_name` / `address_line_1`) is the **one locale-immune layer**: Android view ids do not
+localize. That is the pattern to prefer whenever a defence can be anchored on structure instead of
+copy.
+
+**What the app does about it (#938):** detect and disclose, not translate. `RecognitionLocale`
+(`:domain`) compares the device language against `en` at accessibility-service start; a mismatch
+logs one WARN (ISO-639 code only) and posts a once-per-install dasher-visible notice. The
+degradation stays real — the notice just stops it from being invisible.
+
+**Rule authors:** a non-English vocabulary is a **corpus problem, not a rule-syntax problem**. Adding
+`es` anchors without an `es` golden corpus would ship untested matches into the same priority space
+as the English ones, and — because the sensitive block is `priority: 0, overrideable: false` — a bad
+non-English sensitive anchor is a Pledge risk, not just a miss. So: do **not** add non-English
+anchors to `rules/` until a non-English capture corpus and its `AllMatchersSuite` coverage exist.
+This is a deliberate scope boundary, and it becomes load-bearing once rules ship OTA (#640/#192) to
+users who never do a desk pull — the user base must not silently widen past the assumption.
+
 ## Milestone 2 (unbuilt)
 
 The runtime OTA/CDN channel — signed JSON fetched, verified (#416), capability + sensitive-rule


### PR DESCRIPTION
Closes #938.

The 2026-07-30 adversarial review (§4.2) validated that rule anchors **and both** text-marker SSOTs (`SensitiveTextMarkers.KEYWORDS`, `CustomerTextMarkers.MARKERS`) are literal English strings. On a Spanish-locale device recognition drops toward zero — survivable, everything falls to UNKNOWN and release binds `NoOpCaptureBus` — but the **Pledge layers thin silently**: the sensitive-screen text backstop, the UNKNOWN-capture customer-PII scrub, and the shareable-log scrub all weaken with no signal at all. DoorDash serves Spanish-locale dashers.

Scope is the issue's: **detect + document**. Translating anchors/markers needs a non-English corpus and is explicitly out.

## Seam choice — `AccessibilityListener.onServiceConnected()`

Three candidates were considered:

| Candidate | Verdict |
|---|---|
| `DashBuddyApplication` startup (after `jsonRuleInterpreter.loadDefaults()`) | Rejected. The app process starts for reasons that have nothing to do with sensing (a settings visit, the projector launch). Firing a "recognition won't work" notice on a process start where recognition is not even enabled is a false alarm about a real problem — the worst kind. |
| An `:app`-side collector on a new `AccessibilitySource.connected` StateFlow | Rejected. Adds pipeline *state* and an app-side collector purely to relocate a one-shot call. More moving parts, no extra truth. |
| **`AccessibilityListener.onServiceConnected()`** | **Chosen.** This is the exact moment recognition + the text scrubs go live on this device; before it, the boundary is inert. It's also where #937 will hang its recognition-health seam, so the two stay co-located. |

`:core:pipeline` may only see `:domain`, so the listener calls a `:domain` `LocaleBoundaryReporter` contract and `:app` binds the implementation — the same inversion `PlatformPreferences` (#355) already uses **in this very file**. The call is wrapped in try/catch at the call site *and* fail-open inside the impl: a locale diagnostic must never be able to stop sensing from starting.

## What ships

**Detect**
- **`:domain` `RecognitionLocale`** — the pure decision: device language vs `en`, plus warn-always / notify-once. No Android, no I/O, no clock, no JVM-default read. A **blank** language counts as *supported* — a blank tag is not evidence of a non-English device, and a false "your language isn't supported" notice costs the dasher's trust while changing no behaviour. The bias is documented and pinned by test.
- **`:domain` `LocaleBoundaryReporter`** — the one-method contract the sensor service calls.
- **`:app` `LocaleBoundaryNotifier`** — the edges only: one **WARN per sensor start** (ISO-639 language code only) plus a **once-per-install** dasher-visible notice. Dispatched onto `@ApplicationScope` (the flag read is a suspend DataStore call on a main-thread callback). Every step guarded; `CancellationException` rethrown per the #909 doctrine. A failed post leaves the flag **unset** so a later start retries.
- **Flag home:** the `app_state` DataStore (`locale_boundary_notice_shown`), joining `is_first_run`. It's app-lifecycle state, not a user-editable setting (so not app prefs) and not developer-only (so not dev settings).
- **Notification channel:** a new `app_notice_channel` ("App notices", `IMPORTANCE_DEFAULT`), **not** a reused one. A channel name *is* the user's mute control: `bubble_channel` allows bubbles so this would render as a chathead chat message; `offer_channel` ("Offer Alerts") and `LocationServiceChannel` ("Odometer Active") would both mislabel the notice **and** let an unrelated mute silence a Pledge-honesty disclosure. Created lazily so a dasher who never needs it never sees an empty category. Fixed id `102`, in the small-constant range (1 / 2 / 101) that `BubbleManager.offerNotificationId`'s `[2^30, 2^31)` namespace deliberately avoids.
- **Copy translated into `values-es`.** This notice exists *for* a dasher whose phone isn't in English — an untranslated copy would be the one string in the app that fails its own audience. `values-es` stays otherwise incomplete (the deferred completeness gate is unchanged); `fr` falls back to English like every other string today.

**Document**
- `CLAUDE.md` §1 *Sensor Pipelines* — the boundary, what thins, `ID_MARKERS` (#910) as the one **locale-immune** layer, the detection wiring, and the explicit "not fixed, made loud" scope.
- `matchers/README.md` — a new *"Locale scope: this ruleset is English-only (#938)"* section, including a rule-author directive: **do not add non-English anchors without a non-English corpus.** A bad non-English anchor in the `priority: 0, overrideable: false` sensitive block is a Pledge risk, not just a miss — and this becomes load-bearing once rules ship OTA (#640/#192) to users who never do a desk pull.

## Tests

- `:domain` `RecognitionLocaleTest` (10 cases) — pure, constructs every `Locale` itself so it never touches the JVM default: `en`/`en-US`/`en-GB`/`en-CA` supported; `es`/`es-MX`/`fr`/`zh-Hans-CN` not; `Locale.ROOT` supported (the documented no-false-positive bias); `languageOf` strips region + script; warn-always vs notify-once; a second *different* non-English language does not re-notify.
- `:app` `LocaleBoundaryNotifierTest` (6 cases, Robolectric + mocks) — English is fully silent; first non-`en` start warns + posts + records; the WARN carries `'es'` and **not** `MX` (principle 7); a repeat start warns but never re-notifies; a flag-read failure is swallowed; a failed post leaves the flag unset.

Verification: `./gradlew testDebugUnitTest :domain:test` **green**, and `./gradlew :app:lintVitalRelease` (the #907 CI gate, relevant here because the diff adds resources) **green**.

### Design-goal review

- **1 UDF** — no reducer or state-machine touch. The reporter is a pure edge effect fired from a sensor callback; the pure decision lives in `:domain` and the impl holds only the edges.
- **2 MAD** — Hilt `@Binds` for the contract, DataStore for the flag, `@ApplicationScope` coroutine (no hand-rolled scope), string resources for all copy.
- **3 Single responsibility** — decision (`:domain`) split from side effects (`:app`); three small new files, no existing file grown meaningfully.
- **4 Kotlin/Android** — sealed `LocaleBoundaryCheck` over a stringly-typed result (#283); `Locale.ROOT` for the machine case-fold; `CancellationException` rethrown so structured concurrency survives the fail-open catch.
- **5 SSOT** — `RecognitionLocale.SUPPORTED_LANGUAGE` is the one definition of "the language the anchors are written in"; the WARN interpolates it rather than restating `"en"`. The `app_state` flag has exactly one owner (`AppStateDataSource`) exposed through the existing repository.
- **6 Security & privacy** — this PR **is** a Pledge-honesty change: it makes an existing silent degradation of the scrub layers audible. It adds no capture, no network, no new parse, and does not touch any scrub. The one device-derived value it handles is an ISO-639 code.
- **7 Semantic, PII-safe logging** — WARN is the correct level (a defended assumption fired, and it's rare: once per service connect). Own stable tag `LocaleBoundary`; the pipeline-side fail-open catch logs under `Pipeline`. Both are `Timber.tag(...)`-prefixed, so `TimberTagGuardTest` is untouched. The INFO+ PII contract holds by construction and is pinned by test (the region is deliberately excluded).
- **8 Platform-agnostic core** — no `Platform` literal, no package name, no wire string. The boundary is a property of the *ruleset vocabulary as a class*, not of any one platform; the notice copy names no platform.
- **Reactive UI** — n/a, no Compose surface.
- No `Regex(…)` literals added, so `IcuRegexGuardTest` is unaffected; no new `values-*` directory, so `LocaleAllowlistGuardTest` is unaffected.

### Field-checklist suggestion (not added here — docs/field-testing/README.md left untouched per the build brief)

> **#938 — English-locale boundary notice.** Briefly switch the phone's language to Spanish (Settings → System → Languages), then toggle DashBuddy's accessibility service off and back on. Expect: exactly **one** system notification titled "DashBuddy solo lee pantallas en inglés" under a new "Avisos de la aplicación" channel, and a `WARN/LocaleBoundary` line naming `'es'` (and **not** a region) in the log. Toggle the service again — the WARN should repeat, the notification should **not**. Switch back to English and toggle once more — neither should appear. *Confirmed: 0/2*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
