### PR TITLE
refactor: #943 — split FlowCardItem.kt at its card-kind seams

### DIFF
--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/FlowCardItem.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/FlowCardItem.kt
@@ -1,78 +1,37 @@
 package cloud.trotter.dashbuddy.feature.bubble.cards
 
-import androidx.annotation.DrawableRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import cloud.trotter.dashbuddy.feature.bubble.R
-import cloud.trotter.dashbuddy.domain.format.Formats
-import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
-import cloud.trotter.dashbuddy.domain.format.formatCountdown
-import cloud.trotter.dashbuddy.domain.format.formatDuration
-import cloud.trotter.dashbuddy.core.designsystem.time.rememberNow
-import cloud.trotter.dashbuddy.core.designsystem.time.rememberTimeFormatter
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.height
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.ui.draw.clip
-import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
-import cloud.trotter.dashbuddy.core.designsystem.component.AppGaugeRing
-import cloud.trotter.dashbuddy.core.designsystem.theme.AppColors
-import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
-import cloud.trotter.dashbuddy.domain.model.offer.OfferBadge
-import cloud.trotter.dashbuddy.domain.model.offer.joinDisplayStores
-import cloud.trotter.dashbuddy.domain.model.order.OrderBadge
-import cloud.trotter.dashbuddy.domain.model.cards.TaskEconomics
-import cloud.trotter.dashbuddy.domain.state.PickupActivity
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.state.flowPhase
 import cloud.trotter.dashbuddy.domain.state.presentation
-import cloud.trotter.dashbuddy.domain.model.event.AppEventType
-import cloud.trotter.dashbuddy.domain.model.pay.displayLabel
+import cloud.trotter.dashbuddy.feature.bubble.R
 import cloud.trotter.dashbuddy.feature.bubble.formatters.color
-import cloud.trotter.dashbuddy.feature.bubble.formatters.displayLabel
-import cloud.trotter.dashbuddy.feature.bubble.formatters.offerBadgeIcon
-import cloud.trotter.dashbuddy.feature.bubble.formatters.offerScoreColor
-import cloud.trotter.dashbuddy.feature.bubble.formatters.offerVerdictColor
-import cloud.trotter.dashbuddy.feature.bubble.formatters.offerVerdictContainer
-import cloud.trotter.dashbuddy.feature.bubble.formatters.offerVerdictLabel
 import cloud.trotter.dashbuddy.feature.bubble.formatters.phaseBg
-import cloud.trotter.dashbuddy.domain.state.customerLabel
 
 /**
  * A single flow-phase card in the bubble HUD stack (#257).
@@ -83,6 +42,11 @@ import cloud.trotter.dashbuddy.domain.state.customerLabel
  *   Active cards (`isActive == true`) are always expanded and use the 1Hz
  *   `rememberNow()` ticker for countdowns. Frozen cards default collapsed
  *   and expand on tap, rendering statically from the snapshot.
+ *
+ * The per-card-kind renderers live in sibling files in this package — `FlowCardOffer.kt`
+ * ([OfferBody]), `FlowCardTask.kt` ([AwaitingBody]/[PickupBody]/[DeliveryBody]), and
+ * `FlowCardPostTask.kt` ([PostTaskBody]) — plus the shared primitives kept here ([HeroBig],
+ * [Caption]). #943 split this file at those seams; pure move, no behavior change.
  */
 @Composable
 fun FlowCardItem(
@@ -234,7 +198,8 @@ private fun PhaseChip(snapshot: FlowCardSnapshot, isActive: Boolean) {
 }
 
 // ---------------------------------------------------------------------------
-// Summary (one-line, always visible in header)
+// Summary (one-line, always visible in header) — dispatches to the per-kind
+// renderers in the sibling FlowCard*.kt files.
 // ---------------------------------------------------------------------------
 
 @Composable
@@ -246,53 +211,9 @@ private fun cardSummary(snapshot: FlowCardSnapshot, isActive: Boolean): String =
     is FlowCardSnapshot.PostTask -> postTaskSummary(snapshot)
 }
 
-@Composable
-private fun awaitingSummary(snap: FlowCardSnapshot.Awaiting, isActive: Boolean): String {
-    val now = if (isActive) rememberNow().value else (snap.phaseEndedAt ?: snap.phaseStartedAt)
-    val elapsed = now - snap.phaseStartedAt
-    return if (isActive) stringResource(R.string.flow_card_awaiting_active_format, formatDuration(elapsed))
-    else stringResource(R.string.flow_card_awaiting_frozen_format, formatDuration(elapsed))
-}
-
-@Composable
-private fun offerSummary(snap: FlowCardSnapshot.Offer): String {
-    val store = snap.storeNames.firstOrNull()?.takeIf { it.isNotBlank() } ?: stringResource(R.string.flow_card_offer_fallback_store)
-    val pay = snap.payAmount?.let { " · ${Formats.money(it)}" } ?: ""
-    // Outcome is rendered as a trailing chip in the header — see
-    // CardHeader — so we omit it from the summary text.
-    return "$store$pay"
-}
-
-@Composable
-private fun pickupSummary(snap: FlowCardSnapshot.Pickup, isActive: Boolean): String {
-    val store = snap.storeName
-    val arrivedAt = snap.arrivedAt
-    return when {
-        isActive -> store
-        arrivedAt != null -> stringResource(R.string.flow_card_pickup_arrived_format, store, formatTime(arrivedAt))
-        else -> store
-    }
-}
-
-@Composable
-private fun deliverySummary(snap: FlowCardSnapshot.Delivery, isActive: Boolean): String {
-    val customer = customerLabel(snap.storeName)
-    val arrivedAt = snap.arrivedAt
-    return when {
-        isActive -> customer
-        arrivedAt != null -> stringResource(R.string.flow_card_delivery_delivered_format, customer, formatTime(arrivedAt))
-        else -> customer
-    }
-}
-
-@Composable
-private fun postTaskSummary(snap: FlowCardSnapshot.PostTask): String {
-    val store = snap.storeName?.let { "$it · " } ?: ""
-    return store + Formats.money(snap.totalPay)
-}
-
 // ---------------------------------------------------------------------------
-// Body (expanded content) — minimal density per phase
+// Body (expanded content) — dispatches to the per-kind renderers in the
+// sibling FlowCard*.kt files.
 // ---------------------------------------------------------------------------
 
 @Composable
@@ -306,568 +227,12 @@ private fun CardBody(snapshot: FlowCardSnapshot, isActive: Boolean) {
     }
 }
 
-@Composable
-private fun AwaitingBody(snap: FlowCardSnapshot.Awaiting, isActive: Boolean) {
-    val now = if (isActive) rememberNow().value else (snap.phaseEndedAt ?: snap.phaseStartedAt)
-    val elapsed = now - snap.phaseStartedAt
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(2.dp),
-    ) {
-        HeroBig(formatDuration(elapsed))
-        Caption(
-            if (isActive) stringResource(R.string.flow_card_since_last_offer)
-            else stringResource(R.string.flow_card_before_next_offer)
-        )
-    }
-}
-
-/**
- * Offer body (redesign): a live expiry bar, a score ring beside the net $/hr
- * hero, a verdict banner (action + reason + quality), and badge pills. The
- * DoorDash expiry countdown also ticks in the header. (The Accept/Decline
- * action row + auto-action countdown land in Stage 2/3 of #110.)
- */
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
-    val c = AppTheme.colors
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        // Live expiry progress bar (DoorDash's own offer countdown), active only.
-        val expiresAt = snap.expiresAt
-        val countdownSeconds = snap.countdownSeconds
-        if (isActive && expiresAt != null && countdownSeconds != null && countdownSeconds > 0) {
-            val now by rememberNow()
-            val secsLeft = ((expiresAt - now) / 1000f).coerceAtLeast(0f)
-            val frac = (secsLeft / countdownSeconds).coerceIn(0f, 1f)
-            val barColor = offerExpiryColor(frac.toDouble(), c)
-            Box(
-                Modifier.fillMaxWidth().height(4.dp)
-                    .clip(RoundedCornerShape(2.dp)).background(c.line),
-            ) {
-                Box(Modifier.fillMaxWidth(frac).fillMaxHeight().background(barColor))
-            }
-        }
-
-        // Score ring + net $/hr hero.
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            snap.evaluationScore?.let { score ->
-                // Ring colors track the evaluator's REAL decision boundaries (#400) — via the
-                // [offerScoreColor] SSOT the notification gauge shares (#942).
-                val sc = offerScoreColor(score, c)
-                AppGaugeRing(
-                    progress = (score / 100.0).toFloat(),
-                    value = score.toInt().toString(),
-                    label = stringResource(R.string.flow_card_score_gauge_label),
-                    color = sc,
-                    diameter = 60.dp,
-                )
-            }
-            Column(modifier = Modifier.weight(1f)) {
-                val hourly = snap.dollarsPerHour
-                when {
-                    hourly != null -> Text(
-                        stringResource(R.string.flow_card_hourly_hero_format, Formats.money0(hourly)),
-                        style = AppTheme.num.heroNum, color = c.text, maxLines = 1,
-                    )
-                    snap.payAmount != null -> Text(Formats.money(snap.payAmount!!), style = AppTheme.num.heroNum, color = c.text, maxLines = 1)
-                }
-                val net = snap.netPayAmount ?: snap.payAmount
-                val netLabel = stringResource(R.string.flow_card_net_secondary_format, net?.let { Formats.money(it) } ?: "")
-                val distanceLabel = snap.distanceMiles?.let { stringResource(R.string.flow_card_distance_secondary_format, Formats.decimal(it)) }
-                val perMileLabel = snap.dollarsPerMile?.let { stringResource(R.string.flow_card_per_mile_secondary_format, Formats.money(it)) }
-                val secondary = buildString {
-                    if (net != null) append(netLabel)
-                    distanceLabel?.let {
-                        if (isNotEmpty()) append(" · ")
-                        append(it)
-                    }
-                    perMileLabel?.let {
-                        if (isNotEmpty()) append(" · ")
-                        append(it)
-                    }
-                }
-                if (secondary.isNotBlank()) {
-                    Text(secondary, style = AppTheme.num.smNum, color = c.text2, maxLines = 1)
-                }
-            }
-            // (#461: the item count now rides the [cart N] shop badge below, not the hero tier.)
-        }
-
-        // Verdict banner — action word + reason + quality chip, tinted by the action. The word and
-        // its two tints come from the [offerVerdictLabel]/[offerVerdictColor] SSOT the heads-up
-        // notification shares (#942); this used to be three independent `when`s over the raw enum
-        // NAME (the #283 stringly-typed shape), which is how "REVIEW" here became "MANUAL REVIEW".
-        snap.evaluationAction?.let { name ->
-            val action = runCatching { OfferAction.valueOf(name) }.getOrNull()
-            val vColor = offerVerdictColor(action, c)
-            val vBg = offerVerdictContainer(action, c)
-            val vIcon = when (action) {
-                OfferAction.ACCEPT -> Icons.Default.Check
-                OfferAction.DECLINE -> Icons.Default.Close
-                else -> Icons.Default.Info
-            }
-            Surface(shape = MaterialTheme.shapes.small, color = vBg) {
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Icon(vIcon, contentDescription = null, tint = vColor, modifier = Modifier.size(18.dp))
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            offerVerdictLabel(action),
-                            style = MaterialTheme.typography.labelLarge,
-                            fontWeight = FontWeight.ExtraBold,
-                            color = vColor,
-                        )
-                    }
-                    snap.qualityLevel?.let { AppChip(it.displayLabel(), color = c.text3, container = c.surface3) }
-                }
-            }
-        }
-
-        // Badge row (#461): icon badges tinted by their brand color; the SHOP badge is co-icon-text
-        // [🛒 N] — the shopping-chat cart + the item count. Badges without a drawable fall back to a
-        // text pill so nothing is dropped.
-        if (snap.badges.isNotEmpty()) {
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                verticalArrangement = Arrangement.spacedBy(6.dp),
-            ) {
-                snap.badges.forEach { b ->
-                    val (label, col) = badgeMeta(b, c)
-                    when {
-                        b == FlowCardSnapshot.Offer.SHOP_BADGE -> BadgeIcon(
-                            iconRes = R.drawable.ic_chat_shopping_cart,
-                            label = snap.itemCount.takeIf { it > 0 }?.toString(),
-                            color = col,
-                        )
-                        else -> badgeIcon(b)
-                            ?.let { BadgeIcon(iconRes = it, label = null, color = col) }
-                            ?: AppChip(label, color = col, container = c.surface3)
-                    }
-                }
-            }
-        }
-
-        // Footer: stores, joined by the :domain display SSOT (#942 — the heads-up notification
-        // used to say "A + B" for the same offer this card called "A & B").
-        val storeText = snap.storeNames.joinDisplayStores().ifBlank { null }
-        if (storeText != null) Caption(storeText)
-    }
-}
-
-/** Live m:ss offer-expiry countdown for the active offer card header. */
-@Composable
-private fun OfferCountdownText(expiresAt: Long, countdownSeconds: Int) {
-    val c = AppTheme.colors
-    val now by rememberNow()
-    val secsLeft = ((expiresAt - now) / 1000.0).coerceAtLeast(0.0)
-    val frac = if (countdownSeconds > 0) (secsLeft / countdownSeconds).coerceIn(0.0, 1.0) else 0.0
-    val col = offerExpiryColor(frac, c)
-    Text(
-        text = formatCountdown((secsLeft * 1000).toLong()),
-        style = AppTheme.num.smNum,
-        color = col,
-        fontWeight = FontWeight.Bold,
-    )
-}
-
-/**
- * Badge enum name → `ic_badge_*` drawable (#461); null means "no icon, render the text pill". The
- * SHOP badge is handled by the caller (the shopping-chat cart + the item count, [🛒 N]).
- * Delegates to the [offerBadgeIcon] SSOT (#578) so the bubble card and the offer notification share
- * one map and can't drift.
- */
-@DrawableRes
-private fun badgeIcon(name: String): Int? = offerBadgeIcon(name)
-
-/**
- * Icon badge in the [AppChip] pill family (#461): a brand-tinted icon, optionally with a trailing
- * label — the SHOP badge rides its item count here ([🛒 N]). Mirrors AppChip's chip tokens.
- */
-@Composable
-private fun BadgeIcon(
-    @DrawableRes iconRes: Int,
-    label: String?,
-    color: Color,
-    container: Color = AppTheme.colors.surface3,
-) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        modifier = Modifier
-            .clip(CircleShape)
-            .background(container)
-            .padding(horizontal = 7.dp, vertical = 4.dp),
-    ) {
-        Icon(painterResource(iconRes), contentDescription = null, tint = color, modifier = Modifier.size(14.dp))
-        if (label != null) Text(label, style = AppTheme.num.chip, color = color)
-    }
-}
-
-/**
- * Maps a badge wire name to its label + brand color for the pill row.
- *
- * The **label** is not this function's to own (#942): every badge is an
- * [OfferBadge]/[OrderBadge] constant carrying a `displayName`, and this map used to keep a second,
- * drifted set of labels that silently missed ≥8 branches — those fell to a lowercased-enum mangle
- * ("Age restricted 21 plus"). Only the synthetic
- * [SHOP_BADGE][FlowCardSnapshot.Offer.SHOP_BADGE] marker, which is no enum constant, keeps a
- * string-resource label of its own.
- *
- * The **color** is the one thing this owns — and it is keyed on the typed enums, not on raw name
- * strings (the #283 stringly-typed shape).
- */
-@Composable
-private fun badgeMeta(name: String, c: AppColors): Pair<String, Color> {
-    if (name == FlowCardSnapshot.Offer.SHOP_BADGE) {
-        return stringResource(R.string.flow_card_badge_shop_and_deliver) to c.stPickup
-    }
-    OfferBadge.entries.firstOrNull { it.name == name }?.let { badge ->
-        return badge.displayName to when (badge) {
-            OfferBadge.HIGH_PAYING -> c.good
-            OfferBadge.PRIORITY_ACCESS -> c.stOffer
-            else -> c.neutral
-        }
-    }
-    OrderBadge.entries.firstOrNull { it.name == name }?.let { badge ->
-        return badge.displayName to when (badge) {
-            OrderBadge.RED_CARD -> c.bad
-            OrderBadge.ALCOHOL -> c.warn
-            OrderBadge.LARGE_ORDER, OrderBadge.PIZZA_BAG -> c.neutral
-        }
-    }
-    // Unreachable today — the snapshot's badge list is minted from the two enums plus SHOP — but a
-    // future marker renders as itself rather than vanishing.
-    return name to c.neutral
-}
-
-/** Pickup body — the #324/#460 task-card vocabulary (co-hero pair). */
-@Composable
-private fun PickupBody(snap: FlowCardSnapshot.Pickup, isActive: Boolean) {
-    TaskBody(
-        phaseStartedAt = snap.phaseStartedAt,
-        arrivedAt = snap.arrivedAt,
-        deadlineMillis = snap.deadlineMillis,
-        phaseEndedAt = snap.phaseEndedAt,
-        isActive = isActive,
-        isDrop = false,
-        primary = snap.storeName,
-        netPay = snap.netPay,
-        estMinutes = snap.estMinutes,
-        perMile = snap.perMile,
-        confirmedAt = snap.confirmedAt,
-        itemsShopped = snap.itemsShopped,
-        itemsRemaining = snap.itemsRemaining,
-        activity = snap.activity,
-    )
-}
-
-/** Delivery body — same co-hero shape as Pickup, deliver-by deadline + customer. */
-@Composable
-private fun DeliveryBody(snap: FlowCardSnapshot.Delivery, isActive: Boolean) {
-    TaskBody(
-        phaseStartedAt = snap.phaseStartedAt,
-        arrivedAt = snap.arrivedAt,
-        deadlineMillis = snap.deadlineMillis,
-        phaseEndedAt = snap.phaseEndedAt,
-        isActive = isActive,
-        isDrop = true,
-        primary = customerLabel(snap.storeName),
-        netPay = snap.netPay,
-        estMinutes = snap.estMinutes,
-        perMile = snap.perMile,
-        confirmedAt = null,
-        itemsShopped = null,
-        itemsRemaining = null,
-        activity = null,
-    )
-}
-
-/**
- * Shared task-card body for Pickup + Delivery (#324/#460). Two co-heroes:
- * the phase timer (To-go countdown → Dwell count-up once arrived) and the
- * live "Running at $/hr" realized rate (holds until the deadline, then erodes
- * — the drop-it signal). Below: an arrival/deadline caption, the drop-it
- * floor banner, shop pace, and a store/customer detail line. All time-derived
- * values tick off `rememberNow()` while the card is live.
- */
-@Composable
-private fun TaskBody(
-    phaseStartedAt: Long,
-    arrivedAt: Long?,
-    deadlineMillis: Long?,
-    phaseEndedAt: Long?,
-    isActive: Boolean,
-    isDrop: Boolean,
-    primary: String,
-    netPay: Double?,
-    estMinutes: Double?,
-    perMile: Double?,
-    confirmedAt: Long?,
-    itemsShopped: Int?,
-    itemsRemaining: Int?,
-    activity: String?,
-) {
-    val c = AppTheme.colors
-    val now = if (isActive) rememberNow().value else (phaseEndedAt ?: phaseStartedAt)
-    val arrived = arrivedAt != null
-    val verb = if (isDrop) stringResource(R.string.flow_card_verb_deliver) else stringResource(R.string.flow_card_verb_pickup)
-    val overdue = deadlineMillis != null && now > deadlineMillis
-    // Live realized $/hr — ticks with `now` (erodes past the deadline), so it is recomputed here
-    // each tick from the snapshot's anchors via the TaskEconomics SSOT, never frozen at reduce
-    // time. The fixed $/mi companion ([perMile]) is precomputed on the snapshot.
-    val hourly = TaskEconomics.projectedHourly(netPay, estMinutes, deadlineMillis, now)
-
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        // ---- Co-hero pair: phase timer + live realized $/hr ----
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            // LEFT — phase timer.
-            val timerLabel: String
-            val timerValue: String
-            val timerSub: String?
-            val timerColor: Color
-            when {
-                arrived -> {
-                    timerLabel = stringResource(R.string.flow_card_timer_dwell_label)
-                    timerValue = formatCountdown(now - arrivedAt)
-                    timerSub = if (isDrop) stringResource(R.string.flow_card_timer_at_door_sub) else stringResource(R.string.flow_card_timer_at_store_sub)
-                    timerColor = deadlineMillis?.let { deadlineColor(it - arrivedAt) } ?: c.text
-                }
-                deadlineMillis != null -> {
-                    timerLabel = if (overdue) stringResource(R.string.flow_card_timer_overdue_label) else stringResource(R.string.flow_card_timer_to_go_label)
-                    timerValue = formatCountdown(deadlineMillis - now)
-                    timerSub = null
-                    timerColor = deadlineColor(deadlineMillis - now)
-                }
-                else -> {
-                    timerLabel = stringResource(R.string.flow_card_timer_elapsed_label)
-                    timerValue = formatDuration(now - phaseStartedAt)
-                    timerSub = stringResource(R.string.flow_card_timer_en_route_sub)
-                    timerColor = c.text
-                }
-            }
-            TaskMetric(
-                modifier = Modifier.weight(1f),
-                live = isActive,
-                label = timerLabel,
-                value = timerValue,
-                sub = timerSub,
-                color = timerColor,
-            )
-            Box(Modifier.size(width = 1.dp, height = 36.dp).background(c.line))
-            // RIGHT — Running at $/hr (erodes past the deadline).
-            TaskMetric(
-                modifier = Modifier.weight(1f),
-                live = isActive && hourly != null,
-                label = stringResource(R.string.flow_card_running_at_label),
-                value = if (hourly != null) {
-                    if (overdue) stringResource(R.string.flow_card_running_at_overdue_format, Formats.money0(hourly))
-                    else stringResource(R.string.flow_card_hourly_hero_format, Formats.money0(hourly))
-                } else "—",
-                // Sub line prefers the fixed $/mi efficiency; falls back to the erosion status.
-                sub = perMile?.let { stringResource(R.string.flow_card_per_mile_secondary_format, Formats.money(it)) }
-                    ?: if (hourly == null) null else if (overdue) stringResource(R.string.flow_card_running_at_dropping_sub)
-                    else stringResource(R.string.flow_card_running_at_on_track_sub),
-                color = hourly?.let { hourlyColor(it, c) } ?: c.text3,
-            )
-        }
-
-        // ---- arrival / deadline caption ----
-        val caption = buildString {
-            if (arrived && deadlineMillis != null) {
-                val margin = deadlineMillis - arrivedAt
-                append(
-                    stringResource(
-                        R.string.flow_card_arrived_margin_format,
-                        formatCountdown(kotlin.math.abs(margin)),
-                        if (margin >= 0) stringResource(R.string.flow_card_margin_early) else stringResource(R.string.flow_card_margin_late),
-                    ),
-                )
-            }
-            when {
-                deadlineMillis == null -> append(if (arrived) stringResource(R.string.flow_card_at_stop) else stringResource(R.string.flow_card_en_route))
-                overdue -> append(stringResource(R.string.flow_card_past_deadline_format, formatCountdown(now - deadlineMillis), verb))
-                else -> append(stringResource(R.string.flow_card_by_deadline_format, verb, formatTime(deadlineMillis)))
-            }
-        }
-        Caption(caption)
-
-        // ---- drop-it floor banner: overdue AND the rate has eroded below the floor ----
-        if (isActive && overdue && hourly != null && TaskEconomics.belowDropFloor(hourly)) {
-            Surface(shape = MaterialTheme.shapes.small, color = c.badBg) {
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Icon(Icons.Default.Close, contentDescription = null, tint = c.bad, modifier = Modifier.size(16.dp))
-                    Text(
-                        stringResource(R.string.flow_card_below_floor_warning),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = c.bad,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                }
-            }
-        }
-
-        // ---- shop progress (Shop & Deliver): shopped/total + live pace ----
-        if (activity == PickupActivity.SHOPPING) {
-            val shopped = itemsShopped ?: 0
-            val total = shopped + (itemsRemaining ?: 0)
-            if (total > 0) {
-                val elapsedMs = now - (arrivedAt ?: phaseStartedAt)
-                val pace = if (elapsedMs > 0) shopped / (elapsedMs / 60_000.0) else 0.0
-                Surface(shape = MaterialTheme.shapes.small, color = c.stPickup.copy(alpha = 0.12f)) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        Text(
-                            stringResource(R.string.flow_card_shop_progress_format, shopped, total),
-                            style = AppTheme.num.smNum, color = c.text, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f),
-                        )
-                        Text(
-                            stringResource(R.string.flow_card_shop_pace_format, Formats.decimal(pace)),
-                            style = AppTheme.num.smNum, color = c.stPickup, fontWeight = FontWeight.Bold,
-                        )
-                    }
-                }
-            }
-        }
-
-        // ---- detail line — store/customer + lifecycle times ----
-        val detail = buildString {
-            append(primary)
-            arrivedAt?.let { append(stringResource(R.string.flow_card_detail_arrived_format, formatTime(it))) }
-            confirmedAt?.let { append(stringResource(R.string.flow_card_detail_picked_up_format, formatTime(it))) }
-            if (arrivedAt == null && phaseEndedAt != null && !isActive) {
-                append(" · ${formatDuration(phaseEndedAt - phaseStartedAt)}")
-            }
-        }
-        Caption(detail)
-    }
-}
-
-/** One co-hero metric — a label (with a live dot), a big value, and an optional sub. */
-@Composable
-private fun TaskMetric(
-    modifier: Modifier = Modifier,
-    live: Boolean,
-    label: String,
-    value: String,
-    sub: String?,
-    color: Color,
-) {
-    val c = AppTheme.colors
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(2.dp),
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            if (live) Box(Modifier.size(6.dp).clip(RoundedCornerShape(3.dp)).background(color))
-            Text(label.uppercase(), style = MaterialTheme.typography.labelSmall, color = c.text3, fontWeight = FontWeight.Bold)
-        }
-        // 24sp — a co-hero size (vs the 30sp single hero) so the two metrics fit
-        // side by side in the bubble's width without clipping.
-        Text(value, style = AppTheme.num.heroNum.copy(fontSize = 24.sp * AppTheme.glance), color = color, maxLines = 1)
-        if (sub != null) Text(sub, style = MaterialTheme.typography.labelSmall, color = c.text3, maxLines = 1)
-    }
-}
-
-/**
- * The $/hr tier → brand Color mapping for the task co-hero (#460). The tier
- * *classification* (the cutoffs) lives in [TaskEconomics]; the UI keeps only
- * the color lookup (audit #6).
- */
-private fun hourlyColor(hourly: Double, c: AppColors): Color = when (TaskEconomics.hourlyTier(hourly)) {
-    TaskEconomics.HourlyTier.GOOD -> c.good
-    TaskEconomics.HourlyTier.WARN -> c.warn
-    TaskEconomics.HourlyTier.POOR -> c.bad
-}
-
-/**
- * PostTask body: receipt-style. Hero is total pay. Below: per-item
- * breakdown (base + tip) shown compactly.
- */
-@Composable
-private fun PostTaskBody(snap: FlowCardSnapshot.PostTask) {
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(2.dp),
-    ) {
-        HeroBig(Formats.money(snap.totalPay))
-        Caption(stringResource(R.string.flow_card_post_task_delivery_total))
-        snap.parsedPay?.let { pay ->
-            Column(
-                modifier = Modifier.padding(top = 6.dp),
-                verticalArrangement = Arrangement.spacedBy(2.dp),
-            ) {
-                pay.appPayComponents.forEach { item ->
-                    BreakdownRow(item.type, Formats.money(item.amount))
-                }
-                pay.customerTips.forEach { tip ->
-                    BreakdownRow(stringResource(R.string.flow_card_post_task_tip_format, tip.displayLabel), Formats.money(tip.amount))
-                }
-            }
-        }
-        snap.sessionEarningsAtCompletion?.let {
-            Caption(stringResource(R.string.flow_card_post_task_session_format, Formats.money(it)))
-        }
-    }
-}
-
 // ---------------------------------------------------------------------------
-// Primitives
+// Primitives shared across the per-kind renderers.
 // ---------------------------------------------------------------------------
 
-/** Manual Accept / Decline buttons on the active offer card (#110 Stage 2b). */
 @Composable
-private fun OfferActionRow(onAccept: () -> Unit, onDecline: () -> Unit) {
-    val c = AppTheme.colors
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        OutlinedButton(
-            onClick = onDecline,
-            modifier = Modifier.weight(1f),
-            border = BorderStroke(1.5.dp, c.bad),
-            colors = ButtonDefaults.outlinedButtonColors(contentColor = c.bad),
-        ) { Text(stringResource(R.string.flow_card_action_decline), fontWeight = FontWeight.Bold) }
-        Button(
-            onClick = onAccept,
-            modifier = Modifier.weight(1f),
-            colors = ButtonDefaults.buttonColors(containerColor = c.good, contentColor = c.textInv),
-        ) { Text(stringResource(R.string.flow_card_action_accept), fontWeight = FontWeight.Bold) }
-    }
-}
-
-@Composable
-private fun HeroBig(text: String, color: Color = MaterialTheme.colorScheme.onSurface) {
+internal fun HeroBig(text: String, color: Color = MaterialTheme.colorScheme.onSurface) {
     Text(
         text = text,
         style = AppTheme.num.heroNum,
@@ -877,24 +242,13 @@ private fun HeroBig(text: String, color: Color = MaterialTheme.colorScheme.onSur
 }
 
 @Composable
-private fun Caption(text: String) {
+internal fun Caption(text: String) {
     Text(
         text = text,
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         maxLines = 1,
     )
-}
-
-@Composable
-private fun BreakdownRow(label: String, value: String) {
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Text(label, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(value, style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Medium, color = MaterialTheme.colorScheme.onSurface)
-    }
 }
 
 @Composable
@@ -919,29 +273,3 @@ private fun OutcomeChip(outcome: AppEventType) {
         )
     }
 }
-
-@Composable
-private fun deadlineColor(remainingMs: Long): Color {
-    val mins = remainingMs / 60_000L
-    val c = AppTheme.colors
-    return when {
-        remainingMs < 0 -> c.bad              // past — red
-        mins < 5 -> c.bad                     // <5m — red
-        mins < 10 -> c.warn                   // 5-10m — amber
-        else -> c.good                        // >10m — green
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Time helpers — the shared kit lives in :core:designsystem (#358)
-// ---------------------------------------------------------------------------
-
-/** THE offer-expiry color tiers (#406) — previously written twice in this file. */
-private fun offerExpiryColor(frac: Double, c: AppColors): Color = when {
-    frac > 0.45 -> c.good
-    frac > 0.2 -> c.warn
-    else -> c.bad
-}
-
-@Composable
-private fun formatTime(millis: Long): String = rememberTimeFormatter().invoke(millis)

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/FlowCardOffer.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/FlowCardOffer.kt
@@ -1,0 +1,330 @@
+package cloud.trotter.dashbuddy.feature.bubble.cards
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
+import cloud.trotter.dashbuddy.core.designsystem.component.AppGaugeRing
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppColors
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.core.designsystem.time.rememberNow
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.format.formatCountdown
+import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+import cloud.trotter.dashbuddy.domain.model.offer.OfferBadge
+import cloud.trotter.dashbuddy.domain.model.offer.joinDisplayStores
+import cloud.trotter.dashbuddy.domain.model.order.OrderBadge
+import cloud.trotter.dashbuddy.feature.bubble.R
+import cloud.trotter.dashbuddy.feature.bubble.formatters.displayLabel
+import cloud.trotter.dashbuddy.feature.bubble.formatters.offerBadgeIcon
+import cloud.trotter.dashbuddy.feature.bubble.formatters.offerScoreColor
+import cloud.trotter.dashbuddy.feature.bubble.formatters.offerVerdictColor
+import cloud.trotter.dashbuddy.feature.bubble.formatters.offerVerdictContainer
+import cloud.trotter.dashbuddy.feature.bubble.formatters.offerVerdictLabel
+
+// ---------------------------------------------------------------------------
+// Offer — summary line, body, live countdown, badges, and the manual
+// Accept/Decline action row (#943 split of FlowCardItem.kt — moves only).
+// ---------------------------------------------------------------------------
+
+@Composable
+internal fun offerSummary(snap: FlowCardSnapshot.Offer): String {
+    val store = snap.storeNames.firstOrNull()?.takeIf { it.isNotBlank() } ?: stringResource(R.string.flow_card_offer_fallback_store)
+    val pay = snap.payAmount?.let { " · ${Formats.money(it)}" } ?: ""
+    // Outcome is rendered as a trailing chip in the header — see
+    // CardHeader — so we omit it from the summary text.
+    return "$store$pay"
+}
+
+/**
+ * Offer body (redesign): a live expiry bar, a score ring beside the net $/hr
+ * hero, a verdict banner (action + reason + quality), and badge pills. The
+ * DoorDash expiry countdown also ticks in the header. (The Accept/Decline
+ * action row + auto-action countdown land in Stage 2/3 of #110.)
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
+    val c = AppTheme.colors
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        // Live expiry progress bar (DoorDash's own offer countdown), active only.
+        val expiresAt = snap.expiresAt
+        val countdownSeconds = snap.countdownSeconds
+        if (isActive && expiresAt != null && countdownSeconds != null && countdownSeconds > 0) {
+            val now by rememberNow()
+            val secsLeft = ((expiresAt - now) / 1000f).coerceAtLeast(0f)
+            val frac = (secsLeft / countdownSeconds).coerceIn(0f, 1f)
+            val barColor = offerExpiryColor(frac.toDouble(), c)
+            Box(
+                Modifier.fillMaxWidth().height(4.dp)
+                    .clip(RoundedCornerShape(2.dp)).background(c.line),
+            ) {
+                Box(Modifier.fillMaxWidth(frac).fillMaxHeight().background(barColor))
+            }
+        }
+
+        // Score ring + net $/hr hero.
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            snap.evaluationScore?.let { score ->
+                // Ring colors track the evaluator's REAL decision boundaries (#400) — via the
+                // [offerScoreColor] SSOT the notification gauge shares (#942).
+                val sc = offerScoreColor(score, c)
+                AppGaugeRing(
+                    progress = (score / 100.0).toFloat(),
+                    value = score.toInt().toString(),
+                    label = stringResource(R.string.flow_card_score_gauge_label),
+                    color = sc,
+                    diameter = 60.dp,
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                val hourly = snap.dollarsPerHour
+                when {
+                    hourly != null -> Text(
+                        stringResource(R.string.flow_card_hourly_hero_format, Formats.money0(hourly)),
+                        style = AppTheme.num.heroNum, color = c.text, maxLines = 1,
+                    )
+                    snap.payAmount != null -> Text(Formats.money(snap.payAmount!!), style = AppTheme.num.heroNum, color = c.text, maxLines = 1)
+                }
+                val net = snap.netPayAmount ?: snap.payAmount
+                val netLabel = stringResource(R.string.flow_card_net_secondary_format, net?.let { Formats.money(it) } ?: "")
+                val distanceLabel = snap.distanceMiles?.let { stringResource(R.string.flow_card_distance_secondary_format, Formats.decimal(it)) }
+                val perMileLabel = snap.dollarsPerMile?.let { stringResource(R.string.flow_card_per_mile_secondary_format, Formats.money(it)) }
+                val secondary = buildString {
+                    if (net != null) append(netLabel)
+                    distanceLabel?.let {
+                        if (isNotEmpty()) append(" · ")
+                        append(it)
+                    }
+                    perMileLabel?.let {
+                        if (isNotEmpty()) append(" · ")
+                        append(it)
+                    }
+                }
+                if (secondary.isNotBlank()) {
+                    Text(secondary, style = AppTheme.num.smNum, color = c.text2, maxLines = 1)
+                }
+            }
+            // (#461: the item count now rides the [cart N] shop badge below, not the hero tier.)
+        }
+
+        // Verdict banner — action word + reason + quality chip, tinted by the action. The word and
+        // its two tints come from the [offerVerdictLabel]/[offerVerdictColor] SSOT the heads-up
+        // notification shares (#942); this used to be three independent `when`s over the raw enum
+        // NAME (the #283 stringly-typed shape), which is how "REVIEW" here became "MANUAL REVIEW".
+        snap.evaluationAction?.let { name ->
+            val action = runCatching { OfferAction.valueOf(name) }.getOrNull()
+            val vColor = offerVerdictColor(action, c)
+            val vBg = offerVerdictContainer(action, c)
+            val vIcon = when (action) {
+                OfferAction.ACCEPT -> Icons.Default.Check
+                OfferAction.DECLINE -> Icons.Default.Close
+                else -> Icons.Default.Info
+            }
+            Surface(shape = MaterialTheme.shapes.small, color = vBg) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Icon(vIcon, contentDescription = null, tint = vColor, modifier = Modifier.size(18.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            offerVerdictLabel(action),
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.ExtraBold,
+                            color = vColor,
+                        )
+                    }
+                    snap.qualityLevel?.let { AppChip(it.displayLabel(), color = c.text3, container = c.surface3) }
+                }
+            }
+        }
+
+        // Badge row (#461): icon badges tinted by their brand color; the SHOP badge is co-icon-text
+        // [🛒 N] — the shopping-chat cart + the item count. Badges without a drawable fall back to a
+        // text pill so nothing is dropped.
+        if (snap.badges.isNotEmpty()) {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                snap.badges.forEach { b ->
+                    val (label, col) = badgeMeta(b, c)
+                    when {
+                        b == FlowCardSnapshot.Offer.SHOP_BADGE -> BadgeIcon(
+                            iconRes = R.drawable.ic_chat_shopping_cart,
+                            label = snap.itemCount.takeIf { it > 0 }?.toString(),
+                            color = col,
+                        )
+                        else -> badgeIcon(b)
+                            ?.let { BadgeIcon(iconRes = it, label = null, color = col) }
+                            ?: AppChip(label, color = col, container = c.surface3)
+                    }
+                }
+            }
+        }
+
+        // Footer: stores, joined by the :domain display SSOT (#942 — the heads-up notification
+        // used to say "A + B" for the same offer this card called "A & B").
+        val storeText = snap.storeNames.joinDisplayStores().ifBlank { null }
+        if (storeText != null) Caption(storeText)
+    }
+}
+
+/** Live m:ss offer-expiry countdown for the active offer card header. */
+@Composable
+internal fun OfferCountdownText(expiresAt: Long, countdownSeconds: Int) {
+    val c = AppTheme.colors
+    val now by rememberNow()
+    val secsLeft = ((expiresAt - now) / 1000.0).coerceAtLeast(0.0)
+    val frac = if (countdownSeconds > 0) (secsLeft / countdownSeconds).coerceIn(0.0, 1.0) else 0.0
+    val col = offerExpiryColor(frac, c)
+    Text(
+        text = formatCountdown((secsLeft * 1000).toLong()),
+        style = AppTheme.num.smNum,
+        color = col,
+        fontWeight = FontWeight.Bold,
+    )
+}
+
+/**
+ * Badge enum name → `ic_badge_*` drawable (#461); null means "no icon, render the text pill". The
+ * SHOP badge is handled by the caller (the shopping-chat cart + the item count, [🛒 N]).
+ * Delegates to the [offerBadgeIcon] SSOT (#578) so the bubble card and the offer notification share
+ * one map and can't drift.
+ */
+@DrawableRes
+private fun badgeIcon(name: String): Int? = offerBadgeIcon(name)
+
+/**
+ * Icon badge in the [AppChip] pill family (#461): a brand-tinted icon, optionally with a trailing
+ * label — the SHOP badge rides its item count here ([🛒 N]). Mirrors AppChip's chip tokens.
+ */
+@Composable
+private fun BadgeIcon(
+    @DrawableRes iconRes: Int,
+    label: String?,
+    color: Color,
+    container: Color = AppTheme.colors.surface3,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        modifier = Modifier
+            .clip(CircleShape)
+            .background(container)
+            .padding(horizontal = 7.dp, vertical = 4.dp),
+    ) {
+        Icon(painterResource(iconRes), contentDescription = null, tint = color, modifier = Modifier.size(14.dp))
+        if (label != null) Text(label, style = AppTheme.num.chip, color = color)
+    }
+}
+
+/**
+ * Maps a badge wire name to its label + brand color for the pill row.
+ *
+ * The **label** is not this function's to own (#942): every badge is an
+ * [OfferBadge]/[OrderBadge] constant carrying a `displayName`, and this map used to keep a second,
+ * drifted set of labels that silently missed ≥8 branches — those fell to a lowercased-enum mangle
+ * ("Age restricted 21 plus"). Only the synthetic
+ * [SHOP_BADGE][FlowCardSnapshot.Offer.SHOP_BADGE] marker, which is no enum constant, keeps a
+ * string-resource label of its own.
+ *
+ * The **color** is the one thing this owns — and it is keyed on the typed enums, not on raw name
+ * strings (the #283 stringly-typed shape).
+ */
+@Composable
+private fun badgeMeta(name: String, c: AppColors): Pair<String, Color> {
+    if (name == FlowCardSnapshot.Offer.SHOP_BADGE) {
+        return stringResource(R.string.flow_card_badge_shop_and_deliver) to c.stPickup
+    }
+    OfferBadge.entries.firstOrNull { it.name == name }?.let { badge ->
+        return badge.displayName to when (badge) {
+            OfferBadge.HIGH_PAYING -> c.good
+            OfferBadge.PRIORITY_ACCESS -> c.stOffer
+            else -> c.neutral
+        }
+    }
+    OrderBadge.entries.firstOrNull { it.name == name }?.let { badge ->
+        return badge.displayName to when (badge) {
+            OrderBadge.RED_CARD -> c.bad
+            OrderBadge.ALCOHOL -> c.warn
+            OrderBadge.LARGE_ORDER, OrderBadge.PIZZA_BAG -> c.neutral
+        }
+    }
+    // Unreachable today — the snapshot's badge list is minted from the two enums plus SHOP — but a
+    // future marker renders as itself rather than vanishing.
+    return name to c.neutral
+}
+
+/** Manual Accept / Decline buttons on the active offer card (#110 Stage 2b). */
+@Composable
+internal fun OfferActionRow(onAccept: () -> Unit, onDecline: () -> Unit) {
+    val c = AppTheme.colors
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        OutlinedButton(
+            onClick = onDecline,
+            modifier = Modifier.weight(1f),
+            border = BorderStroke(1.5.dp, c.bad),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = c.bad),
+        ) { Text(stringResource(R.string.flow_card_action_decline), fontWeight = FontWeight.Bold) }
+        Button(
+            onClick = onAccept,
+            modifier = Modifier.weight(1f),
+            colors = ButtonDefaults.buttonColors(containerColor = c.good, contentColor = c.textInv),
+        ) { Text(stringResource(R.string.flow_card_action_accept), fontWeight = FontWeight.Bold) }
+    }
+}
+
+/** THE offer-expiry color tiers (#406) — previously written twice in this file. */
+private fun offerExpiryColor(frac: Double, c: AppColors): Color = when {
+    frac > 0.45 -> c.good
+    frac > 0.2 -> c.warn
+    else -> c.bad
+}

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/FlowCardPostTask.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/FlowCardPostTask.kt
@@ -1,0 +1,73 @@
+package cloud.trotter.dashbuddy.feature.bubble.cards
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+import cloud.trotter.dashbuddy.domain.model.pay.displayLabel
+import cloud.trotter.dashbuddy.feature.bubble.R
+
+// ---------------------------------------------------------------------------
+// PostTask — receipt-style summary + body (#943 split of FlowCardItem.kt —
+// moves only).
+// ---------------------------------------------------------------------------
+
+@Composable
+internal fun postTaskSummary(snap: FlowCardSnapshot.PostTask): String {
+    val store = snap.storeName?.let { "$it · " } ?: ""
+    return store + Formats.money(snap.totalPay)
+}
+
+/**
+ * PostTask body: receipt-style. Hero is total pay. Below: per-item
+ * breakdown (base + tip) shown compactly.
+ */
+@Composable
+internal fun PostTaskBody(snap: FlowCardSnapshot.PostTask) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        HeroBig(Formats.money(snap.totalPay))
+        Caption(stringResource(R.string.flow_card_post_task_delivery_total))
+        snap.parsedPay?.let { pay ->
+            Column(
+                modifier = Modifier.padding(top = 6.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                pay.appPayComponents.forEach { item ->
+                    BreakdownRow(item.type, Formats.money(item.amount))
+                }
+                pay.customerTips.forEach { tip ->
+                    BreakdownRow(stringResource(R.string.flow_card_post_task_tip_format, tip.displayLabel), Formats.money(tip.amount))
+                }
+            }
+        }
+        snap.sessionEarningsAtCompletion?.let {
+            Caption(stringResource(R.string.flow_card_post_task_session_format, Formats.money(it)))
+        }
+    }
+}
+
+@Composable
+private fun BreakdownRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Medium, color = MaterialTheme.colorScheme.onSurface)
+    }
+}

--- a/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/FlowCardTask.kt
+++ b/feature/bubble/src/main/java/cloud/trotter/dashbuddy/feature/bubble/cards/FlowCardTask.kt
@@ -1,0 +1,365 @@
+package cloud.trotter.dashbuddy.feature.bubble.cards
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppColors
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.core.designsystem.time.rememberNow
+import cloud.trotter.dashbuddy.core.designsystem.time.rememberTimeFormatter
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.format.formatCountdown
+import cloud.trotter.dashbuddy.domain.format.formatDuration
+import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+import cloud.trotter.dashbuddy.domain.model.cards.TaskEconomics
+import cloud.trotter.dashbuddy.domain.state.PickupActivity
+import cloud.trotter.dashbuddy.domain.state.customerLabel
+import cloud.trotter.dashbuddy.feature.bubble.R
+
+// ---------------------------------------------------------------------------
+// Awaiting + Pickup/Delivery (shared task-card) — summary lines and bodies
+// (#943 split of FlowCardItem.kt — moves only).
+// ---------------------------------------------------------------------------
+
+@Composable
+internal fun awaitingSummary(snap: FlowCardSnapshot.Awaiting, isActive: Boolean): String {
+    val now = if (isActive) rememberNow().value else (snap.phaseEndedAt ?: snap.phaseStartedAt)
+    val elapsed = now - snap.phaseStartedAt
+    return if (isActive) stringResource(R.string.flow_card_awaiting_active_format, formatDuration(elapsed))
+    else stringResource(R.string.flow_card_awaiting_frozen_format, formatDuration(elapsed))
+}
+
+@Composable
+internal fun pickupSummary(snap: FlowCardSnapshot.Pickup, isActive: Boolean): String {
+    val store = snap.storeName
+    val arrivedAt = snap.arrivedAt
+    return when {
+        isActive -> store
+        arrivedAt != null -> stringResource(R.string.flow_card_pickup_arrived_format, store, formatTime(arrivedAt))
+        else -> store
+    }
+}
+
+@Composable
+internal fun deliverySummary(snap: FlowCardSnapshot.Delivery, isActive: Boolean): String {
+    val customer = customerLabel(snap.storeName)
+    val arrivedAt = snap.arrivedAt
+    return when {
+        isActive -> customer
+        arrivedAt != null -> stringResource(R.string.flow_card_delivery_delivered_format, customer, formatTime(arrivedAt))
+        else -> customer
+    }
+}
+
+@Composable
+internal fun AwaitingBody(snap: FlowCardSnapshot.Awaiting, isActive: Boolean) {
+    val now = if (isActive) rememberNow().value else (snap.phaseEndedAt ?: snap.phaseStartedAt)
+    val elapsed = now - snap.phaseStartedAt
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        HeroBig(formatDuration(elapsed))
+        Caption(
+            if (isActive) stringResource(R.string.flow_card_since_last_offer)
+            else stringResource(R.string.flow_card_before_next_offer)
+        )
+    }
+}
+
+/** Pickup body — the #324/#460 task-card vocabulary (co-hero pair). */
+@Composable
+internal fun PickupBody(snap: FlowCardSnapshot.Pickup, isActive: Boolean) {
+    TaskBody(
+        phaseStartedAt = snap.phaseStartedAt,
+        arrivedAt = snap.arrivedAt,
+        deadlineMillis = snap.deadlineMillis,
+        phaseEndedAt = snap.phaseEndedAt,
+        isActive = isActive,
+        isDrop = false,
+        primary = snap.storeName,
+        netPay = snap.netPay,
+        estMinutes = snap.estMinutes,
+        perMile = snap.perMile,
+        confirmedAt = snap.confirmedAt,
+        itemsShopped = snap.itemsShopped,
+        itemsRemaining = snap.itemsRemaining,
+        activity = snap.activity,
+    )
+}
+
+/** Delivery body — same co-hero shape as Pickup, deliver-by deadline + customer. */
+@Composable
+internal fun DeliveryBody(snap: FlowCardSnapshot.Delivery, isActive: Boolean) {
+    TaskBody(
+        phaseStartedAt = snap.phaseStartedAt,
+        arrivedAt = snap.arrivedAt,
+        deadlineMillis = snap.deadlineMillis,
+        phaseEndedAt = snap.phaseEndedAt,
+        isActive = isActive,
+        isDrop = true,
+        primary = customerLabel(snap.storeName),
+        netPay = snap.netPay,
+        estMinutes = snap.estMinutes,
+        perMile = snap.perMile,
+        confirmedAt = null,
+        itemsShopped = null,
+        itemsRemaining = null,
+        activity = null,
+    )
+}
+
+/**
+ * Shared task-card body for Pickup + Delivery (#324/#460). Two co-heroes:
+ * the phase timer (To-go countdown → Dwell count-up once arrived) and the
+ * live "Running at $/hr" realized rate (holds until the deadline, then erodes
+ * — the drop-it signal). Below: an arrival/deadline caption, the drop-it
+ * floor banner, shop pace, and a store/customer detail line. All time-derived
+ * values tick off `rememberNow()` while the card is live.
+ */
+@Composable
+private fun TaskBody(
+    phaseStartedAt: Long,
+    arrivedAt: Long?,
+    deadlineMillis: Long?,
+    phaseEndedAt: Long?,
+    isActive: Boolean,
+    isDrop: Boolean,
+    primary: String,
+    netPay: Double?,
+    estMinutes: Double?,
+    perMile: Double?,
+    confirmedAt: Long?,
+    itemsShopped: Int?,
+    itemsRemaining: Int?,
+    activity: String?,
+) {
+    val c = AppTheme.colors
+    val now = if (isActive) rememberNow().value else (phaseEndedAt ?: phaseStartedAt)
+    val arrived = arrivedAt != null
+    val verb = if (isDrop) stringResource(R.string.flow_card_verb_deliver) else stringResource(R.string.flow_card_verb_pickup)
+    val overdue = deadlineMillis != null && now > deadlineMillis
+    // Live realized $/hr — ticks with `now` (erodes past the deadline), so it is recomputed here
+    // each tick from the snapshot's anchors via the TaskEconomics SSOT, never frozen at reduce
+    // time. The fixed $/mi companion ([perMile]) is precomputed on the snapshot.
+    val hourly = TaskEconomics.projectedHourly(netPay, estMinutes, deadlineMillis, now)
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        // ---- Co-hero pair: phase timer + live realized $/hr ----
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // LEFT — phase timer.
+            val timerLabel: String
+            val timerValue: String
+            val timerSub: String?
+            val timerColor: Color
+            when {
+                arrived -> {
+                    timerLabel = stringResource(R.string.flow_card_timer_dwell_label)
+                    timerValue = formatCountdown(now - arrivedAt)
+                    timerSub = if (isDrop) stringResource(R.string.flow_card_timer_at_door_sub) else stringResource(R.string.flow_card_timer_at_store_sub)
+                    timerColor = deadlineMillis?.let { deadlineColor(it - arrivedAt) } ?: c.text
+                }
+                deadlineMillis != null -> {
+                    timerLabel = if (overdue) stringResource(R.string.flow_card_timer_overdue_label) else stringResource(R.string.flow_card_timer_to_go_label)
+                    timerValue = formatCountdown(deadlineMillis - now)
+                    timerSub = null
+                    timerColor = deadlineColor(deadlineMillis - now)
+                }
+                else -> {
+                    timerLabel = stringResource(R.string.flow_card_timer_elapsed_label)
+                    timerValue = formatDuration(now - phaseStartedAt)
+                    timerSub = stringResource(R.string.flow_card_timer_en_route_sub)
+                    timerColor = c.text
+                }
+            }
+            TaskMetric(
+                modifier = Modifier.weight(1f),
+                live = isActive,
+                label = timerLabel,
+                value = timerValue,
+                sub = timerSub,
+                color = timerColor,
+            )
+            Box(Modifier.size(width = 1.dp, height = 36.dp).background(c.line))
+            // RIGHT — Running at $/hr (erodes past the deadline).
+            TaskMetric(
+                modifier = Modifier.weight(1f),
+                live = isActive && hourly != null,
+                label = stringResource(R.string.flow_card_running_at_label),
+                value = if (hourly != null) {
+                    if (overdue) stringResource(R.string.flow_card_running_at_overdue_format, Formats.money0(hourly))
+                    else stringResource(R.string.flow_card_hourly_hero_format, Formats.money0(hourly))
+                } else "—",
+                // Sub line prefers the fixed $/mi efficiency; falls back to the erosion status.
+                sub = perMile?.let { stringResource(R.string.flow_card_per_mile_secondary_format, Formats.money(it)) }
+                    ?: if (hourly == null) null else if (overdue) stringResource(R.string.flow_card_running_at_dropping_sub)
+                    else stringResource(R.string.flow_card_running_at_on_track_sub),
+                color = hourly?.let { hourlyColor(it, c) } ?: c.text3,
+            )
+        }
+
+        // ---- arrival / deadline caption ----
+        val caption = buildString {
+            if (arrived && deadlineMillis != null) {
+                val margin = deadlineMillis - arrivedAt
+                append(
+                    stringResource(
+                        R.string.flow_card_arrived_margin_format,
+                        formatCountdown(kotlin.math.abs(margin)),
+                        if (margin >= 0) stringResource(R.string.flow_card_margin_early) else stringResource(R.string.flow_card_margin_late),
+                    ),
+                )
+            }
+            when {
+                deadlineMillis == null -> append(if (arrived) stringResource(R.string.flow_card_at_stop) else stringResource(R.string.flow_card_en_route))
+                overdue -> append(stringResource(R.string.flow_card_past_deadline_format, formatCountdown(now - deadlineMillis), verb))
+                else -> append(stringResource(R.string.flow_card_by_deadline_format, verb, formatTime(deadlineMillis)))
+            }
+        }
+        Caption(caption)
+
+        // ---- drop-it floor banner: overdue AND the rate has eroded below the floor ----
+        if (isActive && overdue && hourly != null && TaskEconomics.belowDropFloor(hourly)) {
+            Surface(shape = MaterialTheme.shapes.small, color = c.badBg) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Icon(Icons.Default.Close, contentDescription = null, tint = c.bad, modifier = Modifier.size(16.dp))
+                    Text(
+                        stringResource(R.string.flow_card_below_floor_warning),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = c.bad,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
+        }
+
+        // ---- shop progress (Shop & Deliver): shopped/total + live pace ----
+        if (activity == PickupActivity.SHOPPING) {
+            val shopped = itemsShopped ?: 0
+            val total = shopped + (itemsRemaining ?: 0)
+            if (total > 0) {
+                val elapsedMs = now - (arrivedAt ?: phaseStartedAt)
+                val pace = if (elapsedMs > 0) shopped / (elapsedMs / 60_000.0) else 0.0
+                Surface(shape = MaterialTheme.shapes.small, color = c.stPickup.copy(alpha = 0.12f)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(
+                            stringResource(R.string.flow_card_shop_progress_format, shopped, total),
+                            style = AppTheme.num.smNum, color = c.text, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f),
+                        )
+                        Text(
+                            stringResource(R.string.flow_card_shop_pace_format, Formats.decimal(pace)),
+                            style = AppTheme.num.smNum, color = c.stPickup, fontWeight = FontWeight.Bold,
+                        )
+                    }
+                }
+            }
+        }
+
+        // ---- detail line — store/customer + lifecycle times ----
+        val detail = buildString {
+            append(primary)
+            arrivedAt?.let { append(stringResource(R.string.flow_card_detail_arrived_format, formatTime(it))) }
+            confirmedAt?.let { append(stringResource(R.string.flow_card_detail_picked_up_format, formatTime(it))) }
+            if (arrivedAt == null && phaseEndedAt != null && !isActive) {
+                append(" · ${formatDuration(phaseEndedAt - phaseStartedAt)}")
+            }
+        }
+        Caption(detail)
+    }
+}
+
+/** One co-hero metric — a label (with a live dot), a big value, and an optional sub. */
+@Composable
+private fun TaskMetric(
+    modifier: Modifier = Modifier,
+    live: Boolean,
+    label: String,
+    value: String,
+    sub: String?,
+    color: Color,
+) {
+    val c = AppTheme.colors
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            if (live) Box(Modifier.size(6.dp).clip(RoundedCornerShape(3.dp)).background(color))
+            Text(label.uppercase(), style = MaterialTheme.typography.labelSmall, color = c.text3, fontWeight = FontWeight.Bold)
+        }
+        // 24sp — a co-hero size (vs the 30sp single hero) so the two metrics fit
+        // side by side in the bubble's width without clipping.
+        Text(value, style = AppTheme.num.heroNum.copy(fontSize = 24.sp * AppTheme.glance), color = color, maxLines = 1)
+        if (sub != null) Text(sub, style = MaterialTheme.typography.labelSmall, color = c.text3, maxLines = 1)
+    }
+}
+
+/**
+ * The $/hr tier → brand Color mapping for the task co-hero (#460). The tier
+ * *classification* (the cutoffs) lives in [TaskEconomics]; the UI keeps only
+ * the color lookup (audit #6).
+ */
+private fun hourlyColor(hourly: Double, c: AppColors): Color = when (TaskEconomics.hourlyTier(hourly)) {
+    TaskEconomics.HourlyTier.GOOD -> c.good
+    TaskEconomics.HourlyTier.WARN -> c.warn
+    TaskEconomics.HourlyTier.POOR -> c.bad
+}
+
+@Composable
+private fun deadlineColor(remainingMs: Long): Color {
+    val mins = remainingMs / 60_000L
+    val c = AppTheme.colors
+    return when {
+        remainingMs < 0 -> c.bad              // past — red
+        mins < 5 -> c.bad                     // <5m — red
+        mins < 10 -> c.warn                   // 5-10m — amber
+        else -> c.good                        // >10m — green
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Time helpers — the shared kit lives in :core:designsystem (#358)
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun formatTime(millis: Long): String = rememberTimeFormatter().invoke(millis)


### PR DESCRIPTION
## Summary

`feature/bubble/.../cards/FlowCardItem.kt` had grown to 947 lines — past the ~900-line
threshold CLAUDE.md names as the #237 trigger ("don't add to an oversized file, split it
first"). This PR is a **pure file reorganization — moves only, no behavior change**: the
per-card-kind renderers move into sibling files in the same package, at the natural
card-kind seams named in #943.

| File | Lines (before → after) | Contents |
|---|---|---|
| `FlowCardItem.kt` | 947 → 275 | Public `FlowCardItem` entry composable, `CardHeader`/`PlatformChip`/`PhaseChip`, the `cardSummary`/`CardBody` dispatchers, shared primitives (`HeroBig`, `Caption`, `OutcomeChip`) |
| `FlowCardOffer.kt` | — → 330 (new) | `offerSummary`, `OfferBody`, `OfferCountdownText`, `badgeIcon`/`BadgeIcon`/`badgeMeta`, `offerExpiryColor`, `OfferActionRow` |
| `FlowCardTask.kt` | — → 365 (new) | `awaitingSummary`/`AwaitingBody`, `pickupSummary`/`PickupBody`, `deliverySummary`/`DeliveryBody`, the shared `TaskBody`/`TaskMetric`, `hourlyColor`, `deadlineColor`, `formatTime` |
| `FlowCardPostTask.kt` | — → 73 (new) | `postTaskSummary`, `PostTaskBody`, `BreakdownRow` |

Largest resulting file is 365 lines, well under the ~400-line target.

The public entry point (`FlowCardItem`) keeps its exact signature and stays in
`FlowCardItem.kt`, so callers outside the `cards` package (`CardStackAssembler`,
`BubbleDashboardView`, etc.) see no change at all. Within the package, calls that now
cross a file boundary widen from Kotlin's file-private `private` to `internal`
(module-visible only, still not part of any public API) so the split composables/helpers
remain callable from their new dispatcher sites — every other declaration keeps its
original visibility.

The `SideEffectEngine.kt` half of #943 is explicitly **out of scope** here (the issue marks
it optional/dev-deferred); not touched.

## Moves-only attestation

Two independent before/after diffs, both clean:

**1. Top-level function-signature inventory** — every `fun` declaration's signature line,
with `private`/`internal` visibility modifiers normalized out (since some legitimately
widen for cross-file calls), sorted and diffed between the original file (at the commit
this branch forked from) and the concatenation of the four new files:

```
$ diff before_symbols.txt after_symbols.txt && echo "SYMBOL SETS IDENTICAL (moves-only confirmed)"
SYMBOL SETS IDENTICAL (moves-only confirmed)
```

All 30 top-level functions present, none added, none removed, no signature changed.

**2. `@Composable`-annotation placement** — a second pass maps every top-level function to
whether the line immediately above it is `@Composable`, diffed the same way:

```
$ diff before_composable_map.txt after_composable_map.txt && echo "COMPOSABLE ANNOTATIONS IDENTICAL"
COMPOSABLE ANNOTATIONS IDENTICAL
```

(This caught a real mistake during the split — `deadlineColor` initially lost its
`@Composable` annotation when moved, which the compiler caught immediately since it calls
the composable `AppTheme.colors` getter; fixed before this attestation was clean.)

No string/resource changes, no logic changes.

## Test plan

- [x] `./gradlew :feature:bubble:testDebugUnitTest testDebugUnitTest` — green
- [x] `./gradlew :domain:test` — green
- [x] Moves-only symbol-inventory diff — empty (see above)
- [x] Moves-only `@Composable`-placement diff — empty (see above)

### Design-goal review

- **Principle 3 (single responsibility)** — this PR's whole subject: the 947-line file
  (past the #237 threshold this principle itself names) is now four files, largest 365
  lines, each scoped to one card kind (offer / pickup+delivery+awaiting / post-task) or to
  primitives shared across kinds. No god object; composables stay small and stateless with
  hoisted state, unchanged from before.
- Other principles (UDF, MAD, Kotlin/Android practices, SSOT, security & privacy, semantic
  logging, platform-agnostic core) and the Reactive UI rules: **not touched** — this is a
  pure move with zero logic change, so there is nothing new to evaluate against them; the
  attestations above are the evidence that no logic moved either.

### Adversarial review

Pending — CI must be green first. Will run `/code-review` (correctness + principles) per
the standing PR workflow before merge; this diff carries no untrusted-input or Pledge
surface, so `/security-review` is not expected to be load-bearing here, but the workflow
still calls for the adversarial pass before merge.

Closes #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)
