### PR TITLE
cleanup(udf): #944 — PermissionBottomSheet hoisting, StrategySettings simulate, DataExport error copy, Odometer tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -769,7 +769,7 @@ Every new feature or refactor holds to these — they are forefront design input
    `"Effects"`…), never the catch-all `App`. The tag rule is **enforced by a ratchet guard**
    (#764, `TimberTagGuardTest` in `:app` unit tests): any new bare `Timber.i/w/e/wtf(` (incl. the
    `Timber.Forest.*` form) in a main-type source set fails the build; the frozen allowlist
-   (`app/src/test/resources/timber-tag-guard-allowlist.txt`, 30 files) is the visible debt list —
+   (`app/src/test/resources/timber-tag-guard-allowlist.txt`, 27 files as of #944) is the visible debt list —
    tag a file's sites, shrink its entry (counts dropping below the frozen number also fail, so the
    list only burns down). The INFO-must-be-PII-safe rule is **fail-closed and
    tested** (reuse `SensitiveTextMarkers`): a raw merchant/customer string in an INFO+ line is a

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OdometerEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OdometerEffectHandler.kt
@@ -27,7 +27,7 @@ class OdometerEffectHandler @Inject constructor(
     }
 
     fun startUp() {
-        Timber.i("Effect: Starting Odometer & Notification")
+        Timber.tag(TAG).i("Effect: Starting Odometer & Notification")
         try {
             // 1. Start the Logic (Coroutines Job). #438 B5: NO resetSession() here — the odometer
             // is arbitrated at the cross-platform tier (StartOdometer fires only on the 0→1
@@ -40,7 +40,7 @@ class OdometerEffectHandler @Inject constructor(
             notificationManager.notify(notificationId, notification)
 
         } catch (e: Exception) {
-            Timber.e(e, "Failed to start Odometer")
+            Timber.tag(TAG).e(e, "Failed to start Odometer")
         }
     }
 
@@ -54,7 +54,7 @@ class OdometerEffectHandler @Inject constructor(
     }
 
     fun shutDown() {
-        Timber.i("Effect: Stopping Odometer")
+        Timber.tag(TAG).i("Effect: Stopping Odometer")
         try {
             // 1. Stop the Logic (Kills GPS)
             odometerRepository.stopTracking()
@@ -63,27 +63,27 @@ class OdometerEffectHandler @Inject constructor(
             notificationManager.cancel(notificationId)
 
         } catch (e: Exception) {
-            Timber.e(e, "Failed to stop Odometer")
+            Timber.tag(TAG).e(e, "Failed to stop Odometer")
         }
     }
 
     // Idempotent: safe to call even if already paused. stopTracking() no-ops when not active.
     fun pause() {
-        Timber.i("Effect: Pausing Odometer (stationary)")
+        Timber.tag(TAG).i("Effect: Pausing Odometer (stationary)")
         try {
             odometerRepository.stopTracking()
         } catch (e: Exception) {
-            Timber.e(e, "Failed to pause Odometer")
+            Timber.tag(TAG).e(e, "Failed to pause Odometer")
         }
     }
 
     // Idempotent: safe to call even if already running. startTracking() no-ops when active.
     fun resume() {
-        Timber.i("Effect: Resuming Odometer")
+        Timber.tag(TAG).i("Effect: Resuming Odometer")
         try {
             odometerRepository.startTracking()
         } catch (e: Exception) {
-            Timber.e(e, "Failed to resume Odometer")
+            Timber.tag(TAG).e(e, "Failed to resume Odometer")
         }
     }
 
@@ -104,5 +104,10 @@ class OdometerEffectHandler @Inject constructor(
             NotificationManager.IMPORTANCE_LOW
         )
         notificationManager.createNotificationChannel(channel)
+    }
+
+    private companion object {
+        /** Principle 7: this handler's stable Timber tag — never the catch-all `App` (#764). */
+        const val TAG = "Odometer"
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/permissions/PermissionBottomSheet.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/permissions/PermissionBottomSheet.kt
@@ -1,11 +1,13 @@
 package cloud.trotter.dashbuddy.ui.main.setup.permissions
 
 import android.Manifest
+import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.provider.Settings
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -24,82 +26,60 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cloud.trotter.dashbuddy.R
-import cloud.trotter.dashbuddy.util.PermissionUtils
 import kotlinx.coroutines.launch
 
+/**
+ * The permission gate: one "trust card" at a time until every required permission is granted.
+ *
+ * The OS state lives in [PermissionsViewModel] (#944) — this composable only observes
+ * [PermissionsUiState] and dispatches [PermissionsViewModel.refresh] on the edges that can have
+ * changed the OS's answer (composition entry, ON_RESUME, a launcher result). What stays local is
+ * presentation only: the sheet's own animation state and which card is currently up. The grant
+ * taps also stay here — they are pure Android-edge navigation (an `Intent` or a permission
+ * launcher), not state; their result comes back through [PermissionsViewModel.refresh].
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PermissionsBottomSheet(
-    onAllGranted: () -> Unit
+    onAllGranted: () -> Unit,
+    viewModel: PermissionsViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    var isAccessibilityGranted by remember {
-        mutableStateOf(
-            PermissionUtils.isAccessibilityServiceEnabled(
-                context
-            )
-        )
-    }
-    var isListenerGranted by remember {
-        mutableStateOf(
-            PermissionUtils.isNotificationListenerEnabled(
-                context
-            )
-        )
-    }
-    var isLocationGranted by remember { mutableStateOf(PermissionUtils.hasLocationPermission(context)) }
-    var isPostNotifGranted by remember {
-        mutableStateOf(
-            PermissionUtils.hasPostNotificationsPermission(
-                context
-            )
-        )
-    }
+    /**
+     * The card on screen — presentation, so it stays here rather than in the ViewModel. It is
+     * deliberately **sticky**: it keeps the last card after the queue empties so the sheet is
+     * still composed while `sheetState.hide()` animates it out, instead of vanishing mid-frame.
+     * Being composition-local also means a re-opened gate starts from null, so a ViewModel that
+     * outlived the previous sheet can never make this one report "all granted" on arrival.
+     */
+    var displayedPermission by remember { mutableStateOf<PermissionType?>(null) }
 
-    var isBubblesGranted by remember {
-        mutableStateOf(
-            PermissionUtils.hasFullBubblePreference(
-                context
-            )
-        )
-    }
+    // Poll on entry: the ViewModel is scoped to the nav entry and can outlive this sheet, so its
+    // state may predate the gate re-opening. (ON_RESUME below cannot cover this — the sheet is
+    // composed in *response* to a resume, after the event has already been dispatched.)
+    LaunchedEffect(Unit) { viewModel.refresh() }
 
-    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-        isAccessibilityGranted = PermissionUtils.isAccessibilityServiceEnabled(context)
-        isListenerGranted = PermissionUtils.isNotificationListenerEnabled(context)
-        isLocationGranted = PermissionUtils.hasLocationPermission(context)
-        isPostNotifGranted = PermissionUtils.hasPostNotificationsPermission(context)
-        isBubblesGranted = PermissionUtils.hasFullBubblePreference(context)
-    }
+    // The user grants permissions in system Settings, so re-entry is the edge that changes them.
+    // Event up; the ViewModel owns the read.
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { viewModel.refresh() }
 
-    val missingPermissions = remember(
-        isAccessibilityGranted,
-        isListenerGranted,
-        isLocationGranted,
-        isPostNotifGranted,
-        isBubblesGranted
-    ) {
-        buildList {
-            if (!isAccessibilityGranted) add(PermissionType.Accessibility)
-            if (!isListenerGranted) add(PermissionType.NotificationListener)
-            if (!isLocationGranted) add(PermissionType.Location)
-            if (!isPostNotifGranted) add(PermissionType.PostNotifications)
-            if (!isBubblesGranted) add(PermissionType.Bubbles) // Added to the queue!
-        }
-    }
-
-    var displayPermission by remember { mutableStateOf<PermissionType?>(null) }
-
-    LaunchedEffect(missingPermissions) {
-        if (missingPermissions.isNotEmpty()) {
-            displayPermission = missingPermissions.first()
-        } else if (displayPermission != null) {
+    LaunchedEffect(uiState.missing) {
+        val head = uiState.missing.firstOrNull()
+        if (head != null) {
+            displayedPermission = head
+        } else if (displayedPermission != null) {
+            // The queue emptied while a card was up ⇒ the gate just closed: animate out, tell the
+            // host. All-granted with nothing ever displayed is the "gate never opened" case and
+            // reports nothing.
             scope.launch {
                 sheetState.hide()
                 onAllGranted()
@@ -109,19 +89,20 @@ fun PermissionsBottomSheet(
 
     val locationLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
-            isLocationGranted = PermissionUtils.hasLocationPermission(context)
+            // Re-read from the OS rather than trusting the result map — one read path.
+            viewModel.refresh()
         }
 
     val notifLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
-            isPostNotifGranted = it
+            viewModel.refresh()
         }
 
     // Fetch string resources OUTSIDE the click listener to keep Compose happy
     val accToastMsg = stringResource(R.string.perm_toast_accessibility_hint)
     val bubblesToastMsg = stringResource(R.string.perm_toast_bubbles_hint)
 
-    displayPermission?.let { currentPerm ->
+    displayedPermission?.let { currentPerm ->
         val bottomPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
 
         ModalBottomSheet(
@@ -133,55 +114,75 @@ fun PermissionsBottomSheet(
             PermissionCard(
                 type = currentPerm,
                 onGrantClicked = {
-                    when (currentPerm) {
-                        is PermissionType.Accessibility -> {
-                            Toast.makeText(context, accToastMsg, Toast.LENGTH_LONG).show()
-                            context.startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
-                        }
-
-                        is PermissionType.NotificationListener -> {
-                            Toast.makeText(context, accToastMsg, Toast.LENGTH_LONG).show()
-                            context.startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
-                        }
-
-                        is PermissionType.Location -> {
-                            locationLauncher.launch(
-                                arrayOf(
-                                    Manifest.permission.ACCESS_FINE_LOCATION,
-                                    Manifest.permission.ACCESS_COARSE_LOCATION
-                                )
-                            )
-                        }
-
-                        is PermissionType.PostNotifications -> {
-                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                                notifLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-                            } else {
-                                // POST_NOTIFICATIONS doesn't exist pre-33 — the runtime
-                                // request insta-denies with no dialog. Deep-link the app's
-                                // notification settings instead (ON_RESUME re-checks state).
-                                val intent =
-                                    Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
-                                        putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
-                                    }
-                                context.startActivity(intent)
-                            }
-                        }
-
-                        is PermissionType.Bubbles -> {
-                            // Show the helpful Toast!
-                            Toast.makeText(context, bubblesToastMsg, Toast.LENGTH_LONG).show()
-
-                            // Launch the exact Bubble settings page for this app
-                            val intent =
-                                Intent(Settings.ACTION_APP_NOTIFICATION_BUBBLE_SETTINGS).apply {
-                                    putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
-                                }
-                            context.startActivity(intent)
-                        }
-                    }
+                    launchGrantFlow(
+                        context = context,
+                        type = currentPerm,
+                        accessibilityToastMsg = accToastMsg,
+                        bubblesToastMsg = bubblesToastMsg,
+                        locationLauncher = locationLauncher,
+                        postNotificationsLauncher = notifLauncher,
+                    )
                 }
             )
+        }
+    }
+}
+
+/**
+ * Send the user wherever [type] is actually granted — a runtime-permission launcher for the two
+ * standard permissions, a Settings deep-link for the three special ones. Non-composable and
+ * side-effecting by nature (this IS the Android edge); the resulting state change comes back in
+ * through [PermissionsViewModel.refresh], never by writing UI state here.
+ */
+private fun launchGrantFlow(
+    context: Context,
+    type: PermissionType,
+    accessibilityToastMsg: String,
+    bubblesToastMsg: String,
+    locationLauncher: ActivityResultLauncher<Array<String>>,
+    postNotificationsLauncher: ActivityResultLauncher<String>,
+) {
+    when (type) {
+        is PermissionType.Accessibility -> {
+            Toast.makeText(context, accessibilityToastMsg, Toast.LENGTH_LONG).show()
+            context.startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+        }
+
+        is PermissionType.NotificationListener -> {
+            Toast.makeText(context, accessibilityToastMsg, Toast.LENGTH_LONG).show()
+            context.startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
+        }
+
+        is PermissionType.Location -> locationLauncher.launch(
+            arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            )
+        )
+
+        is PermissionType.PostNotifications -> {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                postNotificationsLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            } else {
+                // POST_NOTIFICATIONS doesn't exist pre-33 — the runtime request insta-denies
+                // with no dialog. Deep-link the app's notification settings instead (ON_RESUME
+                // re-checks state).
+                val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                    putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                }
+                context.startActivity(intent)
+            }
+        }
+
+        is PermissionType.Bubbles -> {
+            // Show the helpful Toast!
+            Toast.makeText(context, bubblesToastMsg, Toast.LENGTH_LONG).show()
+
+            // Launch the exact Bubble settings page for this app
+            val intent = Intent(Settings.ACTION_APP_NOTIFICATION_BUBBLE_SETTINGS).apply {
+                putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+            }
+            context.startActivity(intent)
         }
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/permissions/PermissionsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/permissions/PermissionsViewModel.kt
@@ -1,0 +1,90 @@
+package cloud.trotter.dashbuddy.ui.main.setup.permissions
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import cloud.trotter.dashbuddy.util.PermissionUtils
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+/**
+ * Owns the permission-gate state for [PermissionsBottomSheet] (#944): which of the five required
+ * OS permissions are still missing.
+ *
+ * UDF (principle 1): the five reads used to live in `remember { … }` initializers inside the
+ * composable, with the resume re-poll and both launcher callbacks writing back into five
+ * composition-local `mutableStateOf`s — composition doing the sensing. The reads are hoisted here;
+ * the UI observes an immutable [PermissionsUiState] and dispatches exactly one event up
+ * ([refresh]).
+ *
+ * The permission set is OS-owned and can change while the app is backgrounded (the user toggling
+ * accessibility in system Settings), so there is nothing to observe reactively — it is *polled* on
+ * every edge that can have changed it: construction, the sheet entering composition, every
+ * ON_RESUME, and each permission-launcher result. Polling all five on every edge (rather than only
+ * the one just requested) keeps a single read path: the OS is the source of truth, never a
+ * launcher's echoed boolean.
+ *
+ * This holds no presentation state — which card is on screen, and the exit animation that outlives
+ * the last grant, belong to the sheet (see [PermissionsBottomSheet]). Keeping the ViewModel to
+ * pure OS facts is also what makes it safe for it to outlive a sheet on the nav back-stack entry.
+ */
+@HiltViewModel
+class PermissionsViewModel @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PermissionsUiState())
+    val uiState: StateFlow<PermissionsUiState> = _uiState.asStateFlow()
+
+    init {
+        // Never publish a fabricated "nothing missing" before the first poll — a collector that
+        // arrives before the sheet's entry refresh would otherwise read a state that is a lie.
+        refresh()
+    }
+
+    /**
+     * Re-poll the OS. Dispatched by the UI when the sheet enters composition, on ON_RESUME, and
+     * after a permission-launcher result. Cheap synchronous system-service reads — the same ones
+     * that used to run inline in composition.
+     */
+    fun refresh() {
+        _uiState.value = PermissionsUiState(
+            missing = missingPermissions(
+                accessibilityGranted = PermissionUtils.isAccessibilityServiceEnabled(context),
+                notificationListenerGranted = PermissionUtils.isNotificationListenerEnabled(context),
+                locationGranted = PermissionUtils.hasLocationPermission(context),
+                postNotificationsGranted = PermissionUtils.hasPostNotificationsPermission(context),
+                bubblesGranted = PermissionUtils.hasFullBubblePreference(context),
+            )
+        )
+    }
+}
+
+/** Immutable per-screen state (UDF): the outstanding permission queue, in ask-order. */
+data class PermissionsUiState(
+    val missing: List<PermissionType> = emptyList(),
+) {
+    val allGranted: Boolean get() = missing.isEmpty()
+}
+
+/**
+ * Pure projection of one poll (five booleans) onto the outstanding queue — testable without
+ * Android. The order is the **ask-order** and is behavioural: the sheet shows the head of this
+ * list, one card at a time, so it is the order the user is walked through.
+ */
+fun missingPermissions(
+    accessibilityGranted: Boolean,
+    notificationListenerGranted: Boolean,
+    locationGranted: Boolean,
+    postNotificationsGranted: Boolean,
+    bubblesGranted: Boolean,
+): List<PermissionType> = buildList {
+    if (!accessibilityGranted) add(PermissionType.Accessibility)
+    if (!notificationListenerGranted) add(PermissionType.NotificationListener)
+    if (!locationGranted) add(PermissionType.Location)
+    if (!postNotificationsGranted) add(PermissionType.PostNotifications)
+    if (!bubblesGranted) add(PermissionType.Bubbles)
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/setup/permissions/PermissionsUiStateTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/setup/permissions/PermissionsUiStateTest.kt
@@ -1,0 +1,89 @@
+package cloud.trotter.dashbuddy.ui.main.setup.permissions
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #944 — the permission gate's queue projection, hoisted out of composition into
+ * [missingPermissions]. It used to be a `remember(five booleans)` block inside
+ * `PermissionsBottomSheet`, i.e. untestable; these pin the two things the sheet depends on — that
+ * the ask-order is fixed (the sheet renders the head of this list, one card at a time) and that
+ * "nothing missing" is a real empty list, which is the edge that closes the gate.
+ */
+class PermissionsUiStateTest {
+
+    private fun poll(
+        accessibility: Boolean = true,
+        listener: Boolean = true,
+        location: Boolean = true,
+        postNotifications: Boolean = true,
+        bubbles: Boolean = true,
+    ) = missingPermissions(
+        accessibilityGranted = accessibility,
+        notificationListenerGranted = listener,
+        locationGranted = location,
+        postNotificationsGranted = postNotifications,
+        bubblesGranted = bubbles,
+    )
+
+    @Test
+    fun `everything granted leaves an empty queue`() {
+        val missing = poll()
+
+        assertEquals(emptyList<PermissionType>(), missing)
+        assertTrue(PermissionsUiState(missing).allGranted)
+    }
+
+    @Test
+    fun `missing permissions queue in the fixed ask-order`() {
+        val missing = poll(
+            accessibility = false,
+            listener = false,
+            location = false,
+            postNotifications = false,
+            bubbles = false,
+        )
+
+        assertEquals(
+            listOf(
+                PermissionType.Accessibility,
+                PermissionType.NotificationListener,
+                PermissionType.Location,
+                PermissionType.PostNotifications,
+                PermissionType.Bubbles,
+            ),
+            missing,
+        )
+        // The head is the card the sheet shows first.
+        assertEquals(PermissionType.Accessibility, missing.first())
+        assertFalse(PermissionsUiState(missing).allGranted)
+    }
+
+    @Test
+    fun `granting the head advances the queue to the next card`() {
+        val first = poll(accessibility = false, location = false)
+        assertEquals(PermissionType.Accessibility, first.first())
+
+        // The re-poll a resume (or launcher result) triggers, with accessibility now granted.
+        val second = poll(location = false)
+
+        assertEquals(listOf(PermissionType.Location), second)
+    }
+
+    @Test
+    fun `each permission maps to its own card`() {
+        assertEquals(listOf(PermissionType.Accessibility), poll(accessibility = false))
+        assertEquals(listOf(PermissionType.NotificationListener), poll(listener = false))
+        assertEquals(listOf(PermissionType.Location), poll(location = false))
+        assertEquals(listOf(PermissionType.PostNotifications), poll(postNotifications = false))
+        assertEquals(listOf(PermissionType.Bubbles), poll(bubbles = false))
+    }
+
+    @Test
+    fun `state defaults to nothing missing`() {
+        assertTrue(PermissionsUiState().allGranted)
+        assertEquals(emptyList<PermissionType>(), PermissionsUiState().missing)
+    }
+}

--- a/app/src/test/resources/timber-tag-guard-allowlist.txt
+++ b/app/src/test/resources/timber-tag-guard-allowlist.txt
@@ -17,7 +17,6 @@
 
 app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt 3
 app/src/main/java/cloud/trotter/dashbuddy/di/DispatchersModule.kt 1
-app/src/main/java/cloud/trotter/dashbuddy/state/effects/OdometerEffectHandler.kt 8
 app/src/main/java/cloud/trotter/dashbuddy/state/effects/ScreenShotHandler.kt 8
 app/src/main/java/cloud/trotter/dashbuddy/util/AccNodeUtils.kt 3
 core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/DiskCaptureBus.kt 1

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/EvaluationConfig.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/EvaluationConfig.kt
@@ -22,7 +22,7 @@ data class EvaluationConfig(
      * THIS [userEconomy] are whatever the last [forPlatform] call (if any) stamped, which for a
      * freshly-constructed/raw config is the domain default seed, not any platform's real pace. A
      * consumer that scores a SHOP offer against the raw config (skipping [forPlatform]) silently gets
-     * seed-only pricing — see `SettingsViewModel.simulateOffer`, which is safe today only because its
+     * seed-only pricing — see [OfferSimulation.simulate], which is safe today only because its
      * simulated offer is never a shop offer.
      */
     val userEconomy: UserEconomy = UserEconomy(),

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferSimulation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferSimulation.kt
@@ -1,0 +1,45 @@
+package cloud.trotter.dashbuddy.domain.evaluation
+
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+
+/**
+ * The Strategy Lab's "what would this offer score?" preview — a pure function of (pay, miles,
+ * config), with no state of its own.
+ *
+ * It lived on `SettingsViewModel` as `simulateOffer`, which made the Lab screen call a ViewModel
+ * *function* from composition to derive display state (#944 / review §4.8). It is not an action
+ * and it owns nothing: [OfferEvaluator] is a stateless calculator, so the honest home for this is
+ * `:domain` beside the evaluator, where the composable can memoize it on its own inputs
+ * (`remember(pay, miles, config)`) exactly like any other derived value — and where it is
+ * unit-testable without a ViewModel.
+ */
+object OfferSimulation {
+
+    /** Stateless calculator — one instance is enough; nothing is carried between calls. */
+    private val evaluator = OfferEvaluator()
+
+    /**
+     * Score a hypothetical [payDollars]/[milesDistance] offer against [config].
+     *
+     * #588: intentionally NOT calling [EvaluationConfig.forPlatform] — a simulation has no
+     * platform to resolve against. Safe only because the simulated offer is never a shop offer
+     * (no SHOP order ⇒ the shop-pace path is never exercised; see [EvaluationConfig.userEconomy]);
+     * a shop-capable simulator would need to pick a platform and call `forPlatform()` first, or it
+     * would silently price off seed-only shop pace.
+     */
+    fun simulate(payDollars: Double, milesDistance: Double, config: EvaluationConfig): OfferEvaluation {
+        val simulatedOffer = ParsedOffer(
+            // Stable hash (#367): the caller memoizes on (pay, miles, config) — a wall-clock hash
+            // would defeat structural equality.
+            offerHash = "simulated-offer",
+            payAmount = payDollars,
+            distanceMiles = milesDistance,
+            itemCount = SIMULATED_ITEM_COUNT,
+            orders = emptyList(), // non-shop by construction (no SHOP order)
+        )
+        return evaluator.evaluate(simulatedOffer, config)
+    }
+
+    /** Default average workload for the simulated offer (unchanged from the ViewModel original). */
+    private const val SIMULATED_ITEM_COUNT = 5
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferSimulationTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferSimulationTest.kt
@@ -1,0 +1,80 @@
+package cloud.trotter.dashbuddy.domain.evaluation
+
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #944 — the Strategy Lab's simulator, moved off `SettingsViewModel` into `:domain` so the Lab
+ * screen derives it purely instead of calling a ViewModel function from composition. These pin
+ * the properties the screen's `remember(pay, miles, config)` memoization depends on: the result
+ * is a pure function of its three inputs, and the simulated offer stays non-shop (the #588
+ * precondition for skipping `forPlatform`).
+ */
+class OfferSimulationTest {
+
+    private val config = EvaluationConfig(
+        rules = listOf(
+            ScoringRule.MetricRule(
+                id = "payout",
+                metricType = MetricType.PAYOUT,
+                targetValue = 7.0f,
+            ),
+        ),
+        userEconomy = UserEconomy(vehicleClass = VehicleClass.E_BIKE),
+    )
+
+    @Test
+    fun `simulating matches evaluating the equivalent offer directly`() {
+        val simulated = OfferSimulation.simulate(payDollars = 6.5, milesDistance = 3.2, config = config)
+
+        val direct = OfferEvaluator().evaluate(
+            ParsedOffer(
+                offerHash = "simulated-offer",
+                payAmount = 6.5,
+                distanceMiles = 3.2,
+                itemCount = 5,
+                orders = emptyList(),
+            ),
+            config,
+        )
+
+        assertEquals(direct, simulated)
+    }
+
+    @Test
+    fun `the same inputs always produce the same result`() {
+        // What the screen's remember(pay, miles, config) key assumes: no wall clock, no state
+        // carried between calls (#367's stable offer hash).
+        assertEquals(
+            OfferSimulation.simulate(6.5, 3.2, config),
+            OfferSimulation.simulate(6.5, 3.2, config),
+        )
+    }
+
+    @Test
+    fun `more pay over the same distance scores no worse`() {
+        val lean = OfferSimulation.simulate(3.0, 3.2, config)
+        val rich = OfferSimulation.simulate(12.0, 3.2, config)
+
+        assertTrue(rich.score >= lean.score)
+    }
+
+    @Test
+    fun `the simulated offer is never a shop offer`() {
+        // #588: the simulator deliberately skips forPlatform(), which is only safe while no
+        // shop-pace field is ever exercised. Proven from the outside: the time estimate is the
+        // non-shop branch (drive + flat base overhead), NOT the items-over-pace shop branch —
+        // which for the 5 simulated items would land somewhere else entirely.
+        val economy = config.userEconomy
+        val result = OfferSimulation.simulate(6.5, 3.2, config)
+
+        assertEquals(
+            3.2 * economy.avgMinutesPerMile + economy.basePickupMinutes,
+            result.estimatedTimeMinutes,
+            0.0001,
+        )
+    }
+}

--- a/feature/settings/src/main/java/cloud/trotter/dashbuddy/feature/settings/DataExportScreen.kt
+++ b/feature/settings/src/main/java/cloud/trotter/dashbuddy/feature/settings/DataExportScreen.kt
@@ -115,7 +115,7 @@ fun DataExportScreen(
                 }
                 is DataExportViewModel.ExportState.Error -> {
                     Text(
-                        stringResource(R.string.data_export_csv_error_format, s.message),
+                        stringResource(R.string.data_export_csv_error_format, s.errorClass),
                         color = MaterialTheme.colorScheme.error,
                         style = MaterialTheme.typography.bodyMedium,
                     )
@@ -162,7 +162,7 @@ fun DataExportScreen(
                 }
                 is DataExportViewModel.LogExportState.Error -> {
                     Text(
-                        stringResource(R.string.data_export_log_error_format, s.message),
+                        stringResource(R.string.data_export_log_error_format, s.errorClass),
                         color = MaterialTheme.colorScheme.error,
                         style = MaterialTheme.typography.bodyMedium,
                     )

--- a/feature/settings/src/main/java/cloud/trotter/dashbuddy/feature/settings/DataExportViewModel.kt
+++ b/feature/settings/src/main/java/cloud/trotter/dashbuddy/feature/settings/DataExportViewModel.kt
@@ -41,7 +41,15 @@ class DataExportViewModel @Inject constructor(
         data object Idle : ExportState
         data object InProgress : ExportState
         data class Success(val filesWritten: Int) : ExportState
-        data class Error(val message: String) : ExportState
+
+        /**
+         * [errorClass] is the exception's simple class name — never its message (#944). A platform
+         * exception message can embed the SAF folder URI, i.e. a user path, which is exactly why
+         * the log below records only the class; the on-screen copy is the same disclosure surface
+         * (a screenshotted/shared error is as public as an exported log line), so it gets the same
+         * treatment. The class name is diagnostic and path-free.
+         */
+        data class Error(val errorClass: String) : ExportState
     }
 
     /** Bug-report (shareable log) export state (#551), separate from the CSV export state. */
@@ -50,7 +58,9 @@ class DataExportViewModel @Inject constructor(
         data object InProgress : LogExportState
         /** [scrubbedLines] = INFO+ lines the sink-gate redacted (surfaced for honesty). */
         data class Success(val scrubbedLines: Int) : LogExportState
-        data class Error(val message: String) : LogExportState
+
+        /** [errorClass] — same path-free disclosure rule as [ExportState.Error] (#944). */
+        data class Error(val errorClass: String) : LogExportState
     }
 
     private val _state = MutableStateFlow<ExportState>(ExportState.Idle)
@@ -82,11 +92,13 @@ class DataExportViewModel @Inject constructor(
                 onFailure = { e ->
                     // P7: ERROR ships in exported bug reports. Platform exception messages can
                     // embed the SAF folder URI (a user-path), so log only the exception CLASS —
-                    // never the raw message/stack-message.
+                    // never the raw message/stack-message. The UI state carries the same class
+                    // (#944): the raw message used to be rendered on screen two lines under this
+                    // very comment.
                     Timber.tag("Export").e(
                         "CSV export failed: %s", e.javaClass.simpleName
                     )
-                    ExportState.Error(e.message ?: "Export failed")
+                    ExportState.Error(e.javaClass.simpleName)
                 },
             )
         }
@@ -120,9 +132,10 @@ class DataExportViewModel @Inject constructor(
                     LogExportState.Success(scrubbed)
                 },
                 onFailure = { e ->
-                    // P7: log the exception CLASS only — messages can embed the SAF folder URI.
+                    // P7 + #944: log AND display the exception CLASS only — a message can embed
+                    // the SAF folder URI.
                     Timber.tag("Export").e("Log export failed: %s", e.javaClass.simpleName)
-                    LogExportState.Error(e.message ?: "Export failed")
+                    LogExportState.Error(e.javaClass.simpleName)
                 },
             )
         }

--- a/feature/settings/src/main/java/cloud/trotter/dashbuddy/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/cloud/trotter/dashbuddy/feature/settings/SettingsViewModel.kt
@@ -6,9 +6,6 @@ import cloud.trotter.dashbuddy.core.data.strategy.StrategyRepository
 import cloud.trotter.dashbuddy.domain.config.OfferAutomationConfig
 import cloud.trotter.dashbuddy.domain.evaluation.EvaluationConfig
 import cloud.trotter.dashbuddy.domain.evaluation.ScoringRule
-import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
-import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluator
-import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -20,7 +17,6 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val strategyRepository: StrategyRepository,
-    private val offerEvaluator: OfferEvaluator,
 ) : ViewModel() {
 
     // --- STATE ---
@@ -69,24 +65,8 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    // --- SIMULATOR ---
-
-    fun simulateOffer(pay: Double, miles: Double): OfferEvaluation {
-        val fakeOffer = ParsedOffer(
-            // Stable hash (#367): the screen memoizes on (pay, dist, config) —
-            // a wall-clock hash would defeat structural equality.
-            offerHash = "simulated-offer",
-            payAmount = pay,
-            distanceMiles = miles,
-            itemCount = 5, // Default average workload
-            orders = emptyList() // non-shop by construction (no SHOP order) — never exercises shop pace
-        )
-
-        // #588: intentionally NOT calling evaluationConfig.value.forPlatform(...) — this simulator has
-        // no platform to resolve against. Safe only because fakeOffer is never a shop offer (see
-        // EvaluationConfig.userEconomy KDoc); a shop-capable simulator would need to pick a platform
-        // and call forPlatform() first, or it would silently price off seed-only shop pace.
-        val currentConfig = evaluationConfig.value
-        return offerEvaluator.evaluate(fakeOffer, currentConfig)
-    }
+    // The Strategy Lab's offer simulator is a PURE function of (pay, miles, config) and no longer
+    // lives here (#944): `OfferSimulation.simulate` in :domain. It was never an action — having
+    // the Lab screen call a ViewModel function from composition to derive display state inverted
+    // UDF, and the evaluator it wrapped is stateless.
 }

--- a/feature/settings/src/main/java/cloud/trotter/dashbuddy/feature/settings/StrategySettingsScreen.kt
+++ b/feature/settings/src/main/java/cloud/trotter/dashbuddy/feature/settings/StrategySettingsScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import cloud.trotter.dashbuddy.feature.settings.R
+import cloud.trotter.dashbuddy.domain.evaluation.OfferSimulation
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.feature.settings.components.DraggableRuleRow
 import cloud.trotter.dashbuddy.feature.settings.components.FakeOfferCard
@@ -59,9 +60,10 @@ fun StrategySettingsScreen(
     var simPay by remember { mutableFloatStateOf(6.50f) }
     var simDist by remember { mutableFloatStateOf(3.2f) }
 
-    // Memoized (#367): this ran an un-remembered evaluation every recomposition.
+    // Derived display state, memoized on its own inputs (#367 memoization, #944 UDF): a pure
+    // :domain call, not a ViewModel function invoked from composition.
     val simulationResult = remember(simPay, simDist, config) {
-        viewModel.simulateOffer(simPay.toDouble(), simDist.toDouble())
+        OfferSimulation.simulate(simPay.toDouble(), simDist.toDouble(), config)
     }
 
     // --- REORDERABLE STATE ---

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -30,12 +30,12 @@
     <string name="data_export_csv_desc">Pick a folder and DashBuddy writes three spreadsheet files into it:\n• deliveries.csv — one row per delivery\n• sessions.csv — one row per session\n• summary.csv — totals + estimated IRS mileage deduction\n\nThis is your own data, on-device — nothing is uploaded. Exports all history (a date-range picker is coming later).</string>
     <string name="data_export_csv_button">"  Choose folder &amp; export"</string>
     <string name="data_export_csv_success_format">Exported %1$d files to the chosen folder.</string>
-    <string name="data_export_csv_error_format">Export failed: %1$s</string>
+    <string name="data_export_csv_error_format">Export failed (%1$s). Check the folder and try again.</string>
     <string name="data_export_log_heading">Export a bug report</string>
     <string name="data_export_log_desc">Pick a folder and DashBuddy writes dashbuddy-log.txt into it — the log the developer needs to diagnose an issue.\n\nINFO+ milestones only — no raw store, customer, or address text. Every line is auto-scrubbed at the sink before it\'s written, so a leaked name can\'t reach the file. On-device, nothing is uploaded.</string>
     <string name="data_export_log_button">"  Choose folder &amp; export log"</string>
     <string name="data_export_log_success_format">Exported dashbuddy-log.txt — %1$d line(s) were auto-scrubbed.</string>
-    <string name="data_export_log_error_format">Log export failed: %1$s</string>
+    <string name="data_export_log_error_format">Log export failed (%1$s). Check the folder and try again.</string>
     <string name="consent_title">Automation &amp; Consent</string>
     <string name="consent_disclosure_heading">Review or change what DashBuddy is allowed to tap</string>
     <string name="consent_disclosure_body">DashBuddy uses Android\'s Accessibility service to read the screens of the delivery apps you turn on, so it can recognize offers, pickups, and deliveries. This recognition runs entirely on your phone.\n\nDashBuddy can also tap buttons in a delivery app for you — but only the specific actions you allow, only inside that delivery app, and only on a button whose label matches the action (except the icon-only pay-details arrow, which is verified by app boundary only). Nothing is turned on for you: each action below stays off until you allow it, and DashBuddy asks you the first time it can offer one. Turn any action off and DashBuddy will not tap it — you do it manually.</string>


### PR DESCRIPTION
Four UDF/polish cleanups from the 2026-07-30 adversarial review (§4.8/§5 P1), one batch.

## 1. `PermissionBottomSheet` — hoist the platform reads out of composition

The five permission reads lived in `remember { }` initializers, with the ON_RESUME re-poll and both launcher callbacks writing back into five composition-local `mutableStateOf`s — composition doing the sensing (principle 1).

- New **`PermissionsViewModel`** (`@HiltViewModel`, `@ApplicationContext`) owns the reads and exposes an immutable `PermissionsUiState(missing: List<PermissionType>)`. The UI dispatches exactly **one** event up — `refresh()` — on composition entry, ON_RESUME, and each launcher result.
- The launcher callbacks no longer echo their own booleans (`isPostNotifGranted = it`); every edge re-reads the OS, so there is a **single read path** and no launcher-derived second source of truth.
- The queue projection is a pure `missingPermissions(five booleans)` — the ask-order was previously untestable inside a `remember` block; it now has `PermissionsUiStateTest` (5 cases).
- The ~45-line grant-intent `when` moved to a private `launchGrantFlow(...)`, **verbatim** — both `Build.VERSION` guards, the pre-33 deep-link fallback, and both Toasts unchanged. It takes the launchers directly (not lambdas) so `Manifest.permission.POST_NOTIFICATIONS` stays inside its version guard.

**Why the entry poll (`LaunchedEffect(Unit) { refresh() }`)**: the ViewModel is scoped to the nav back-stack entry and outlives the sheet, so a *re-opened* gate would render a stale queue. `LifecycleEventEffect(ON_RESUME)` cannot cover that case — the host composes the sheet **in response to** its own ON_RESUME poll, i.e. after the event has already been dispatched, so the sheet's observer registers too late to fire.

**Why the displayed card stays composition-local**: it is presentation, not OS state. It is deliberately sticky — it keeps the last card after the queue empties so the sheet is still composed while `sheetState.hide()` animates it out instead of vanishing mid-frame (exactly the pre-change `displayPermission` behaviour, which was also never cleared). Being per-composition-entry additionally makes the "stale VM reports all-granted on arrival" failure structurally impossible: a re-opened sheet starts from `null`, so the `onAllGranted` edge (`missing.isEmpty() && displayed != null`) cannot fire on arrival.

**Resume re-poll still works — reasoning** (no instrumented test for a lifecycle+OS surface): the ON_RESUME observer is unchanged in position and now calls `viewModel.refresh()`, which re-reads all five `PermissionUtils` values and republishes `uiState`; `LaunchedEffect(uiState.missing)` re-keys on the new list and advances the displayed card. The one gap that observer never covered (a sheet composed *after* the resume event) is now covered by the entry poll — a strict improvement over the previous behaviour, where a re-opened sheet re-ran its `remember` initializers only because the composable was fresh.

## 2. `StrategySettingsScreen:64` — `viewModel.simulateOffer(...)` in composition

`simulateOffer` was never an action: a thin wrapper that built a fake `ParsedOffer` and called the **stateless** `OfferEvaluator`. Rather than plumb a derived flow for what is a pure function of `(pay, miles, config)`, it moves down to `:domain` as `OfferSimulation.simulate(...)`, and the screen memoizes it exactly like any other derived value (`remember(simPay, simDist, config)`).

- `SettingsViewModel` loses its `OfferEvaluator` dependency entirely.
- The #588 "deliberately skips `forPlatform`" caveat and the #367 stable-hash note move **with** the code; `EvaluationConfig`'s KDoc pointer now resolves to `[OfferSimulation.simulate]` instead of a dangling `SettingsViewModel.simulateOffer` reference.
- New `OfferSimulationTest`: equals a direct `OfferEvaluator.evaluate` of the equivalent offer, is stable across calls (what the `remember` key assumes), monotone in pay, and stays on the **non-shop** time branch (the precondition that makes skipping `forPlatform` safe).

Slider smoothness is untouched — the slider positions remain composable-local UI state.

## 3. `DataExportViewModel` — raw exception message rendered to the UI

`ExportState.Error(e.message ?: …)` was displayed on screen **two lines under** the comment explaining why the log deliberately records only the exception class (a platform message can embed the SAF folder URI — a user path). A screenshotted or shared error is the same disclosure surface as an exported log line, so both states now carry `errorClass` = `e.javaClass.simpleName`: still diagnostic, structurally path-free. The two error strings gain generic recovery copy (`Export failed (%1$s). Check the folder and try again.`).

## 4. `OdometerEffectHandler` Timber tags (#764 ratchet)

All 8 bare `Timber.i/e(` sites now use `Timber.tag(TAG)` with a file-local `TAG = "Odometer"`, and the file's `timber-tag-guard-allowlist.txt` line is **deleted** — the ratchet is strict in both directions, so a stale entry would have failed `allowlistHasNoStaleEntries`. CLAUDE.md's allowlist file count was already stale (said 30, was 28) and is corrected to 27.

## Verification

- `./gradlew testDebugUnitTest :domain:test` — **green** (includes `TimberTagGuardTest`, both new test classes).
- `./gradlew :app:lintVitalRelease` — **green** (the #907 release-variant gate).

## Design-goal review

- **1 (UDF)** — the point of the PR. Item 1 moves OS sensing out of composition into a ViewModel; UI observes immutable state and dispatches one event. What deliberately stays composable-local is presentation only (sheet animation state, the displayed card) — stated above with the reason, not silently. Item 2 removes a ViewModel-function call from composition in favour of a pure derivation. Reducers/steppers untouched; no side effects added to any reducer.
- **2 (MAD)** — Hilt `@HiltViewModel` + `StateFlow` + `collectAsStateWithLifecycle`, matching the sibling `ConsentPromptViewModel` (#843) pattern in the same package. Pure logic lands in `:domain`, respecting the module graph (`:feature:settings → :domain` already exists; no new edges).
- **3 (single responsibility)** — `PermissionBottomSheet` drops five state variables and its intent-routing `when`; the new VM is ~90 lines with one job (poll + publish). `SettingsViewModel` sheds a concern it never owned.
- **4 (Kotlin/Android)** — immutable state class, pure top-level projections, `buildList`, no new mutable shared state. `refresh()` assigns `_uiState.value` from values read first (no OS reads inside an `update` retry loop). The API-33 constant stays inside its `Build.VERSION` guard.
- **5 (SSOT)** — the launcher-result booleans were a second source of truth for permission state alongside the OS; both now re-read `PermissionUtils`. `OfferSimulation` is the single home of the simulated-offer construction (its `#588`/`#367` caveats travel with it rather than being re-stated). Noted follow-up, out of scope: `DashboardScreen` still runs its own `PermissionUtils.hasAllEssentialPermissions` ON_RESUME poll — a second (pre-existing) read of the same OS facts that could later consume this ViewModel.
- **6 (security & privacy)** — item 3 is a small privacy fix: a platform exception message can carry the user's SAF folder path, and it was being rendered on screen; the UI now shows only the exception class, matching what the log already did. No new logging, no network, no capture surface touched. Permission *enforcement* is unchanged — this PR only changes where the *display* state for the gate is computed; nothing gates on it beyond which card is shown.
- **7 (semantic logging)** — item 4 tags 8 INFO/ERROR sites under a stable `Odometer` tag (no message text changed, no level changed, no PII: they are fixed literals). No new log sites elsewhere.
- **8 (platform-agnostic core)** — no platform literals added; `:core:state` / `:core:pipeline` / rule JSON untouched. The one `:domain` addition (`OfferSimulation`) is platform-free by construction and documents why it skips `forPlatform`.
- **Reactive UI rules** — no time-derived value is introduced or frozen. The permission state is OS-owned and *not* observable, so polling on every edge that can change it (entry / resume / launcher result) is the reactive-equivalent; the sheet re-renders from `StateFlow` rather than from `remember` initializers, which is strictly fresher than before.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
