### PR TITLE
ci: #939 — instrumented nightly (emulator) — Room migration tests + ICU regex engine

### DIFF
--- a/.github/workflows/instrumented-nightly.yml
+++ b/.github/workflows/instrumented-nightly.yml
@@ -1,0 +1,99 @@
+# #939 — the instrumented tier PR CI structurally cannot cover.
+#
+# Two device-class blind spots exist today, both admitted in their own guard's docs:
+#   1. The 8 real MigrationTestHelper cases under core/database/src/androidTest (7 per-step
+#      AnalyticsMigrationNtoMTest + the full-chain MigrationTest) require an on-disk SQLite DB
+#      via the framework factory — instrumented-only, and with the destructive-fallback retired
+#      (#690) they're the ONLY thing proving a declared AutoMigration edge actually WORKS, not
+#      just that SchemaVersionGuardTest proves it's *declared*.
+#   2. No unit/Robolectric test runs against a real ICU-backed regex engine — #909 (an
+#      ICU-invalid `Regex` literal silently killed the effect-engine drain worker and lost
+#      91.7% of a dash's data) is guarded by IcuRegexGuardTest, a SOURCE SCAN whose own KDoc
+#      lists what it can't see (concatenated/variable patterns, `Pattern.compile`). Only a real
+#      Android device/emulator runs the actual ICU regex engine PR CI (Robolectric, host JVM)
+#      never touches.
+#
+# This is a NIGHTLY (not PR-gating) emulator job — reactivecircus/android-emulator-runner is slow
+# and occasionally flaky, which is exactly why it doesn't belong on the PR path. A red run here is
+# a device-class failure the PR CI structurally cannot see; see the failure summary step below.
+name: Instrumented Nightly (emulator)
+
+on:
+  schedule:
+    # 10:23 UTC, Tue/Fri — off-peak, 2x weekly, odd minute avoids the top-of-hour Actions
+    # scheduling pile-up (dev decision welcome to retune, same convention as #940's prop-explore).
+    - cron: '23 10 * * 2,5'
+  workflow_dispatch: {}
+
+jobs:
+  instrumented-tests:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Enable KVM group perms
+        # Standard reactivecircus/android-emulator-runner prerequisite on GitHub-hosted
+        # ubuntu-latest runners — without it the emulator falls back to (much slower,
+        # frequently timing-out) software rendering.
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run instrumented tests (emulator)
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          arch: x86_64
+          # No target specified — default (google_apis) matches minSdk 30 (#793); the migration
+          # tests and app instrumented tests need no Play Services surface.
+          disable-animations: true
+          script: ./gradlew :core:database:connectedAndroidTest :app:connectedAndroidTest
+
+      - name: Upload instrumented test reports
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: instrumented-test-reports-${{ github.run_id }}
+          path: |
+            **/build/reports/androidTests/
+            **/build/outputs/androidTest-results/
+          retention-days: 14
+
+      - name: Failure summary
+        if: ${{ failure() }}
+        run: |
+          {
+            echo "## Instrumented nightly failed"
+            echo
+            echo "This run is the ONLY automation executing:"
+            echo "- the Room migration chain (MigrationTestHelper, core/database/src/androidTest)"
+            echo "- a real ICU-backed regex engine (the #909 guard's admitted blind spot —"
+            echo "  IcuRegexGuardTest is a source scan, not an execution test)"
+            echo
+            echo "A red run here is a device-class failure PR CI structurally cannot see."
+            echo "Download the reports artifact above and investigate before the next dash."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The 2026-07-30 adversarial review (§4.4 items 1–2, filed as #939) found two device-class blind spots PR CI structurally cannot see:

1. **The 8 real `MigrationTestHelper` cases** under `core/database/src/androidTest/` (7 per-step `AnalyticsMigration{N}to{M}Test` + the full-chain `MigrationTest`) open an on-disk SQLite DB via the framework factory — instrumented-only, and with the destructive fallback retired (#690) they're the ONLY thing proving a declared `AutoMigration` edge actually **works**, not just that `SchemaVersionGuardTest` proves it's *declared*.
2. **No unit/Robolectric test ever executes a real ICU-backed regex engine.** #909 (an ICU-invalid `Regex` literal silently killed the effect-engine drain worker and lost 91.7% of a dash's data) is guarded by `IcuRegexGuardTest`, a source scan whose own KDoc lists what it can't see (concatenated/variable patterns, `Pattern.compile`). Only a real Android device/emulator runs the actual ICU engine.

**New workflow `.github/workflows/instrumented-nightly.yml`:** `schedule` (Tue/Fri 10:23 UTC — off-peak, odd minute, same pile-up-avoidance convention as #940's `prop-explore.yml`) + `workflow_dispatch: {}`. Job on `ubuntu-latest` with the standard KVM-enable udev step, then `reactivecircus/android-emulator-runner@v2` (API 30 to match minSdk, `arch: x86_64`, default target) running `./gradlew :core:database:connectedAndroidTest :app:connectedAndroidTest` inside `script:`. On failure: uploads `**/build/reports/androidTests/` + `**/build/outputs/androidTest-results/` (14-day retention) and writes a `$GITHUB_STEP_SUMMARY` note that this run is the ONLY automation executing the Room migration tests and a real ICU regex engine — a red run here is a device-class failure PR CI structurally cannot see.

**androidTest inventory (confirmed by grep before writing the command):**
- `core/database/src/androidTest/`: 9 `@Test` total — the 8 real `MigrationTestHelper` cases (`AnalyticsMigration8to9Test` … `AnalyticsMigration14to15Test`, 7 files, one step-migration test each, + `MigrationTest.migrate8ToCurrent_chained_preservesAppEventsIntact`) plus the stock `ExampleInstrumentedTest` (1 trivial test, untouched boilerplate).
- `app/src/androidTest/`: only the stock `ExampleInstrumentedTest` (1 trivial `useAppContext` assertion) — no app-specific instrumented tests exist yet. It's not empty, so `:app:connectedAndroidTest` stays in the command per the issue's literal command shape rather than being dropped; it currently adds only device-process coverage, not ICU-regex-specific assertions — a genuine gap for a future instrumented test to fill, noted here rather than silently glossed over.

**Verification:** YAML validated with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/instrumented-nightly.yml'))"` — parses clean (the `on:` → `True` key is standard PyYAML 1.1 behavior present in every existing workflow file too, confirmed against `pr-check.yml`, not an issue introduced here). **The emulator job cannot be run locally** (no KVM/emulator in this sandboxed environment) — same accepted limitation as PR #948: the post-merge `workflow_dispatch` run is the live smoke test. New workflow files only become dispatchable/schedulable once present on the default branch, so this can't be proven green before merge.

### Design-goal review
Testing/CI-only diff, no `:core:*`/`:domain`/rule-JSON touched. The workflow codifies the #939 review finding operationally — it doesn't add new test *content*, it puts existing dead-in-CI instrumented tests (and the real ICU engine they run against) onto a schedule. No SSOT, security, or platform-agnosticism surface touched.

### Adversarial review
Not yet run — requesting the standard fable-tier pass per CLAUDE.md before merge. Flagging for the reviewer: (1) confirm the KVM-enable step + emulator-runner args match the current recommended pattern (action version pinned at `@v2` per the issue spec, not further pinned to a SHA), (2) confirm the schedule cadence/time doesn't collide with `prop-explore.yml`'s Mon/Wed/Sat 09:17 UTC slot, (3) confirm scoping `:app:connectedAndroidTest` in despite it being boilerplate-only is the right call vs. dropping it.

Closes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)